### PR TITLE
ci: add JavaScript dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,36 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "client/package.json"
+      - "client/package-lock.json"
+      - "server/package.json"
+      - "server/package-lock.json"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Review npm dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fail the job on any vulnerability at High severity or above.
+          # Contributors can still see Moderate/Low findings in the PR summary.
+          fail-on-severity: high
+          # Block common copyleft / unlicensed packages so they don't slip into
+          # the tree without review.
+          deny-licenses: GPL-2.0-only, GPL-2.0-or-later, GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary
Add `.github/workflows/dependency-review.yml` so npm dependency changes are reviewed automatically on every PR, matching the existing cargo-audit workflow for Rust contracts.

## Why this matters
Issue #194 pointed at a gap: `.github/workflows/security.yml` audits `contracts/**` Rust changes via `cargo-audit`, but there's no equivalent coverage for the client and server npm trees. With three package lockfiles (`package-lock.json`, `client/package-lock.json`, `server/package-lock.json`), an unreviewed transitive bump can slip in without catch.

`actions/dependency-review-action` is GitHub's official solution and only compares the PR's diff, so it's fast and scoped.

## Changes
- `.github/workflows/dependency-review.yml` (new)
  - Triggers only on pull requests touching `package.json` / `package-lock.json` at repo root, `client/`, or `server/` (paths filter keeps irrelevant PRs untouched)
  - Uses `actions/dependency-review-action@v4`
  - `fail-on-severity: high` - moderate/low still show in the PR summary, only High+ blocks
  - `deny-licenses` covers GPL/AGPL variants, matching the issue's "severity thresholds appropriate for the project" ask
  - `comment-summary-in-pr: on-failure` so when the workflow fails the contributor sees the offending package and CVE inline - that's the "what to do when it fails" guidance

## Testing
Workflow-only addition. Validated:
- YAML structure matches `.github/workflows/security.yml`
- `paths:` matches the three lockfile paths present in the repo

Fixes #194

This contribution was developed with AI assistance (Claude Code).
