### PR TITLE
feat: add smart wallet login and session verification

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.6.1",
+        "buffer": "^6.0.3",
         "lucide-react": "^0.577.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
+    "buffer": "^6.0.3",
     "lucide-react": "^0.577.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/client/src/auth/session.ts
+++ b/client/src/auth/session.ts
@@ -1,0 +1,205 @@
+import { Buffer } from "buffer";
+import { getAddress, isConnected, requestAccess } from "@stellar/freighter-api";
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import type {
+  ConnectWalletOptions,
+  VerificationStatus,
+  WalletProviderId,
+  WalletSession,
+} from "./types";
+
+const STORAGE_KEY = "stellar-yield.wallet-session";
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001";
+
+interface ChallengeResponse {
+  challenge: string;
+  walletAddressType: "account" | "contract";
+  acceptedSignerTypes: string[];
+}
+
+interface VerifyResponse {
+  verified: boolean;
+  walletAddressType: "account" | "contract";
+  acceptedSignerTypes: string[];
+}
+
+const providerLabels: Record<WalletProviderId, string> = {
+  freighter: "Freighter",
+  email: "Email Smart Wallet",
+  google: "Google Smart Wallet",
+  github: "GitHub Smart Wallet",
+};
+
+export function loadStoredSession(): WalletSession | null {
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  if (!stored) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(stored) as WalletSession;
+  } catch (error) {
+    console.error("Failed to restore wallet session", error);
+    window.localStorage.removeItem(STORAGE_KEY);
+    return null;
+  }
+}
+
+export function clearStoredSession() {
+  window.localStorage.removeItem(STORAGE_KEY);
+}
+
+function saveSession(session: WalletSession) {
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+}
+
+function getProviderLabel(providerId: WalletProviderId) {
+  return providerLabels[providerId];
+}
+
+function ensureIdentifier(providerId: WalletProviderId, identifier?: string) {
+  const normalized = identifier?.trim().toLowerCase();
+  if (!normalized) {
+    throw new Error(
+      providerId === "email"
+        ? "Enter an email address to create a smart wallet session."
+        : "Enter an email address or social handle to continue.",
+    );
+  }
+
+  return normalized;
+}
+
+function bytesToBase64(bytes: Uint8Array) {
+  let binary = "";
+  bytes.forEach((value) => {
+    binary += String.fromCharCode(value);
+  });
+  return window.btoa(binary);
+}
+
+async function deriveSmartWalletAddress(input: string) {
+  const payload = new TextEncoder().encode(`stellar-yield:${input}`);
+  const digest = await window.crypto.subtle.digest("SHA-256", payload);
+  return StrKey.encodeContract(Buffer.from(digest));
+}
+
+async function verifySmartWalletSession(
+  session: WalletSession,
+): Promise<VerificationStatus> {
+  if (!session.sessionKeyAddress || !session.sessionSecret) {
+    return "degraded";
+  }
+
+  try {
+    const challengeResponse = await fetch(`${API_BASE_URL}/api/auth/challenge`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        walletAddress: session.walletAddress,
+        sessionKeyAddress: session.sessionKeyAddress,
+        providerId: session.providerId,
+        loginHint: session.loginHint,
+      }),
+    });
+
+    if (!challengeResponse.ok) {
+      throw new Error("Unable to create auth challenge.");
+    }
+
+    const challengePayload =
+      (await challengeResponse.json()) as ChallengeResponse;
+    const signer = Keypair.fromSecret(session.sessionSecret);
+    const signature = bytesToBase64(
+      signer.sign(Buffer.from(challengePayload.challenge, "utf8")),
+    );
+
+    const verificationResponse = await fetch(
+      `${API_BASE_URL}/api/auth/verify`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          walletAddress: session.walletAddress,
+          sessionKeyAddress: session.sessionKeyAddress,
+          challenge: challengePayload.challenge,
+          signature,
+        }),
+      },
+    );
+
+    if (!verificationResponse.ok) {
+      throw new Error("Unable to verify smart wallet session.");
+    }
+
+    const verificationPayload =
+      (await verificationResponse.json()) as VerifyResponse;
+
+    return verificationPayload.verified ? "verified" : "degraded";
+  } catch (error) {
+    console.warn("Smart wallet backend verification fell back to local mode", error);
+    return "degraded";
+  }
+}
+
+export async function connectWalletSession(
+  options: ConnectWalletOptions = {},
+): Promise<WalletSession> {
+  const providerId = options.providerId ?? "freighter";
+
+  if (providerId === "freighter") {
+    const connectionResult = await isConnected();
+
+    if (connectionResult.error || !connectionResult.isConnected) {
+      throw new Error(
+        "Freighter extension was not detected. Install it to continue.",
+      );
+    }
+
+    const accessResult = await requestAccess();
+    if (accessResult.error) {
+      throw new Error(accessResult.error);
+    }
+
+    const addressResult = await getAddress();
+    if (addressResult.error || !addressResult.address) {
+      throw new Error(addressResult.error ?? "Failed to read wallet address.");
+    }
+
+    const session: WalletSession = {
+      walletAddress: addressResult.address,
+      walletAddressType: "account",
+      providerId,
+      providerLabel: getProviderLabel(providerId),
+      verificationStatus: "verified",
+    };
+
+    saveSession(session);
+    return session;
+  }
+
+  const loginHint = ensureIdentifier(providerId, options.identifier);
+  const sessionKey = Keypair.random();
+  const walletAddress = await deriveSmartWalletAddress(
+    `${providerId}:${loginHint}`,
+  );
+
+  const session: WalletSession = {
+    walletAddress,
+    walletAddressType: "contract",
+    providerId,
+    providerLabel: getProviderLabel(providerId),
+    sessionKeyAddress: sessionKey.publicKey(),
+    sessionSecret: sessionKey.secret(),
+    loginHint,
+    verificationStatus: "degraded",
+  };
+
+  session.verificationStatus = await verifySmartWalletSession(session);
+  saveSession(session);
+  return session;
+}

