### PR TITLE
feat: develop api data pipeline for stellar protocol yields

### DIFF
--- a/server/src/__tests__/yieldNormalization.test.ts
+++ b/server/src/__tests__/yieldNormalization.test.ts
@@ -1,0 +1,45 @@
+import { normalizeYield, normalizeYields } from "../utils/yieldNormalization";
+import type { RawProtocolYield } from "../types/yields";
+
+const rawYield: RawProtocolYield = {
+  protocolName: "Blend",
+  protocolType: "blend",
+  apyBps: 675,
+  tvlUsd: 12_500_000.567,
+  volatilityPct: 2.5,
+  protocolAgeDays: 400,
+  network: "mainnet",
+  source: "stellar://blend",
+  fetchedAt: "2026-03-25T10:00:00.000Z",
+};
+
+describe("yield normalization utilities", () => {
+  it("normalizes a raw protocol payload into the frontend shape", () => {
+    const normalized = normalizeYield(rawYield);
+
+    expect(normalized).toEqual({
+      protocolName: "Blend",
+      apy: 6.75,
+      tvl: 12_500_000.57,
+      riskScore: expect.any(Number),
+      source: "stellar://blend",
+      fetchedAt: "2026-03-25T10:00:00.000Z",
+    });
+  });
+
+  it("normalizes multiple yield payloads", () => {
+    const normalized = normalizeYields([
+      rawYield,
+      {
+        ...rawYield,
+        protocolName: "Soroswap",
+        protocolType: "soroswap",
+        apyBps: 1120,
+      },
+    ]);
+
+    expect(normalized).toHaveLength(2);
+    expect(normalized[1].protocolName).toBe("Soroswap");
+    expect(normalized[1].apy).toBe(11.2);
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -7,6 +7,7 @@ const PORT = process.env.PORT || 3001;
 app.use(cors());
 app.use(express.json());
 import rateLimit from "express-rate-limit";
+import yieldsRouter from "./routes/yields";
 
 const relayerLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
@@ -16,6 +17,7 @@ const relayerLimiter = rateLimit({
 
 import { signFeeBump } from "./relayer/relayer";
 app.post("/api/relayer/fee-bump", relayerLimiter, signFeeBump);
+app.use("/api/yields", yieldsRouter);
 
 import { startIndexer } from "./indexer/indexer";
 startIndexer().catch(console.error);
@@ -32,38 +34,6 @@ app.get("/api/events", async (req, res) => {
     take: 10,
   });
   res.json(events);
-});
-
-// Mock Data for Vaults
-const mockYields = [
-  { protocol: "Blend", asset: "USDC", apy: 6.5, tvl: 12000000, risk: "Low" },
-  {
-    protocol: "Soroswap",
-    asset: "XLM-USDC",
-    apy: 12.2,
-    tvl: 4500000,
-    risk: "Medium",
-  },
-  {
-    protocol: "DeFindex",
-    asset: "Yield Index",
-    apy: 8.9,
-    tvl: 8000000,
-    risk: "Medium",
-  },
-  { protocol: "Blend", asset: "XLM", apy: 4.2, tvl: 25000000, risk: "Low" },
-  {
-    protocol: "Soroswap",
-    asset: "AQUA-USDC",
-    apy: 18.5,
-    tvl: 1200000,
-    risk: "High",
-  },
-];
-
-app.get("/api/yields", (req: Request, res: Response) => {
-  void req;
-  res.json(mockYields);
 });
 
 app.post("/api/recommend", (req: Request, res: Response) => {
@@ -84,6 +54,11 @@ app.get("/api/yields/predict", (req: Request, res: Response) => {
   const protocol = (req.query.protocol as string) || "Blend";
 
   // Generate mock historical data (last 30 days) based on the protocol's current APY
+  const mockYields = [
+    { protocol: "Blend", apy: 6.5, tvl: 12000000 },
+    { protocol: "Soroswap", apy: 12.2, tvl: 4500000 },
+    { protocol: "DeFindex", apy: 8.9, tvl: 8000000 },
+  ];
   const vault = mockYields.find((v) => v.protocol === protocol);
   const baseApy = vault?.apy ?? 5;
 

--- a/server/src/routes/yields.ts
+++ b/server/src/routes/yields.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { getYieldData } from "../services/yieldService";
+
+const yieldsRouter = Router();
+
+yieldsRouter.get("/", async (_req, res) => {
+  try {
+    const yields = await getYieldData();
+    res.json(yields);
+  } catch (error) {
+    console.error("Failed to serve /api/yields.", error);
+    res.status(500).json({
+      error: "Unable to fetch yield data right now.",
+    });
+  }
+});
+
+export default yieldsRouter;


### PR DESCRIPTION
## Description
Implemented a backend APY data pipeline in the server that fetches fresh Stellar network context with the Stellar SDK, normalizes protocol yield records, caches responses in memory, and exposes a resilient `/api/yields` endpoint for the frontend.

Closes #2

## Changes proposed

### What were you told to do?
Build a Node.js/Express service under `/server` that uses the Stellar SDK to fetch real-time data for Stellar protocols, normalize APY/TVL/risk data into a standard JSON contract, cache responses to reduce rate limiting, expose `GET /api/yields`, and include unit tests for normalization utilities.

### What did I do?
#### Backend service structure
- extracted the Express app into a reusable `app.ts` and added a dedicated `/api/yields` router
- added a yield service layer with protocol configuration, in-memory caching via `node-cache`, and graceful fallback behavior when upstream Stellar calls fail
- integrated `@stellar/stellar-sdk` through a Horizon ledger snapshot service so the API refreshes against live Stellar network data

#### Data normalization and testing
- added typed raw and normalized yield models for a stable frontend contract
- implemented normalization helpers that convert APY basis points, round TVL, and derive a numeric risk score from the existing risk utility
- added unit tests for normalization utilities plus a route test for `GET /api/yields`

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm test -- --runInBand` in `/server`
- `npm run build` in `/server`