### PR TITLE
One-Click Zap Deposits (Auto-Swap & Deposit)

### DIFF
--- a/client/src/components/deposit/ZapDeposit.tsx
+++ b/client/src/components/deposit/ZapDeposit.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import { ArrowDown, Zap, Loader2, AlertTriangle } from "lucide-react";
+
+interface ZapDepositProps {
+  walletAddress: string | null;
+  onDeposit?: (inputToken: string, amount: string, slippage: number) => Promise<void>;
+}
+
+const SUPPORTED_TOKENS = [
+  { symbol: "XLM", name: "Stellar Lumens", icon: "X" },
+  { symbol: "USDC", name: "USD Coin", icon: "$" },
+  { symbol: "AQUA", name: "Aquarius", icon: "A" },
+];
+
+const VAULT_TOKEN = "USDC";
+
+export default function ZapDeposit({ walletAddress, onDeposit }: ZapDepositProps) {
+  const [inputToken, setInputToken] = useState("XLM");
+  const [amount, setAmount] = useState("");
+  const [slippage, setSlippage] = useState(0.5);
+  const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [error, setError] = useState("");
+
+  const needsSwap = inputToken !== VAULT_TOKEN;
+
+  const handleDeposit = async () => {
+    if (!walletAddress || !amount || parseFloat(amount) <= 0) return;
+
+    setStatus("loading");
+    setError("");
+
+    try {
+      if (onDeposit) {
+        await onDeposit(inputToken, amount, slippage);
+      }
+      setStatus("success");
+      setAmount("");
+    } catch (err) {
+      setStatus("error");
+      setError(err instanceof Error ? err.message : "Transaction failed");
+    }
+  };
+
+  if (!walletAddress) {
+    return (
+      <div className="bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 p-8 text-center">
+        <Zap className="w-12 h-12 text-yellow-400 mx-auto mb-4" />
+        <h3 className="text-xl font-bold text-white mb-2">Zap Deposit</h3>
+        <p className="text-gray-400">Connect your wallet to make a deposit</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 p-6 max-w-md mx-auto">
+      <div className="flex items-center gap-2 mb-6">
+        <Zap className="w-5 h-5 text-yellow-400" />
+        <h3 className="text-lg font-bold text-white">Zap Deposit</h3>
+      </div>
+
+      {/* Input Token */}
+      <div className="bg-white/5 rounded-xl p-4 mb-2">
+        <label className="text-sm text-gray-400 mb-2 block">You pay</label>
+        <div className="flex gap-3">
+          <select
+            value={inputToken}
+            onChange={(e) => setInputToken(e.target.value)}
+            className="bg-white/10 text-white rounded-lg px-3 py-2 border border-white/10"
+          >
+            {SUPPORTED_TOKENS.map((t) => (
+              <option key={t.symbol} value={t.symbol}>
+                {t.symbol}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+            placeholder="0.00"
+            className="flex-1 bg-transparent text-white text-right text-2xl outline-none"
+          />
+        </div>
+      </div>
+
+      {/* Arrow */}
+      <div className="flex justify-center my-2">
+        <div className="bg-white/10 rounded-full p-2">
+          <ArrowDown className="w-4 h-4 text-gray-400" />
+        </div>
+      </div>
+
+      {/* Output (Vault Token) */}
+      <div className="bg-white/5 rounded-xl p-4 mb-4">
+        <label className="text-sm text-gray-400 mb-2 block">
+          {needsSwap ? "Swapped & deposited into vault" : "Deposited into vault"}
+        </label>
+        <div className="flex items-center justify-between">
+          <span className="text-white font-medium">{VAULT_TOKEN} Vault</span>
+          <span className="text-gray-400 text-sm">
+            {needsSwap ? "Auto-swap via DEX" : "Direct deposit"}
+          </span>
+        </div>
+      </div>
+
+      {/* Slippage */}
+      {needsSwap && (
+        <div className="bg-white/5 rounded-xl p-4 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm text-gray-400">Slippage tolerance</span>
+            <span className="text-sm text-white">{slippage}%</span>
+          </div>
+          <div className="flex gap-2">
+            {[0.1, 0.5, 1.0, 2.0].map((s) => (
+              <button
+                key={s}
+                onClick={() => setSlippage(s)}
+                className={`flex-1 py-1 rounded-lg text-sm ${
+                  slippage === s
+                    ? "bg-blue-500 text-white"
+                    : "bg-white/10 text-gray-400 hover:bg-white/20"
+                }`}
+              >
+                {s}%
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Error */}
+      {error && (
+        <div className="flex items-center gap-2 text-red-400 text-sm mb-4">
+          <AlertTriangle className="w-4 h-4" />
+          {error}
+        </div>
+      )}
+
+      {/* Submit */}
+      <button
+        onClick={handleDeposit}
+        disabled={!amount || parseFloat(amount) <= 0 || status === "loading"}
+        className="w-full py-3 rounded-xl font-semibold text-white bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+      >
+        {status === "loading" ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Processing...
+          </>
+        ) : status === "success" ? (
+          "Deposit Successful!"
+        ) : needsSwap ? (
+          <>
+            <Zap className="w-4 h-4" />
+            Zap Deposit
+          </>
+        ) : (
+          "Deposit"
+        )}
+      </button>
+
+      {needsSwap && (
+        <p className="text-xs text-gray-500 text-center mt-3">
+          Your {inputToken} will be swapped for {VAULT_TOKEN} and deposited in one transaction
+        </p>
+      )}
+    </div>
+  );
+}

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["yield_vault"]
+members = ["yield_vault", "zap"]
 
 [profile.release]
 opt-level = "z"

--- a/contracts/zap/Cargo.toml
+++ b/contracts/zap/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "zap"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "22.0.0"
+soroban-token-sdk = "22.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "22.0.0", features = ["testutils"] }

--- a/contracts/zap/src/lib.rs
+++ b/contracts/zap/src/lib.rs
@@ -1,0 +1,166 @@
+#![no_std]
+
+//! # Zap — One-Click Swap & Deposit
+//!
+//! Accepts any SAC token from the user, swaps it for the vault's required
+//! token via a DEX router, and deposits the result into the YieldVault in
+//! a single transaction. Handles slippage tolerance during the swap.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, symbol_short, token, vec, Address, Env,
+    IntoVal, Symbol, Val,
+};
+
+// ── Storage ──────────────────────────────────────────────────────────────────
+
+#[contracttype]
+enum DataKey {
+    Admin,
+    DexRouter,
+    Initialized,
+}
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ZapError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    ZeroAmount = 3,
+    Unauthorized = 4,
+    SlippageExceeded = 5,
+    SwapFailed = 6,
+}
+
+// ── Contract ─────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct Zap;
+
+#[contractimpl]
+impl Zap {
+    /// Initialize the Zap contract with an admin and DEX router address.
+    pub fn initialize(env: Env, admin: Address, dex_router: Address) -> Result<(), ZapError> {
+        if env.storage().instance().has(&DataKey::Initialized) {
+            return Err(ZapError::AlreadyInitialized);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::DexRouter, &dex_router);
+        env.storage().instance().set(&DataKey::Initialized, &true);
+
+        env.events().publish(
+            (symbol_short!("zap_init"),),
+            (admin, dex_router),
+        );
+
+        Ok(())
+    }
+
+    /// Zap deposit: swap input token for vault token, then deposit into vault.
+    ///
+    /// # Arguments
+    /// * `user` - The depositor (must authorize the call).
+    /// * `input_token` - The token the user wants to deposit (e.g. XLM).
+    /// * `vault_token` - The token the vault requires (e.g. USDC).
+    /// * `vault` - The YieldVault contract address.
+    /// * `amount_in` - Amount of input_token to swap.
+    /// * `min_amount_out` - Minimum vault_token to receive (slippage protection).
+    ///
+    /// # Returns
+    /// The number of vault shares received.
+    pub fn zap_deposit(
+        env: Env,
+        user: Address,
+        input_token: Address,
+        vault_token: Address,
+        vault: Address,
+        amount_in: i128,
+        min_amount_out: i128,
+    ) -> Result<i128, ZapError> {
+        Self::require_init(&env)?;
+        user.require_auth();
+
+        if amount_in <= 0 {
+            return Err(ZapError::ZeroAmount);
+        }
+
+        let zap_addr = env.current_contract_address();
+        let dex_router: Address = env.storage().instance().get(&DataKey::DexRouter).unwrap();
+
+        // Step 1: Transfer input tokens from user to this contract
+        let input_client = token::Client::new(&env, &input_token);
+        input_client.transfer(&user, &zap_addr, &amount_in);
+
+        // Step 2: If input_token == vault_token, skip the swap
+        let deposit_amount = if input_token == vault_token {
+            amount_in
+        } else {
+            // Approve DEX router to spend our input tokens
+            input_client.approve(&zap_addr, &dex_router, &amount_in, &4294967295u32);
+
+            // Swap via DEX router
+            let swap_fn = Symbol::new(&env, "swap");
+            let swap_args: soroban_sdk::Vec<Val> = vec![
+                &env,
+                input_token.into_val(&env),
+                vault_token.clone().into_val(&env),
+                amount_in.into_val(&env),
+                min_amount_out.into_val(&env),
+            ];
+            let amount_out: i128 =
+                env.invoke_contract(&dex_router, &swap_fn, swap_args);
+
+            if amount_out < min_amount_out {
+                return Err(ZapError::SlippageExceeded);
+            }
+
+            amount_out
+        };
+
+        // Step 3: Approve vault to spend the swapped tokens
+        let vault_token_client = token::Client::new(&env, &vault_token);
+        vault_token_client.approve(&zap_addr, &vault, &deposit_amount, &4294967295u32);
+
+        // Step 4: Deposit into YieldVault
+        let deposit_fn = Symbol::new(&env, "deposit");
+        let deposit_args: soroban_sdk::Vec<Val> = vec![
+            &env,
+            zap_addr.into_val(&env),
+            deposit_amount.into_val(&env),
+        ];
+        let shares: i128 = env.invoke_contract(&vault, &deposit_fn, deposit_args);
+
+        env.events().publish(
+            (symbol_short!("zap_dep"),),
+            (user, amount_in, deposit_amount, shares),
+        );
+
+        Ok(shares)
+    }
+
+    /// Update the DEX router address. Admin-only.
+    pub fn set_dex_router(env: Env, admin: Address, new_router: Address) -> Result<(), ZapError> {
+        Self::require_init(&env)?;
+        admin.require_auth();
+
+        let stored_admin: Address = env.storage().instance().get(&DataKey::Admin).unwrap();
+        if admin != stored_admin {
+            return Err(ZapError::Unauthorized);
+        }
+
+        env.storage().instance().set(&DataKey::DexRouter, &new_router);
+        Ok(())
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────
+
+    fn require_init(env: &Env) -> Result<(), ZapError> {
+        if !env.storage().instance().has(&DataKey::Initialized) {
+            return Err(ZapError::NotInitialized);
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description
Add Zap contract and frontend component for single-transaction swap + deposit.

## Changes

### Contract (contracts/zap/)
- Zap contract accepts any SAC token, swaps via DEX router, deposits into YieldVault
- zap_deposit(user, input_token, vault_token, vault, amount_in, min_amount_out)
- Handles slippage tolerance; skips swap when tokens match
- Admin-only set_dex_router for router upgrades

### Frontend (client/src/components/deposit/ZapDeposit.tsx)
- Token selector (XLM, USDC, AQUA)
- Configurable slippage tolerance (0.1%, 0.5%, 1%, 2%)
- Auto-detects swap vs direct deposit
- Loading, success, error states with wallet gate

### Workspace
- Add zap to Cargo.toml workspace members

Closes #31