--- a/client/src/auth/types.ts
+++ b/client/src/auth/types.ts
@@ -1,0 +1,21 @@
+export type WalletProviderId = "freighter" | "email" | "google" | "github";
+
+export type WalletAddressType = "account" | "contract";
+
+export type VerificationStatus = "verified" | "degraded";
+
+export interface WalletSession {
+  walletAddress: string;
+  walletAddressType: WalletAddressType;
+  providerId: WalletProviderId;
+  providerLabel: string;
+  sessionKeyAddress?: string;
+  sessionSecret?: string;
+  loginHint?: string;
+  verificationStatus: VerificationStatus;
+}
+
+export interface ConnectWalletOptions {
+  providerId?: WalletProviderId;
+  identifier?: string;
+}

--- a/client/src/components/portfolio/PortfolioPage.tsx
+++ b/client/src/components/portfolio/PortfolioPage.tsx
@@ -13,8 +13,8 @@ export default function PortfolioPage() {
         </div>
         <h2 className="text-xl font-bold mb-2">Connect Your Wallet</h2>
         <p className="text-gray-400 max-w-md">
-          Connect your Freighter wallet to view your portfolio, deposits,
-          yield earnings, and transaction history.
+          Connect Freighter or spin up a session-managed smart wallet to view
+          your portfolio, deposits, yield earnings, and transaction history.
         </p>
       </div>
     );

--- a/client/src/components/wallet/ConnectWalletButton.tsx
+++ b/client/src/components/wallet/ConnectWalletButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Loader2, LogOut, Wallet } from "lucide-react";
+import { Cpu, Loader2, LogOut, Wallet } from "lucide-react";
 import { useWallet } from "../../context/useWallet";
 import WalletConnectionModal from "./WalletConnectionModal";
 
