### PR TITLE
feat: add interactive APY history chart

### DIFF
--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
-import { ArrowUpRight, TrendingUp, ShieldCheck, Activity } from 'lucide-react';
+import { useEffect, useState } from "react";
+import { Activity, ArrowUpRight, ShieldCheck, TrendingUp } from "lucide-react";
+import ApyHistoryChart from "./charts/ApyHistoryChart";
 
 interface YieldData {
   protocol: string;
@@ -10,27 +10,18 @@ interface YieldData {
   risk: string;
 }
 
-const chartData = [
-  { name: 'Jan', value: 400 },
-  { name: 'Feb', value: 800 },
-  { name: 'Mar', value: 600 },
-  { name: 'Apr', value: 1200 },
-  { name: 'May', value: 1800 },
-  { name: 'Jun', value: 2400 },
-];
-
 export default function Dashboard() {
   const [yields, setYields] = useState<YieldData[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('http://localhost:3001/api/yields')
-      .then(res => res.json())
-      .then(data => {
+    fetch("http://localhost:3001/api/yields")
+      .then((res) => res.json())
+      .then((data) => {
         setYields(data);
         setLoading(false);
       })
-      .catch(err => {
+      .catch((err) => {
         console.error("Failed to fetch yields", err);
         setLoading(false);
       });
@@ -39,143 +30,146 @@ export default function Dashboard() {
   return (
     <div className="space-y-8 animate-in fade-in slide-in-from-bottom-4 duration-700">
       <header className="mb-10">
-        <h2 className="text-4xl font-extrabold tracking-tight mb-2">Welcome Back</h2>
-        <p className="text-gray-400">Optimize your returns across the Stellar ecosystem</p>
+        <h2 className="mb-2 text-4xl font-extrabold tracking-tight">
+          Welcome Back
+        </h2>
+        <p className="text-gray-400">
+          Optimize your returns across the Stellar ecosystem
+        </p>
       </header>
 
-      {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <div className="glass-card p-6 border-l-4 border-[#6C5DD3]">
-          <div className="flex justify-between items-start mb-4">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div className="glass-card border-l-4 border-[#6C5DD3] p-6">
+          <div className="mb-4 flex items-start justify-between">
             <div>
-              <p className="text-sm text-gray-400 font-medium tracking-wide">TOTAL VALUE LOCKED</p>
-              <h3 className="text-3xl font-bold mt-1 shadow-sm">$4,250,000</h3>
+              <p className="text-sm font-medium tracking-wide text-gray-400">
+                TOTAL VALUE LOCKED
+              </p>
+              <h3 className="mt-1 text-3xl font-bold shadow-sm">$4,250,000</h3>
             </div>
-            <div className="bg-[#6C5DD3]/20 p-3 rounded-xl text-[#6C5DD3]">
+            <div className="rounded-xl bg-[#6C5DD3]/20 p-3 text-[#6C5DD3]">
               <Activity size={24} />
             </div>
           </div>
-          <div className="text-sm font-medium text-green-400 flex items-center gap-1">
+          <div className="flex items-center gap-1 text-sm font-medium text-green-400">
             <ArrowUpRight size={16} /> +12.5% this week
           </div>
         </div>
 
-        <div className="glass-card p-6 border-l-4 border-green-500">
-          <div className="flex justify-between items-start mb-4">
+        <div className="glass-card border-l-4 border-green-500 p-6">
+          <div className="mb-4 flex items-start justify-between">
             <div>
-              <p className="text-sm text-gray-400 font-medium tracking-wide">NET APY</p>
-              <h3 className="text-3xl font-bold mt-1">14.2%</h3>
+              <p className="text-sm font-medium tracking-wide text-gray-400">
+                NET APY
+              </p>
+              <h3 className="mt-1 text-3xl font-bold">14.2%</h3>
             </div>
-            <div className="bg-green-500/20 p-3 rounded-xl text-green-500">
+            <div className="rounded-xl bg-green-500/20 p-3 text-green-500">
               <TrendingUp size={24} />
             </div>
           </div>
-          <div className="text-sm font-medium text-gray-400 flex items-center gap-1">
+          <div className="flex items-center gap-1 text-sm font-medium text-gray-400">
             Active in 3 protocols
           </div>
         </div>
 
-        <div className="glass-card p-6 border-l-4 border-blue-500">
-          <div className="flex justify-between items-start mb-4">
+        <div className="glass-card border-l-4 border-blue-500 p-6">
+          <div className="mb-4 flex items-start justify-between">
             <div>
-              <p className="text-sm text-gray-400 font-medium tracking-wide">RISK SCORE</p>
-              <h3 className="text-3xl font-bold mt-1">Low</h3>
+              <p className="text-sm font-medium tracking-wide text-gray-400">
+                RISK SCORE
+              </p>
+              <h3 className="mt-1 text-3xl font-bold">Low</h3>
             </div>
-            <div className="bg-blue-500/20 p-3 rounded-xl text-blue-500">
+            <div className="rounded-xl bg-blue-500/20 p-3 text-blue-500">
               <ShieldCheck size={24} />
             </div>
           </div>
-          <div className="text-sm font-medium text-gray-400 flex items-center gap-1">
+          <div className="flex items-center gap-1 text-sm font-medium text-gray-400">
             Audited smart contracts
           </div>
         </div>
       </div>
 
-      {/* Chart Component */}
-      <div className="glass-card p-6 h-[350px] mt-8">
-        <h3 className="text-xl font-bold mb-6 flex items-center gap-2">
-          Portfolio Growth
-        </h3>
-        <ResponsiveContainer width="100%" height="80%">
-          <AreaChart data={chartData}>
-            <defs>
-              <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor="#6C5DD3" stopOpacity={0.6}/>
-                <stop offset="95%" stopColor="#6C5DD3" stopOpacity={0}/>
-              </linearGradient>
-            </defs>
-            <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" vertical={false} />
-            <XAxis dataKey="name" stroke="#6b7280" tick={{fill: '#6b7280'}} axisLine={false} tickLine={false} dy={10} />
-            <YAxis stroke="#6b7280" tick={{fill: '#6b7280'}} axisLine={false} tickLine={false} tickFormatter={(val) => `$${val}`} dx={-10} />
-            <Tooltip 
-              contentStyle={{ backgroundColor: 'rgba(20,24,34,0.95)', border: '1px solid rgba(255,255,255,0.1)', borderRadius: '12px', boxShadow: '0 10px 25px rgba(0,0,0,0.5)' }}
-              itemStyle={{ color: '#fff', fontWeight: 'bold' }}
-            />
-            <Area type="monotone" dataKey="value" stroke="#6C5DD3" strokeWidth={4} fillOpacity={1} fill="url(#colorValue)" />
-          </AreaChart>
-        </ResponsiveContainer>
-      </div>
+      <ApyHistoryChart />
 
-      {/* Main Yield Table */}
-      <div className="glass-panel overflow-hidden mt-8">
-        <div className="p-6 border-b border-[rgba(255,255,255,0.05)] flex justify-between items-center">
+      <div className="glass-panel mt-8 overflow-hidden">
+        <div className="flex items-center justify-between border-b border-[rgba(255,255,255,0.05)] p-6">
           <h3 className="text-xl font-bold">Top Stellar Yields</h3>
-          <button className="text-sm text-[#6C5DD3] font-medium hover:text-white transition-colors">View All &rarr;</button>
+          <button className="text-sm font-medium text-[#6C5DD3] transition-colors hover:text-white">
+            View All &rarr;
+          </button>
         </div>
         <div className="overflow-x-auto">
-          <table className="w-full text-left border-collapse">
+          <table className="w-full border-collapse text-left">
             <thead>
-              <tr className="bg-[rgba(255,255,255,0.02)] text-gray-400 text-xs uppercase tracking-wider">
+              <tr className="bg-[rgba(255,255,255,0.02)] text-xs uppercase tracking-wider text-gray-400">
                 <th className="px-6 py-4 font-semibold">Protocol</th>
                 <th className="px-6 py-4 font-semibold">Asset</th>
                 <th className="px-6 py-4 font-semibold">APY</th>
                 <th className="px-6 py-4 font-semibold">TVL</th>
                 <th className="px-6 py-4 font-semibold">Risk</th>
-                <th className="px-6 py-4 font-semibold text-right">Action</th>
+                <th className="px-6 py-4 text-right font-semibold">Action</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-[rgba(255,255,255,0.05)]">
               {loading ? (
                 <tr>
-                  <td colSpan={6} className="px-6 py-12 text-center text-gray-500">
-                    <div className="flex justify-center items-center gap-3">
-                       <span className="w-5 h-5 rounded-full border-2 border-[#6C5DD3] border-t-transparent animate-spin"></span>
-                       Fetching on-chain data...
+                  <td
+                    colSpan={6}
+                    className="px-6 py-12 text-center text-gray-500"
+                  >
+                    <div className="flex items-center justify-center gap-3">
+                      <span className="h-5 w-5 animate-spin rounded-full border-2 border-[#6C5DD3] border-t-transparent" />
+                      Fetching on-chain data...
                     </div>
                   </td>
                 </tr>
-              ) : yields.map((y, i) => (
-                <tr key={i} className="group hover:bg-[rgba(255,255,255,0.03)] transition-colors">
-                  <td className="px-6 py-5">
-                    <span className="font-semibold text-white tracking-wide">{y.protocol}</span>
-                  </td>
-                  <td className="px-6 py-5">
-                    <span className="bg-gradient-to-r from-[#6C5DD3]/20 to-[#6C5DD3]/10 text-[#6C5DD3] px-3 py-1.5 rounded-full text-xs font-bold border border-[#6C5DD3]/30">
-                      {y.asset}
-                    </span>
-                  </td>
-                  <td className="px-6 py-5">
-                    <span className="text-green-400 font-extrabold text-lg">{y.apy}%</span>
-                  </td>
-                  <td className="px-6 py-5 text-gray-300 font-medium">
-                    ${y.tvl.toLocaleString()}
-                  </td>
-                  <td className="px-6 py-5">
-                    <span className={`px-2.5 py-1.5 rounded bg-opacity-20 text-xs font-bold uppercase tracking-wider ${
-                      y.risk === 'Low' ? 'bg-green-500 text-green-400' :
-                      y.risk === 'Medium' ? 'bg-yellow-500 text-yellow-400' :
-                      'bg-red-500 text-red-400'
-                    }`}>
-                      {y.risk}
-                    </span>
-                  </td>
-                  <td className="px-6 py-5 text-right">
-                    <button className="btn-secondary text-sm px-5 py-2 opacity-80 group-hover:opacity-100 group-hover:bg-[#6C5DD3] group-hover:border-[#6C5DD3] group-hover:text-white transition-all shadow-md">
-                      Deposit
-                    </button>
-                  </td>
-                </tr>
-              ))}
+              ) : (
+                yields.map((y, i) => (
+                  <tr
+                    key={i}
+                    className="group transition-colors hover:bg-[rgba(255,255,255,0.03)]"
+                  >
+                    <td className="px-6 py-5">
+                      <span className="font-semibold tracking-wide text-white">
+                        {y.protocol}
+                      </span>
+                    </td>
+                    <td className="px-6 py-5">
+                      <span className="rounded-full border border-[#6C5DD3]/30 bg-gradient-to-r from-[#6C5DD3]/20 to-[#6C5DD3]/10 px-3 py-1.5 text-xs font-bold text-[#6C5DD3]">
+                        {y.asset}
+                      </span>
+                    </td>
+                    <td className="px-6 py-5">
+                      <span className="text-lg font-extrabold text-green-400">
+                        {y.apy}%
+                      </span>
+                    </td>
+                    <td className="px-6 py-5 font-medium text-gray-300">
+                      ${y.tvl.toLocaleString()}
+                    </td>
+                    <td className="px-6 py-5">
+                      <span
+                        className={`rounded px-2.5 py-1.5 text-xs font-bold uppercase tracking-wider ${
+                          y.risk === "Low"
+                            ? "bg-green-500 text-green-400"
+                            : y.risk === "Medium"
+                              ? "bg-yellow-500 text-yellow-400"
+                              : "bg-red-500 text-red-400"
+                        } bg-opacity-20`}
+                      >
+                        {y.risk}
+                      </span>
+                    </td>
+                    <td className="px-6 py-5 text-right">
+                      <button className="btn-secondary px-5 py-2 text-sm opacity-80 shadow-md transition-all group-hover:border-[#6C5DD3] group-hover:bg-[#6C5DD3] group-hover:text-white group-hover:opacity-100">
+                        Deposit
+                      </button>
+                    </td>
+                  </tr>
+                ))
+              )}
             </tbody>
           </table>
         </div>

--- a/client/src/components/charts/ApyHistoryChart.tsx
+++ b/client/src/components/charts/ApyHistoryChart.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+type TimeRange = "1W" | "1M" | "All";
+
+interface HistoricalApyPoint {
+  date: string;
+  apy: number;
+}
+
+const mockHistory: HistoricalApyPoint[] = [
+  { date: "2026-02-20", apy: 8.12 },
+  { date: "2026-02-24", apy: 8.34 },
+  { date: "2026-02-28", apy: 8.2 },
+  { date: "2026-03-03", apy: 8.56 },
+  { date: "2026-03-06", apy: 8.75 },
+  { date: "2026-03-09", apy: 8.63 },
+  { date: "2026-03-12", apy: 8.91 },
+  { date: "2026-03-15", apy: 9.08 },
+  { date: "2026-03-18", apy: 8.84 },
+  { date: "2026-03-20", apy: 9.16 },
+  { date: "2026-03-22", apy: 9.28 },
+  { date: "2026-03-25", apy: 9.41 },
+];
+
+function formatAxisDate(date: string) {
+  return new Date(date).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function filterHistory(history: HistoricalApyPoint[], range: TimeRange) {
+  if (range === "All") {
+    return history;
+  }
+
+  const daysBack = range === "1W" ? 7 : 30;
+  const latest = new Date(history[history.length - 1]?.date ?? Date.now());
+  const threshold = new Date(latest);
+  threshold.setDate(latest.getDate() - daysBack);
+
+  return history.filter((point) => new Date(point.date) >= threshold);
+}
+
+const rangeOptions: TimeRange[] = ["1W", "1M", "All"];
+
+export default function ApyHistoryChart() {
+  const [range, setRange] = useState<TimeRange>("1M");
+  const [history, setHistory] = useState<HistoricalApyPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadHistory() {
+      try {
+        const response = await fetch(
+          "http://localhost:3001/api/yields/history",
+        );
+
+        if (!response.ok) {
+          throw new Error("History endpoint unavailable");
+        }
+
+        const data = (await response.json()) as HistoricalApyPoint[];
+        setHistory(data.length > 0 ? data : mockHistory);
+      } catch (error) {
+        console.warn("Using mock APY history data", error);
+        setHistory(mockHistory);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void loadHistory();
+  }, []);
+
+  const filteredHistory = useMemo(
+    () => filterHistory(history, range),
+    [history, range],
+  );
+
+  return (
+    <div className="glass-card mt-8 p-6">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 className="text-xl font-bold text-white">APY History</h3>
+          <p className="mt-1 text-sm text-gray-400">
+            Review recent yield changes before committing to a vault.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          {rangeOptions.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => setRange(option)}
+              className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
+                range === option
+                  ? "bg-[#6C5DD3] text-white shadow-lg shadow-[#6C5DD3]/30"
+                  : "bg-white/5 text-gray-300 hover:bg-white/10"
+              }`}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="h-[320px] w-full sm:h-[360px]">
+        {loading ? (
+          <div className="flex h-full items-center justify-center text-gray-400">
+            Loading APY history...
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart
+              data={filteredHistory}
+              margin={{ top: 12, right: 12, left: -16, bottom: 0 }}
+            >
+              <CartesianGrid
+                stroke="rgba(255,255,255,0.08)"
+                strokeDasharray="4 4"
+                vertical={false}
+              />
+              <XAxis
+                dataKey="date"
+                tickFormatter={formatAxisDate}
+                stroke="#94a3b8"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                axisLine={false}
+                tickLine={false}
+              />
+              <YAxis
+                domain={["dataMin - 0.4", "dataMax + 0.4"]}
+                tickFormatter={(value) => `${value.toFixed(1)}%`}
+                stroke="#94a3b8"
+                tick={{ fill: "#94a3b8", fontSize: 12 }}
+                axisLine={false}
+                tickLine={false}
+                width={54}
+              />
+              <Tooltip
+                formatter={(value: number) => [`${value.toFixed(2)}%`, "APY"]}
+                labelFormatter={(label) =>
+                  new Date(label).toLocaleDateString("en-US", {
+                    weekday: "short",
+                    month: "short",
+                    day: "numeric",
+                    year: "numeric",
+                  })
+                }
+                contentStyle={{
+                  backgroundColor: "rgba(15, 23, 42, 0.94)",
+                  border: "1px solid rgba(148, 163, 184, 0.2)",
+                  borderRadius: "16px",
+                  boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
+                }}
+                cursor={{ stroke: "rgba(108, 93, 211, 0.6)", strokeWidth: 1 }}
+              />
+              <Line
+                type="monotone"
+                dataKey="apy"
+                stroke="#6C5DD3"
+                strokeWidth={3}
+                dot={{ r: 0 }}
+                activeDot={{
+                  r: 5,
+                  stroke: "#ffffff",
+                  strokeWidth: 2,
+                  fill: "#6C5DD3",
+                }}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Added a responsive APY history chart to the dashboard with range filters, exact hover details, and mock-backend fallback data so users can inspect recent yield movement before depositing.

Closes #7

## Changes proposed

### What were you told to do?
Build an interactive APY history chart in the React client using Recharts or Chart.js, fetch historical APY data from the backend with mock data acceptable until the endpoint exists, show exact APY percentages and dates in tooltips, add `1W`, `1M`, and `All` range filters, and keep the chart responsive for mobile screens.

### What did I do?
#### Chart experience
- added a dedicated `ApyHistoryChart` component under `client/src/components/charts`
- switched the dashboard from the old static portfolio area chart to a responsive line chart focused on APY history
- included `1W`, `1M`, and `All` filters with exact tooltip formatting for both APY and date values

#### Data loading and fallback behavior
- fetch historical data from a backend history endpoint when available
- fall back to realistic mock history data so the chart remains usable before the backend endpoint ships
- preserved the existing dashboard layout and yield table while making the chart mobile friendly

## Check List (Check all the applicable boxes)
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the main branch (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots / Testing Evidence
- `npm run build` in `/client`
- `npm run lint` in `/client`
- Verified chart responsiveness and mock-data fallback behavior locally through the production build