### PR TITLE
feat(og): dynamic og:image meta for vault routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -112,7 +112,7 @@ const router = createBrowserRouter([
         element: <AIAdvisor />,
       },
       {
-        path: "/vault",
+        path: "/vault/:vaultId?",
         element: <Vault />,
       },
       {

--- a/client/src/components/Vault.tsx
+++ b/client/src/components/Vault.tsx
@@ -1,6 +1,14 @@
-import { Landmark } from 'lucide-react';
+import { Landmark } from "lucide-react";
+import { useParams } from "react-router-dom";
+import { useVaultOgMeta } from "../hooks/useVaultOgMeta";
+
+const DEFAULT_VAULT_OG = "StellarYield";
 
 export default function Vault() {
+  const { vaultId } = useParams<{ vaultId?: string }>();
+  const vault = vaultId ?? DEFAULT_VAULT_OG;
+  useVaultOgMeta(vault);
+
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center space-y-6">
       <div className="bg-green-500/20 p-6 rounded-full inline-block mb-4">

--- a/client/src/hooks/useVaultOgMeta.ts
+++ b/client/src/hooks/useVaultOgMeta.ts
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { buildVaultOgImagePath } from "../utils/vaultOg";
+
+/**
+ * Injects / updates Open Graph and Twitter image meta tags in document head for vault pages.
+ * Tags are removed on unmount so other routes do not keep a stale preview image.
+ */
+export function useVaultOgMeta(vault: string): void {
+  useEffect(() => {
+    const content = buildVaultOgImagePath(vault);
+
+    const og = document.createElement("meta");
+    og.setAttribute("property", "og:image");
+    og.setAttribute("content", content);
+    og.setAttribute("data-stellaryield-vault-og", "1");
+    document.head.appendChild(og);
+
+    const tw = document.createElement("meta");
+    tw.setAttribute("name", "twitter:image");
+    tw.setAttribute("content", content);
+    tw.setAttribute("data-stellaryield-vault-og", "1");
+    document.head.appendChild(tw);
+
+    return () => {
+      og.remove();
+      tw.remove();
+    };
+  }, [vault]);
+}

--- a/client/src/utils/vaultOg.ts
+++ b/client/src/utils/vaultOg.ts
@@ -1,0 +1,7 @@
+/**
+ * Path to the dynamic OG image endpoint for a vault (see `src/pages/api/og.tsx`).
+ * Uses URLSearchParams so `vault` is encoded correctly in the query string.
+ */
+export function buildVaultOgImagePath(vault: string): string {
+  return `/api/og?${new URLSearchParams({ vault }).toString()}`;
+}


### PR DESCRIPTION
Implemented dynamic OG images for Vault pages per issue #120. Adds dynamic meta tag injection via hook.