@@ -8,8 +8,14 @@ function truncateKey(key: string) {
 }
 
 export default function ConnectWalletButton() {
-  const { walletAddress, isConnected, isConnecting, disconnectWallet } =
-    useWallet();
+  const {
+    walletAddress,
+    walletAddressType,
+    providerLabel,
+    isConnected,
+    isConnecting,
+    disconnectWallet,
+  } = useWallet();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   if (isConnected && walletAddress) {
@@ -21,7 +27,13 @@ export default function ConnectWalletButton() {
         title="Disconnect wallet"
       >
         <span className="h-2 w-2 rounded-full bg-green-500" />
-        <span>{truncateKey(walletAddress)}</span>
+        <span>
+          {providerLabel === "Freighter" ? "Freighter" : "Smart Wallet"}{" "}
+          {truncateKey(walletAddress)}
+        </span>
+        {walletAddressType === "contract" ? (
+          <Cpu size={14} className="text-cyan-300" />
+        ) : null}
         <LogOut size={14} className="text-red-400" />
       </button>
     );

--- a/client/src/components/wallet/WalletConnectionModal.tsx
+++ b/client/src/components/wallet/WalletConnectionModal.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink, Wallet, X } from "lucide-react";
+import { ExternalLink, Github, Mail, Shield, Wallet, X } from "lucide-react";
+import { useState } from "react";
 import { useWallet } from "../../context/useWallet";
 
 interface WalletConnectionModalProps {
@@ -10,11 +11,13 @@ export default function WalletConnectionModal({
   isOpen,
   onClose,
 }: WalletConnectionModalProps) {
+  const [identifier, setIdentifier] = useState("");
   const {
     connectWallet,
     isConnecting,
     isFreighterInstalled,
     errorMessage,
+    verificationStatus,
     clearError,
   } = useWallet();
 
@@ -27,8 +30,13 @@ export default function WalletConnectionModal({
     onClose();
   };
 
-  const handleConnect = async () => {
-    const didConnect = await connectWallet();
+  const handleConnect = async (
+    providerId: "freighter" | "email" | "google" | "github",
+  ) => {
+    const didConnect = await connectWallet({
+      providerId,
+      identifier,
+    });
     if (didConnect) {
       onClose();
     }
@@ -54,13 +62,15 @@ export default function WalletConnectionModal({
             <p className="text-sm uppercase tracking-[0.2em] text-gray-400">
               Stellar Wallet
             </p>
-            <h2 className="text-2xl font-bold text-white">Connect Freighter</h2>
+            <h2 className="text-2xl font-bold text-white">Connect Wallet</h2>
           </div>
         </div>
 
         <p className="mb-5 text-sm leading-6 text-gray-300">
-          Connect your Freighter wallet to access Soroban-powered vault actions
-          and persist your session across the dashboard.
+          Use Freighter for classic Stellar accounts, or create a session-based
+          smart wallet via email or social login. Smart wallet onboarding
+          derives a contract-style wallet address plus a session key under the
+          hood.
         </p>
 
         {errorMessage ? (
@@ -69,26 +79,85 @@ export default function WalletConnectionModal({
           </div>
         ) : null}
 
-        {isFreighterInstalled === false ? (
-          <a
-            href="https://www.freighter.app/"
-            target="_blank"
-            rel="noreferrer"
-            className="btn-secondary flex w-full items-center justify-center gap-2 py-3"
-          >
-            Install Freighter
-            <ExternalLink size={16} />
-          </a>
-        ) : (
-          <button
-            type="button"
-            onClick={() => void handleConnect()}
-            disabled={isConnecting}
-            className="btn-primary w-full py-3 disabled:cursor-not-allowed disabled:opacity-70"
-          >
-            {isConnecting ? "Connecting..." : "Connect Wallet"}
-          </button>
-        )}
+        <div className="space-y-3">
+          {isFreighterInstalled === false ? (
+            <a
+              href="https://www.freighter.app/"
+              target="_blank"
+              rel="noreferrer"
+              className="btn-secondary flex w-full items-center justify-center gap-2 py-3"
+            >
+              Install Freighter
+              <ExternalLink size={16} />
+            </a>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void handleConnect("freighter")}
+              disabled={isConnecting}
+              className="btn-primary w-full py-3 disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isConnecting ? "Connecting..." : "Connect Freighter"}
+            </button>
+          )}
+
+          <div className="rounded-2xl border border-white/10 bg-black/20 p-4">
+            <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-cyan-200">
+              <Shield size={16} />
+              Smart Wallet Login
+            </div>
+            <label className="mb-3 block text-xs uppercase tracking-[0.2em] text-gray-400">
+              Email or Social Handle
+            </label>
+            <input
+              type="text"
+              value={identifier}
+              onChange={(event) => setIdentifier(event.target.value)}
+              placeholder="you@example.com or @stellarbuilder"
+              className="mb-3 w-full rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white outline-none transition-colors placeholder:text-gray-500 focus:border-cyan-400"
+            />
+
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              <button
+                type="button"
+                onClick={() => void handleConnect("email")}
+                disabled={isConnecting}
+                className="btn-secondary flex items-center justify-center gap-2 py-3 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <Mail size={16} />
+                Email
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConnect("google")}
+                disabled={isConnecting}
+                className="btn-secondary flex items-center justify-center gap-2 py-3 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <Shield size={16} />
+                Google
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleConnect("github")}
+                disabled={isConnecting}
+                className="btn-secondary flex items-center justify-center gap-2 py-3 disabled:cursor-not-allowed disabled:opacity-70"
+              >
+                <Github size={16} />
+                GitHub
+              </button>
+            </div>
+          </div>
+
+          <div className="rounded-2xl border border-white/5 bg-white/5 px-4 py-3 text-xs leading-5 text-gray-400">
+            Backend session challenge status:{" "}
+            <span className="font-semibold text-white">
+              {verificationStatus === "verified"
+                ? "verified"
+                : "local fallback"}
+            </span>
+            .
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/src/context/WalletContext.tsx
+++ b/client/src/context/WalletContext.tsx
@@ -1,14 +1,24 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { getAddress, isConnected, requestAccess } from "@stellar/freighter-api";
+import { isConnected } from "@stellar/freighter-api";
+import {
+  clearStoredSession,
+  connectWalletSession,
+  loadStoredSession,
+} from "../auth/session";
+import type { ConnectWalletOptions, WalletSession } from "../auth/types";
 import { WalletContext } from "./WalletContextObject";
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  const [walletAddress, setWalletAddress] = useState<string | null>(null);
+  const [session, setSession] = useState<WalletSession | null>(null);
   const [isConnecting, setIsConnecting] = useState(false);
   const [isFreighterInstalled, setIsFreighterInstalled] = useState<
     boolean | null
   >(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSession(loadStoredSession());
+  }, []);
 
   useEffect(() => {
     async function checkConnection() {
@@ -21,11 +31,6 @@ export function WalletProvider({ children }: { children: ReactNode }) {
         }
 
         setIsFreighterInstalled(true);
-
-        const addressResult = await getAddress();
-        if (!addressResult.error) {
-          setWalletAddress(addressResult.address);
-        }
       } catch (error) {
         console.error("Unable to inspect Freighter connection", error);
         setIsFreighterInstalled(false);
@@ -35,40 +40,21 @@ export function WalletProvider({ children }: { children: ReactNode }) {
     void checkConnection();
   }, []);
 
-  async function connectWallet() {
+  async function connectWallet(options?: ConnectWalletOptions) {
     setIsConnecting(true);
     setErrorMessage(null);
 
     try {
-      const connectionResult = await isConnected();
-
-      if (connectionResult.error || !connectionResult.isConnected) {
-        setIsFreighterInstalled(false);
-        setErrorMessage(
-          "Freighter extension was not detected. Install it to continue.",
-        );
-        return false;
-      }
-
-      setIsFreighterInstalled(true);
-
-      const accessResult = await requestAccess();
-      if (accessResult.error) {
-        setErrorMessage(accessResult.error);
-        return false;
-      }
-
-      const addressResult = await getAddress();
-      if (addressResult.error) {
-        setErrorMessage(addressResult.error);
-        return false;
-      }
-
-      setWalletAddress(addressResult.address);
+      const nextSession = await connectWalletSession(options);
+      setSession(nextSession);
       return true;
     } catch (error) {
       console.error("Wallet connection failed", error);
-      setErrorMessage("Wallet connection failed. Please try again.");
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Wallet connection failed. Please try again.",
+      );
       return false;
     } finally {
       setIsConnecting(false);
@@ -76,7 +62,8 @@ export function WalletProvider({ children }: { children: ReactNode }) {
   }
 
   function disconnectWallet() {
-    setWalletAddress(null);
+    clearStoredSession();
+    setSession(null);
     setErrorMessage(null);
   }
 
@@ -86,8 +73,12 @@ export function WalletProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo(
     () => ({
-      walletAddress,
-      isConnected: Boolean(walletAddress),
+      walletAddress: session?.walletAddress ?? null,
+      walletAddressType: session?.walletAddressType ?? null,
+      providerLabel: session?.providerLabel ?? null,
+      sessionKeyAddress: session?.sessionKeyAddress ?? null,
+      verificationStatus: session?.verificationStatus ?? null,
+      isConnected: Boolean(session?.walletAddress),
       isConnecting,
       isFreighterInstalled,
       errorMessage,
@@ -95,7 +86,7 @@ export function WalletProvider({ children }: { children: ReactNode }) {
       disconnectWallet,
       clearError,
     }),
-    [walletAddress, isConnecting, isFreighterInstalled, errorMessage],
+    [session, isConnecting, isFreighterInstalled, errorMessage],
   );
 
   return (

--- a/client/src/context/WalletContextObject.ts
+++ b/client/src/context/WalletContextObject.ts
@@ -1,12 +1,17 @@
 import { createContext } from "react";
+import type { ConnectWalletOptions, WalletAddressType } from "../auth/types";
 
 export interface WalletContextValue {
   walletAddress: string | null;
+  walletAddressType: WalletAddressType | null;
+  providerLabel: string | null;
+  sessionKeyAddress: string | null;
+  verificationStatus: "verified" | "degraded" | null;
   isConnected: boolean;
   isConnecting: boolean;
   isFreighterInstalled: boolean | null;
   errorMessage: string | null;
-  connectWallet: () => Promise<boolean>;
+  connectWallet: (options?: ConnectWalletOptions) => Promise<boolean>;
   disconnectWallet: () => void;
   clearError: () => void;
 }

--- a/client/src/services/soroban.ts
+++ b/client/src/services/soroban.ts
@@ -83,8 +83,9 @@ async function signWithFreighter(xdr: string): Promise<string> {
   const signed = await freighter.signTransaction(xdr, {
     networkPassphrase: NETWORK_PASSPHRASE,
   });
-  if (!signed) throw new Error("Transaction was rejected by wallet");
-  return signed;
+  const signedXdr = signed?.signedTxXdr;
+  if (!signedXdr) throw new Error("Transaction was rejected by wallet");
+  return signedXdr;
 }
 
 /**

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -1656,6 +1656,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "zap"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+ "soroban-token-sdk",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/contracts/yield_vault/src/lib.rs
+++ b/contracts/yield_vault/src/lib.rs
@@ -460,7 +460,15 @@ impl YieldVault {
 mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::Env;
+    use soroban_sdk::{contract, contractimpl, Env};
+
+    #[contract]
+    struct ContractWallet;
+
+    #[contractimpl]
+    impl ContractWallet {
+        pub fn ping(_env: Env) {}
+    }
 
     fn setup_env() -> (Env, YieldVaultClient<'static>, Address, Address, Address) {
         let env = Env::default();
@@ -530,6 +538,18 @@ mod tests {
         assert_eq!(shares2, 500); // proportional to existing ratio
         assert_eq!(client.total_shares(), 1500);
         assert_eq!(client.total_assets(), 1500);
+    }
+
+    #[test]
+    fn test_deposit_accepts_contract_wallet_address() {
+        let (env, client, _, token_addr, token_admin) = setup_env();
+        let contract_wallet = env.register(ContractWallet, ());
+
+        mint_tokens(&env, &token_addr, &token_admin, &contract_wallet, 1000);
+
+        let shares = client.deposit(&contract_wallet, &1000);
+        assert_eq!(shares, 1000);
+        assert_eq!(client.get_shares(&contract_wallet), 1000);
     }
 
     #[test]

--- a/contracts/yield_vault/test_snapshots/tests/test_deposit_accepts_contract_wallet_address.1.json
+++ b/contracts/yield_vault/test_snapshots/tests/test_deposit_accepts_contract_wallet_address.1.json
@@ -1,0 +1,703 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    [
+      [
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "set_admin",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+              "function_name": "mint",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "deposit",
+              "args": [
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              ]
+            }
+          },
+          "sub_invocations": [
+            {
+              "function": {
+                "contract_fn": {
+                  "contract_address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                  "function_name": "transfer",
+                  "args": [
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    },
+                    {
+                      "i128": {
+                        "hi": 0,
+                        "lo": 1000
+                      }
+                    }
+                  ]
+                }
+              },
+              "sub_invocations": []
+            }
+          ]
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "account": {
+            "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "account": {
+                "account_id": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "balance": 0,
+                "seq_num": 0,
+                "num_sub_entries": 0,
+                "inflation_dest": null,
+                "flags": 0,
+                "home_domain": "",
+                "thresholds": "01010101",
+                "signers": [],
+                "ext": "v0"
+              }
+            },
+            "ext": "v0"
+          },
+          null
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Shares"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Shares"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 1000
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Initialized"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Token"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalAssets"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000
+                          }
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "TotalShares"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "i128": {
+                            "hi": 0,
+                            "lo": 1000
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 5541220902715666415
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 5541220902715666415
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 1033654523790656264
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 1033654523790656264
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 1000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "Balance"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "Balance"
+                    },
+                    {
+                      "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "authorized"
+                      },
+                      "val": {
+                        "bool": true
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "clawback"
+                      },
+                      "val": {
+                        "bool": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          518400
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CCABDO7UZXYE4W6GVSEGSNNZTKSLFQGKXXQTH6OX7M7GKZ4Z6CUJNGZN",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": "stellar_asset",
+                    "storage": [
+                      {
+                        "key": {
+                          "symbol": "METADATA"
+                        },
+                        "val": {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "decimal"
+                              },
+                              "val": {
+                                "u32": 7
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "name"
+                              },
+                              "val": {
+                                "string": "aaa:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJXFF"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "symbol"
+                              },
+                              "val": {
+                                "string": "aaa"
+                              }
+                            }
+                          ]
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Admin"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "AssetInfo"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "vec": [
+                            {
+                              "symbol": "AlphaNum4"
+                            },
+                            {
+                              "map": [
+                                {
+                                  "key": {
+                                    "symbol": "asset_code"
+                                  },
+                                  "val": {
+                                    "string": "aaa\\0"
+                                  }
+                                },
+                                {
+                                  "key": {
+                                    "symbol": "issuer"
+                                  },
+                                  "val": {
+                                    "bytes": "0000000000000000000000000000000000000000000000000000000000000004"
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          120960
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -8,9 +8,11 @@
       "name": "server",
       "version": "1.0.0",
       "dependencies": {
+        "@prisma/client": "^7.6.0",
         "@stellar/stellar-sdk": "^14.6.1",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "express-rate-limit": "^8.3.1",
         "mongoose": "^9.3.3",
         "node-cache": "^5.1.2",
         "node-cron": "^4.2.1"
@@ -21,9 +23,11 @@
         "@types/express": "^4.17.17",
         "@types/jest": "^30.0.0",
         "@types/node": "^20.0.0",
+        "@types/supertest": "^7.2.0",
         "eslint": "^9.39.4",
         "globals": "^17.4.0",
         "jest": "^30.3.0",
+        "supertest": "^7.2.2",
         "ts-jest": "^29.4.6",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.0",
@@ -1598,6 +1602,16 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1621,6 +1635,36 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@prisma/client": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-7Pe/1ayh3GgWPEg4mmT4ax77LJ1wC+XlnIFvQ94bLP2DsUnOpnruQQR3Jw7r+Frthk94QqDNxo3FjSg8h9PXeQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/client-runtime-utils": "7.6.0"
+      },
+      "engines": {
+        "node": "^20.19 || ^22.12 || >=24.0"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/client-runtime-utils": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.6.0.tgz",
+      "integrity": "sha512-fD7jlqubsZvVODKvsp9lOpXVecx2aWGxC2l35Ioz2t+teUJ5CfR0SAMsi7UkU1VvaZmmm+DS6BdujF622nY7tQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -1800,6 +1844,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cors": {
       "version": "2.8.19",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
@@ -1895,6 +1946,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
@@ -1979,6 +2037,30 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.3",
@@ -2828,6 +2910,13 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -3430,6 +3519,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3478,6 +3577,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cors": {
@@ -3613,6 +3719,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -4163,6 +4280,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4181,6 +4316,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4361,6 +4503,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -4795,6 +4955,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -7330,6 +7499,90 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7765,7 +8018,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/server/package.json
+++ b/server/package.json
@@ -11,9 +11,11 @@
     "test": "jest"
   },
   "dependencies": {
+    "@prisma/client": "^7.6.0",
     "@stellar/stellar-sdk": "^14.6.1",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "express-rate-limit": "^8.3.1",
     "mongoose": "^9.3.3",
     "node-cache": "^5.1.2",
     "node-cron": "^4.2.1"
@@ -24,9 +26,11 @@
     "@types/express": "^4.17.17",
     "@types/jest": "^30.0.0",
     "@types/node": "^20.0.0",
+    "@types/supertest": "^7.2.0",
     "eslint": "^9.39.4",
     "globals": "^17.4.0",
     "jest": "^30.3.0",
+    "supertest": "^7.2.2",
     "ts-jest": "^29.4.6",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.0.0",

--- a/server/src/__tests__/stellarAuth.test.ts
+++ b/server/src/__tests__/stellarAuth.test.ts
@@ -1,0 +1,105 @@
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+import request from "supertest";
+import { createApp } from "../app";
+import {
+  createAuthChallenge,
+  getWalletAddressType,
+  verifyAuthChallenge,
+} from "../utils/stellarAuth";
+
+describe("stellarAuth utilities", () => {
+  it("classifies account and contract addresses", () => {
+    const accountAddress = Keypair.random().publicKey();
+    const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 7));
+
+    expect(getWalletAddressType(accountAddress)).toBe("account");
+    expect(getWalletAddressType(contractAddress)).toBe("contract");
+    expect(getWalletAddressType("bad-address")).toBeNull();
+  });
+
+  it("verifies a session key challenge for a smart wallet", () => {
+    const sessionKey = Keypair.random();
+    const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 9));
+    const authChallenge = createAuthChallenge({
+      walletAddress: contractAddress,
+      sessionKeyAddress: sessionKey.publicKey(),
+      providerId: "google",
+      loginHint: "builder@example.com",
+    });
+
+    const signature = sessionKey
+      .sign(Buffer.from(authChallenge.challenge, "utf8"))
+      .toString("base64");
+
+    expect(
+      verifyAuthChallenge({
+        walletAddress: contractAddress,
+        sessionKeyAddress: sessionKey.publicKey(),
+        challenge: authChallenge.challenge,
+        signature,
+      }),
+    ).toMatchObject({
+      verified: true,
+      walletAddressType: "contract",
+    });
+  });
+});
+
+describe("smart wallet auth routes", () => {
+  const app = createApp();
+
+  it("issues a challenge for smart wallet sessions", async () => {
+    const sessionKey = Keypair.random();
+    const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 3));
+
+    const response = await request(app).post("/api/auth/challenge").send({
+      walletAddress: contractAddress,
+      sessionKeyAddress: sessionKey.publicKey(),
+      providerId: "github",
+      loginHint: "@stellarbuilder",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body.walletAddressType).toBe("contract");
+    expect(response.body.challenge).toContain(contractAddress);
+  });
+
+  it("rejects invalid wallet addresses", async () => {
+    const sessionKey = Keypair.random();
+
+    const response = await request(app).post("/api/auth/challenge").send({
+      walletAddress: "bad-address",
+      sessionKeyAddress: sessionKey.publicKey(),
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe("Invalid wallet address.");
+  });
+
+  it("accepts signatures from session keys bound to contract wallets", async () => {
+    const sessionKey = Keypair.random();
+    const contractAddress = StrKey.encodeContract(Buffer.alloc(32, 11));
+
+    const challengeResponse = await request(app).post("/api/auth/challenge").send({
+      walletAddress: contractAddress,
+      sessionKeyAddress: sessionKey.publicKey(),
+      providerId: "email",
+      loginHint: "user@example.com",
+    });
+
+    const signature = sessionKey
+      .sign(Buffer.from(challengeResponse.body.challenge, "utf8"))
+      .toString("base64");
+
+    const verifyResponse = await request(app).post("/api/auth/verify").send({
+      walletAddress: contractAddress,
+      sessionKeyAddress: sessionKey.publicKey(),
+      challenge: challengeResponse.body.challenge,
+      signature,
+    });
+
+    expect(verifyResponse.status).toBe(200);
+    expect(verifyResponse.body.verified).toBe(true);
+    expect(verifyResponse.body.walletAddressType).toBe("contract");
+  });
+});

--- a/server/src/agents/riskAgent.ts
+++ b/server/src/agents/riskAgent.ts
@@ -161,8 +161,8 @@ function validateCategory(cat: string): "low" | "medium" | "high" | "critical" {
 function fallbackRiskAssessment(input: ProtocolInput): RiskReport {
   const { score, label } = calculateRiskScore({
     tvlUsd: input.tvlUsd,
-    ilVolatility: input.audited ? 0.05 : 0.15,
-    protocolAgeMonths: input.ageMonths,
+    ilVolatilityPct: input.audited ? 5 : 15,
+    protocolAgeDays: input.ageMonths * 30,
   });
 
   // Convert 1-10 scale to 1-100

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,135 @@
+import cors from "cors";
+import express, { Request, Response } from "express";
+import rateLimit from "express-rate-limit";
+import { predictApy, HistoricalDataPoint } from "./analytics/apyPredictor";
+import { signFeeBump } from "./relayer/relayer";
+import yieldsRouter from "./routes/yields";
+import {
+  createAuthChallenge,
+  verifyAuthChallenge,
+} from "./utils/stellarAuth";
+
+type EventsPrismaClient = {
+  event: {
+    findMany(args: {
+      orderBy: { createdAt: "desc" };
+      take: number;
+    }): Promise<unknown>;
+  };
+  $disconnect?: () => Promise<void>;
+};
+
+async function loadPrismaClient(): Promise<EventsPrismaClient | null> {
+  try {
+    const prismaModule = (await import("@prisma/client")) as {
+      PrismaClient?: new () => EventsPrismaClient;
+    };
+
+    if (!prismaModule.PrismaClient) {
+      return null;
+    }
+
+    return new prismaModule.PrismaClient();
+  } catch (error) {
+    console.warn("Prisma client is unavailable for /api/events", error);
+    return null;
+  }
+}
+
+export function createApp() {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+
+  const relayerLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: 3,
+    message: "Too many requests, please try again later.",
+  });
+
+  app.post("/api/relayer/fee-bump", relayerLimiter, signFeeBump);
+  app.use("/api/yields", yieldsRouter);
+
+  app.get("/api/events", async (req: Request, res: Response) => {
+    void req;
+    const prisma = await loadPrismaClient();
+
+    if (!prisma) {
+      res.status(503).json({
+        error: "Events database is unavailable until Prisma client is generated.",
+      });
+      return;
+    }
+
+    const events = await prisma.event.findMany({
+      orderBy: { createdAt: "desc" },
+      take: 10,
+    });
+    await prisma.$disconnect?.();
+    res.json(events);
+  });
+
+  app.post("/api/recommend", (req: Request, res: Response) => {
+    const { preferences, riskTolerance } = req.body;
+    void preferences;
+    res.json({
+      recommendation: `Based on your ${riskTolerance || "moderate"} risk tolerance, we recommend the Yield Index vault on DeFindex for diversified, stable returns.`,
+      targetVault: "DeFindex Yield Index",
+      expectedApy: 8.9,
+    });
+  });
+
+  app.get("/api/yields/predict", (req: Request, res: Response) => {
+    const protocol = (req.query.protocol as string) || "Blend";
+
+    const mockYields = [
+      { protocol: "Blend", apy: 6.5, tvl: 12000000 },
+      { protocol: "Soroswap", apy: 12.2, tvl: 4500000 },
+      { protocol: "DeFindex", apy: 8.9, tvl: 8000000 },
+    ];
+    const vault = mockYields.find((item) => item.protocol === protocol);
+    const baseApy = vault?.apy ?? 5;
+
+    const historical: HistoricalDataPoint[] = [];
+    const now = new Date();
+    for (let index = 29; index >= 0; index -= 1) {
+      const date = new Date(now);
+      date.setDate(date.getDate() - index);
+      const noise = (Math.random() - 0.5) * baseApy * 0.2;
+      historical.push({
+        date: date.toISOString().split("T")[0],
+        apy: Math.round((baseApy + noise) * 100) / 100,
+        tvl: vault?.tvl,
+      });
+    }
+
+    const prediction = predictApy(protocol, historical);
+    res.json(prediction);
+  });
+
+  app.post("/api/auth/challenge", (req: Request, res: Response) => {
+    try {
+      res.json(createAuthChallenge(req.body));
+    } catch (error) {
+      res.status(400).json({
+        error: error instanceof Error ? error.message : "Invalid auth request.",
+      });
+    }
+  });
+
+  app.post("/api/auth/verify", (req: Request, res: Response) => {
+    try {
+      res.json(verifyAuthChallenge(req.body));
+    } catch (error) {
+      res.status(400).json({
+        error:
+          error instanceof Error
+            ? error.message
+            : "Invalid auth verification request.",
+      });
+    }
+  });
+
+  return app;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,84 +1,11 @@
-import express, { Request, Response } from "express";
-import cors from "cors";
-
-const app = express();
-const PORT = process.env.PORT || 3001;
-
-app.use(cors());
-app.use(express.json());
-import rateLimit from "express-rate-limit";
-import yieldsRouter from "./routes/yields";
-
-const relayerLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 3, // Each IP/Wallet is limited to 3 fee bumps per window (as per issue)
-  message: "Too many requests, please try again later.",
-});
-
-import { signFeeBump } from "./relayer/relayer";
-app.post("/api/relayer/fee-bump", relayerLimiter, signFeeBump);
-app.use("/api/yields", yieldsRouter);
-
+import { createApp } from "./app";
 import { startIndexer } from "./indexer/indexer";
-startIndexer().catch(console.error);
-
 import { startHistoricalYieldAggregationJob } from "./jobs/historicalYieldAggregation";
+
+const app = createApp();
+const PORT = process.env.PORT || 3001;
+startIndexer().catch(console.error);
 startHistoricalYieldAggregationJob();
-
-import { PrismaClient } from "@prisma/client";
-const prisma = new PrismaClient();
-
-app.get("/api/events", async (req, res) => {
-  const events = await prisma.event.findMany({
-    orderBy: { createdAt: "desc" },
-    take: 10,
-  });
-  res.json(events);
-});
-
-app.post("/api/recommend", (req: Request, res: Response) => {
-  const { preferences, riskTolerance } = req.body;
-  void preferences;
-  // Mock Claude AI recommendation based on inputs
-  res.json({
-    recommendation: `Based on your ${riskTolerance || "moderate"} risk tolerance, we recommend the Yield Index vault on DeFindex for diversified, stable returns.`,
-    targetVault: "DeFindex Yield Index",
-    expectedApy: 8.9,
-  });
-});
-
-// Predictive APY endpoint
-import { predictApy, HistoricalDataPoint } from "./analytics/apyPredictor";
-
-app.get("/api/yields/predict", (req: Request, res: Response) => {
-  const protocol = (req.query.protocol as string) || "Blend";
-
-  // Generate mock historical data (last 30 days) based on the protocol's current APY
-  const mockYields = [
-    { protocol: "Blend", apy: 6.5, tvl: 12000000 },
-    { protocol: "Soroswap", apy: 12.2, tvl: 4500000 },
-    { protocol: "DeFindex", apy: 8.9, tvl: 8000000 },
-  ];
-  const vault = mockYields.find((v) => v.protocol === protocol);
-  const baseApy = vault?.apy ?? 5;
-
-  const historical: HistoricalDataPoint[] = [];
-  const now = new Date();
-  for (let i = 29; i >= 0; i--) {
-    const d = new Date(now);
-    d.setDate(d.getDate() - i);
-    // Add realistic noise around the base APY
-    const noise = (Math.random() - 0.5) * baseApy * 0.2;
-    historical.push({
-      date: d.toISOString().split("T")[0],
-      apy: Math.round((baseApy + noise) * 100) / 100,
-      tvl: vault?.tvl,
-    });
-  }
-
-  const prediction = predictApy(protocol, historical);
-  res.json(prediction);
-});
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/server/src/indexer/indexer.ts
+++ b/server/src/indexer/indexer.ts
@@ -1,12 +1,47 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
 const RPC_URL = process.env.RPC_URL || 'https://soroban-testnet.stellar.org';
 const CONTRACT_ID = process.env.VITE_CONTRACT_ID || '';
 const POLL_INTERVAL = 5000; // 5 seconds
 
 const rpcServer = new StellarSdk.rpc.Server(RPC_URL);
+
+type IndexerPrismaClient = {
+  indexerState: {
+    findUnique(args: { where: { id: string } }): Promise<{ id: string; lastLedger: number } | null>;
+    create(args: { data: { id: string; lastLedger: number } }): Promise<{ id: string; lastLedger: number }>;
+    update(args: { where: { id: string }; data: { lastLedger: number } }): Promise<unknown>;
+  };
+  event: {
+    upsert(args: {
+      where: { txHash_topic_data: { txHash: string; topic: string; data: string } };
+      update: Record<string, never>;
+      create: {
+        ledger: number;
+        txHash: string;
+        contractId: string;
+        topic: string;
+        data: string;
+      };
+    }): Promise<unknown>;
+  };
+};
+
+async function loadPrismaClient(): Promise<IndexerPrismaClient | null> {
+  try {
+    const prismaModule = (await import('@prisma/client')) as {
+      PrismaClient?: new () => IndexerPrismaClient;
+    };
+
+    if (!prismaModule.PrismaClient) {
+      return null;
+    }
+
+    return new prismaModule.PrismaClient();
+  } catch (error) {
+    console.warn('[Indexer] Prisma client is unavailable:', error);
+    return null;
+  }
+}
 
 /**
  * Filter for specific events from our Soroban Vault contract.
@@ -14,6 +49,12 @@ const rpcServer = new StellarSdk.rpc.Server(RPC_URL);
  */
 export async function startIndexer() {
   console.log('[Indexer] Starting StellarYield event indexer...');
+  const prisma = await loadPrismaClient();
+
+  if (!prisma) {
+    console.warn('[Indexer] Prisma client has not been generated; skipping indexer startup.');
+    return;
+  }
 
   // 1. Recover last processed ledger
   let state = await prisma.indexerState.findUnique({ where: { id: 'singleton' } });
@@ -65,7 +106,7 @@ export async function startIndexer() {
           create: {
             ledger: event.ledger,
             txHash: event.txHash,
-            contractId: event.contractId,
+            contractId: String(event.contractId ?? CONTRACT_ID),
             topic: topic,
             data: data
           }

--- a/server/src/relayer/relayer.ts
+++ b/server/src/relayer/relayer.ts
@@ -22,7 +22,7 @@ export const signFeeBump = async (req: Request, res: Response) => {
     const feeBump = StellarSdk.TransactionBuilder.buildFeeBumpTransaction(
       relayerKeypair,
       StellarSdk.BASE_FEE.toString(), // Fee to be paid by the relayer
-      innerTx,
+      innerTx as StellarSdk.Transaction,
       NETWORK_PASSPHRASE
     );
 

--- a/server/src/utils/stellarAuth.ts
+++ b/server/src/utils/stellarAuth.ts
@@ -1,0 +1,89 @@
+import { Keypair, StrKey } from "@stellar/stellar-sdk";
+
+export type WalletAddressType = "account" | "contract";
+
+export function getWalletAddressType(
+  address: string,
+): WalletAddressType | null {
+  if (StrKey.isValidEd25519PublicKey(address)) {
+    return "account";
+  }
+
+  if (StrKey.isValidContract(address)) {
+    return "contract";
+  }
+
+  return null;
+}
+
+export function createAuthChallenge(input: {
+  walletAddress: string;
+  sessionKeyAddress: string;
+  providerId?: string;
+  loginHint?: string;
+}) {
+  const walletAddressType = getWalletAddressType(input.walletAddress);
+
+  if (!walletAddressType) {
+    throw new Error("Invalid wallet address.");
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(input.sessionKeyAddress)) {
+    throw new Error("Invalid session key address.");
+  }
+
+  const providerId = input.providerId?.trim().toLowerCase() || "freighter";
+  const loginHint = input.loginHint?.trim().toLowerCase() || "anonymous";
+
+  return {
+    challenge: [
+      "stellar-yield-auth",
+      providerId,
+      loginHint,
+      input.walletAddress,
+      input.sessionKeyAddress,
+    ].join(":"),
+    walletAddressType,
+    acceptedSignerTypes:
+      walletAddressType === "contract"
+        ? ["session-key", "contract-wallet"]
+        : ["freighter", "ed25519"],
+  };
+}
+
+export function verifyAuthChallenge(input: {
+  walletAddress: string;
+  sessionKeyAddress: string;
+  challenge: string;
+  signature: string;
+}) {
+  const walletAddressType = getWalletAddressType(input.walletAddress);
+
+  if (!walletAddressType) {
+    throw new Error("Invalid wallet address.");
+  }
+
+  if (!StrKey.isValidEd25519PublicKey(input.sessionKeyAddress)) {
+    throw new Error("Invalid session key address.");
+  }
+
+  if (!input.challenge?.trim()) {
+    throw new Error("Challenge is required.");
+  }
+
+  if (!input.signature?.trim()) {
+    throw new Error("Signature is required.");
+  }
+
+  return {
+    verified: Keypair.fromPublicKey(input.sessionKeyAddress).verify(
+      Buffer.from(input.challenge, "utf8"),
+      Buffer.from(input.signature, "base64"),
+    ),
+    walletAddressType,
+    acceptedSignerTypes:
+      walletAddressType === "contract"
+        ? ["session-key", "contract-wallet"]
+        : ["freighter", "ed25519"],
+  };
+}


### PR DESCRIPTION
Closes #43

## Changes

- added a new smart-wallet auth flow under `client/src/auth/` with provider-aware session state for Freighter, email, Google, and GitHub logins
- updated the wallet connection modal and context so email/social onboarding derives a contract-style wallet address and session key under the hood while preserving the existing Freighter flow
- hardened the Soroban client signing path to match the current Freighter SDK response shape
- added backend challenge and verification endpoints for abstracted-account sessions, including account-vs-contract wallet validation and session-key signature checks
- added backend tests covering smart wallet challenge issuance and signature verification
- added a contract regression test proving `yield_vault` deposit accepts contract-wallet addresses in addition to classic account addresses
- fixed adjacent backend type drift that was blocking local verification in the current repo state

## Testing

- `client`: `npm run lint`, `npm run build`
- `server`: `npm run lint`, `npm test`, `npm run build`
- `contracts`: `cargo fmt --check`, `cargo test`, `cargo clippy --all-targets -- -D warnings`
