### PR TITLE
feat(client): Soroban transaction status timeline

### DIFF
--- a/client/src/components/transaction/TxStatusTimeline.tsx
+++ b/client/src/components/transaction/TxStatusTimeline.tsx
@@ -1,0 +1,163 @@
+import { CheckCircle2, Circle, Loader2, XCircle, Copy, RotateCcw } from "lucide-react";
+import {
+  TX_PHASE_LABELS,
+  type TxPhase,
+  isStepActive,
+  isStepCompleted,
+} from "../../services/transactionPhase";
+
+function stepIsDone(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+  stepIdx: number,
+  failedAtPhase: TxPhase | null | undefined,
+): boolean {
+  if (phase === "success") return true;
+  if (phase === "failure") {
+    const fi =
+      failedAtPhase != null && steps.includes(failedAtPhase)
+        ? steps.indexOf(failedAtPhase)
+        : steps.length - 1;
+    return fi >= 0 && stepIdx < fi;
+  }
+  return isStepCompleted(steps, phase, stepIdx);
+}
+
+function stepIsActive(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+  stepIdx: number,
+): boolean {
+  if (phase === "failure" || phase === "success") return false;
+  return isStepActive(steps, phase, stepIdx);
+}
+
+function stepIsFailed(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+  stepIdx: number,
+  failedAtPhase: TxPhase | null | undefined,
+): boolean {
+  if (phase !== "failure") return false;
+  const fi =
+    failedAtPhase != null && steps.includes(failedAtPhase)
+      ? steps.indexOf(failedAtPhase)
+      : steps.length - 1;
+  return fi >= 0 && stepIdx === fi;
+}
+
+export interface TxStatusTimelineProps {
+  /** Ordered phases to show (e.g. full pipeline or submit/poll only). */
+  steps: readonly TxPhase[];
+  /** Current phase from the Soroban engine. */
+  phase: TxPhase;
+  errorMessage?: string | null;
+  /** Successful transaction hash (explorer link left to caller). */
+  txHash?: string | null;
+  /** Where the flow failed (for highlighting the step). */
+  failedAtPhase?: TxPhase | null;
+  onRetry?: () => void;
+  className?: string;
+}
+
+async function copyText(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    /* ignore */
+  }
+}
+
+export default function TxStatusTimeline({
+  steps,
+  phase,
+  errorMessage,
+  txHash,
+  failedAtPhase,
+  onRetry,
+  className = "",
+}: TxStatusTimelineProps) {
+  const showTimeline = phase !== "idle";
+  if (!showTimeline) return null;
+
+  return (
+    <div
+      className={`rounded-xl border border-white/10 bg-white/5 p-4 space-y-3 ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      <p className="text-xs font-medium text-gray-400 uppercase tracking-wide">
+        Transaction status
+      </p>
+      <ol className="space-y-2">
+        {steps.map((stepId, i) => {
+          const label = TX_PHASE_LABELS[stepId];
+          const complete = stepIsDone(steps, phase, i, failedAtPhase);
+          const active = stepIsActive(steps, phase, i);
+          const failedHere = stepIsFailed(steps, phase, i, failedAtPhase);
+
+          return (
+            <li key={`${stepId}-${i}`} className="flex items-start gap-3 text-sm">
+              <span className="mt-0.5 shrink-0" aria-hidden>
+                {complete && !failedHere ? (
+                  <CheckCircle2 className="w-4 h-4 text-emerald-400" />
+                ) : active ? (
+                  <Loader2 className="w-4 h-4 text-indigo-400 animate-spin" />
+                ) : failedHere ? (
+                  <XCircle className="w-4 h-4 text-red-400" />
+                ) : (
+                  <Circle className="w-4 h-4 text-gray-600" />
+                )}
+              </span>
+              <span
+                className={
+                  failedHere
+                    ? "text-red-300"
+                    : active
+                      ? "text-white font-medium"
+                      : complete
+                        ? "text-gray-300"
+                        : "text-gray-500"
+                }
+              >
+                {label}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+
+      {phase === "success" && txHash && (
+        <p className="text-xs text-emerald-400/90 font-mono break-all pt-1">
+          Hash: {txHash}
+        </p>
+      )}
+
+      {phase === "failure" && errorMessage && (
+        <div className="pt-2 border-t border-white/10 space-y-2">
+          <p className="text-xs text-red-300 break-words">{errorMessage}</p>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void copyText(errorMessage)}
+              className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-white/10 hover:bg-white/15 text-gray-200"
+            >
+              <Copy className="w-3.5 h-3.5" />
+              Copy error
+            </button>
+            {onRetry && (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-indigo-600/40 hover:bg-indigo-600/60 text-white"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+                Retry
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -1,6 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
-import { zapDeposit, type TxStatus } from "../../services/soroban";
+import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
+import { zapDeposit } from "../../services/soroban";
+import type { TxPhase } from "../../services/transactionPhase";
+import { TX_PHASE_PIPELINE } from "../../services/transactionPhase";
 import { fetchSwapQuote } from "./fetchSwapQuote";
 import { minAmountAfterSlippage } from "./slippage";
 import { parseDecimalToStroops, formatStroopsToDecimal } from "./amount";
@@ -46,7 +49,9 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
   const [amount, setAmount] = useState("");
   const [slippage, setSlippage] = useState(0.5);
   const [status, setStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
-  const [txPhase, setTxPhase] = useState<TxStatus>("idle");
+  const [txPhase, setTxPhase] = useState<TxPhase>("idle");
+  const lastProgressPhaseRef = useRef<TxPhase>("idle");
+  const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState("");
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [expectedOut, setExpectedOut] = useState<bigint | null>(null);
@@ -112,7 +117,14 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     return minAmountAfterSlippage(expectedOut, slippage);
   }, [expectedOut, slippage]);
 
-  const handleZap = async () => {
+  const emitPhase = useCallback((p: TxPhase) => {
+    setTxPhase(p);
+    if (p !== "success" && p !== "failure") {
+      lastProgressPhaseRef.current = p;
+    }
+  }, []);
+
+  const handleZap = useCallback(async () => {
     if (!walletAddress || !inputAsset || !vaultContractId || !vaultToken.contractId) return;
     let amountIn: bigint;
     try {
@@ -127,6 +139,9 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
       return;
     }
 
+    lastProgressPhaseRef.current = "idle";
+    setTxPhase("idle");
+    setTxHash(null);
     setStatus("loading");
     setError("");
     try {
@@ -140,18 +155,32 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
           minAmountOut: minOut,
           minSharesOut: minOut,
         },
-        (s) => setTxPhase(s)
+        emitPhase
       );
       if (!result.success) {
         throw new Error(result.error || "Transaction failed");
       }
+      setTxHash(result.hash ?? null);
       setStatus("success");
       setAmount("");
     } catch (err) {
       setStatus("error");
       setError(err instanceof Error ? err.message : "Transaction failed");
     }
-  };
+  }, [
+    walletAddress,
+    inputAsset,
+    vaultContractId,
+    vaultToken.contractId,
+    amount,
+    minOut,
+    emitPhase,
+  ]);
+
+  const retryZap = useCallback(() => {
+    setError("");
+    void handleZap();
+  }, [handleZap]);
 
   const configOk =
     Boolean(vaultContractId) &&
@@ -295,16 +324,28 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
         </div>
       )}
 
-      {error && (
+      {error && txPhase !== "failure" && (
         <div className="flex items-center gap-2 text-red-400 text-sm mb-4">
           <AlertTriangle className="w-4 h-4 shrink-0" />
           {error}
         </div>
       )}
 
-      {txPhase !== "idle" && status === "loading" && (
-        <p className="text-xs text-gray-500 mb-2 capitalize">Status: {txPhase}</p>
-      )}
+      <TxStatusTimeline
+        steps={TX_PHASE_PIPELINE}
+        phase={txPhase}
+        errorMessage={txPhase === "failure" ? error : null}
+        txHash={txHash}
+        failedAtPhase={
+          txPhase === "failure"
+            ? lastProgressPhaseRef.current !== "idle"
+              ? lastProgressPhaseRef.current
+              : "polling"
+            : null
+        }
+        onRetry={txPhase === "failure" ? retryZap : undefined}
+        className="mb-4"
+      />
 
       <button
         type="button"

--- a/client/src/pages/governance/PendingTransactionCard.tsx
+++ b/client/src/pages/governance/PendingTransactionCard.tsx
@@ -1,19 +1,23 @@
-import { useState } from "react";
-import * as StellarSdk from "@stellar/stellar-sdk";
+import { useRef, useState } from "react";
 import freighter from "@stellar/freighter-api";
+import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
 import { useWallet } from "../../context/useWallet";
+import { submitSignedXdrAndPoll } from "../../services/soroban";
+import type { TxPhase } from "../../services/transactionPhase";
+import {
+  TX_PHASE_SUBMIT_POLL,
+  TX_PHASE_WALLET_ONLY,
+} from "../../services/transactionPhase";
 import type { PendingTransaction } from "./types";
+
+const NETWORK_PASSPHRASE =
+  import.meta.env.VITE_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
 
 interface PendingTransactionCardProps {
   transaction: PendingTransaction;
   onSign: (txId: string, publicKey: string) => void;
   onExecute: (txId: string) => void;
 }
-
-const RPC_URL =
-  import.meta.env.VITE_SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
-const NETWORK_PASSPHRASE =
-  import.meta.env.VITE_NETWORK_PASSPHRASE ?? "Test SDF Network ; September 2015";
 
 export default function PendingTransactionCard({
   transaction,
@@ -25,6 +29,14 @@ export default function PendingTransactionCard({
   const [executing, setExecuting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  const [signPhase, setSignPhase] = useState<TxPhase>("idle");
+  const [signError, setSignError] = useState<string | null>(null);
+
+  const [execPhase, setExecPhase] = useState<TxPhase>("idle");
+  const [execError, setExecError] = useState<string | null>(null);
+  const [execHash, setExecHash] = useState<string | null>(null);
+  const lastExecPhaseRef = useRef<TxPhase>("idle");
+
   const hasSigned = transaction.signatures.some(
     (s) => s.publicKey === walletAddress,
   );
@@ -35,6 +47,8 @@ export default function PendingTransactionCard({
     if (!walletAddress) return;
     setSigning(true);
     setError(null);
+    setSignError(null);
+    setSignPhase("waiting_for_wallet");
 
     try {
       const signed = await freighter.signTransaction(transaction.xdr, {
@@ -46,8 +60,13 @@ export default function PendingTransactionCard({
       }
 
       onSign(transaction.id, walletAddress);
+      setSignPhase("success");
+      setTimeout(() => setSignPhase("idle"), 1800);
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      setSignError(msg);
+      setSignPhase("failure");
     } finally {
       setSigning(false);
     }
@@ -57,45 +76,46 @@ export default function PendingTransactionCard({
     if (!isReady) return;
     setExecuting(true);
     setError(null);
+    setExecError(null);
+    setExecHash(null);
+    lastExecPhaseRef.current = "idle";
 
     try {
-      const server = new StellarSdk.rpc.Server(RPC_URL);
-      const tx = StellarSdk.TransactionBuilder.fromXDR(
-        transaction.xdr,
-        NETWORK_PASSPHRASE,
-      );
+      const result = await submitSignedXdrAndPoll(transaction.xdr, (p) => {
+        setExecPhase(p);
+        if (p !== "success" && p !== "failure") {
+          lastExecPhaseRef.current = p;
+        }
+      });
 
-      const sendResponse = await server.sendTransaction(tx);
-
-      if (sendResponse.status === "ERROR") {
-        throw new Error(
-          `Submission rejected: ${sendResponse.errorResult?.toXDR("base64") ?? "unknown"}`,
-        );
-      }
-
-      const hash = sendResponse.hash;
-      const deadline = Date.now() + 30_000;
-      let result = await server.getTransaction(hash);
-
-      while (
-        result.status === StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND &&
-        Date.now() < deadline
-      ) {
-        await new Promise((r) => setTimeout(r, 2000));
-        result = await server.getTransaction(hash);
-      }
-
-      if (result.status === StellarSdk.rpc.Api.GetTransactionStatus.SUCCESS) {
+      if (result.success) {
+        setExecHash(result.hash ?? null);
         onExecute(transaction.id);
       } else {
-        throw new Error(`Transaction ${result.status}`);
+        const msg = result.error ?? "Transaction failed";
+        setExecError(msg);
+        setError(msg);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      const msg = err instanceof Error ? err.message : String(err);
+      setExecError(msg);
+      setError(msg);
     } finally {
       setExecuting(false);
     }
   }
+
+  const retryExecute = () => {
+    setExecError(null);
+    setError(null);
+    void handleExecute();
+  };
+
+  const retrySign = () => {
+    setSignError(null);
+    setError(null);
+    void handleSign();
+  };
 
   const statusColor = isExecuted
     ? "text-green-400"
@@ -142,27 +162,55 @@ export default function PendingTransactionCard({
         </p>
       </div>
 
-      {error && <p className="text-sm text-red-400">{error}</p>}
+      {error && signPhase !== "failure" && execPhase !== "failure" && (
+        <p className="text-sm text-red-400">{error}</p>
+      )}
 
       {!isExecuted && (
-        <div className="flex gap-3">
+        <div className="flex flex-col gap-4">
           {!hasSigned && (
-            <button
-              onClick={handleSign}
-              disabled={signing || !walletAddress}
-              className="flex-1 bg-indigo-500/20 text-indigo-300 border border-indigo-500/30 font-semibold py-2 rounded-lg hover:bg-indigo-500/30 disabled:opacity-50 transition-all"
-            >
-              {signing ? "Signing..." : "Sign Transaction"}
-            </button>
+            <div className="space-y-2">
+              <TxStatusTimeline
+                steps={TX_PHASE_WALLET_ONLY}
+                phase={signPhase}
+                errorMessage={signPhase === "failure" ? signError : null}
+                onRetry={signPhase === "failure" ? retrySign : undefined}
+              />
+              <button
+                type="button"
+                onClick={() => void handleSign()}
+                disabled={signing || !walletAddress}
+                className="w-full bg-indigo-500/20 text-indigo-300 border border-indigo-500/30 font-semibold py-2 rounded-lg hover:bg-indigo-500/30 disabled:opacity-50 transition-all"
+              >
+                {signing ? "Signing..." : "Sign Transaction"}
+              </button>
+            </div>
           )}
           {isReady && (
-            <button
-              onClick={handleExecute}
-              disabled={executing}
-              className="flex-1 bg-gradient-to-r from-green-500 to-emerald-600 text-white font-semibold py-2 rounded-lg disabled:opacity-50 transition-opacity"
-            >
-              {executing ? "Executing..." : "Execute"}
-            </button>
+            <div className="space-y-2">
+              <TxStatusTimeline
+                steps={TX_PHASE_SUBMIT_POLL}
+                phase={execPhase}
+                errorMessage={execPhase === "failure" ? execError : null}
+                txHash={execHash}
+                failedAtPhase={
+                  execPhase === "failure"
+                    ? lastExecPhaseRef.current !== "idle"
+                      ? lastExecPhaseRef.current
+                      : "polling"
+                    : null
+                }
+                onRetry={execPhase === "failure" ? retryExecute : undefined}
+              />
+              <button
+                type="button"
+                onClick={() => void handleExecute()}
+                disabled={executing}
+                className="w-full bg-gradient-to-r from-green-500 to-emerald-600 text-white font-semibold py-2 rounded-lg disabled:opacity-50 transition-opacity"
+              >
+                {executing ? "Executing..." : "Execute"}
+              </button>
+            </div>
           )}
         </div>
       )}

--- a/client/src/services/soroban.ts
+++ b/client/src/services/soroban.ts
@@ -7,6 +7,7 @@
 
 import * as StellarSdk from "@stellar/stellar-sdk";
 import freighter from "@stellar/freighter-api";
+import type { TxPhase } from "./transactionPhase";
 
 // ── Configuration ───────────────────────────────────────────────────────
 
@@ -33,7 +34,13 @@ export interface TxResult {
   error?: string;
 }
 
-export type TxStatus = "idle" | "building" | "signing" | "submitting" | "confirming" | "success" | "error";
+/** Lifecycle phases for Soroban flows (timeline + callbacks). */
+export type { TxPhase };
+
+/** @deprecated Prefer `TxPhase`; kept for older call sites. */
+export type TxStatus = TxPhase;
+
+export type TxPhaseCallback = (phase: TxPhase) => void;
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -80,8 +87,10 @@ async function buildContractCallOn(
   contract: StellarSdk.Contract,
   sourcePublicKey: string,
   method: string,
-  ...args: StellarSdk.xdr.ScVal[]
+  args: StellarSdk.xdr.ScVal[],
+  onPhase?: TxPhaseCallback,
 ): Promise<string> {
+  onPhase?.("building");
   const server = getServer();
   const source = await server.getAccount(sourcePublicKey);
   const baseFee = await getRecommendedBaseFee("average");
@@ -94,6 +103,7 @@ async function buildContractCallOn(
     .setTimeout(30)
     .build();
 
+  onPhase?.("simulating");
   const simulated = await server.simulateTransaction(tx);
 
   if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
@@ -112,18 +122,19 @@ async function buildContractCallOn(
 async function buildContractCall(
   sourcePublicKey: string,
   method: string,
-  ...args: StellarSdk.xdr.ScVal[]
+  args: StellarSdk.xdr.ScVal[],
+  onPhase?: TxPhaseCallback,
 ): Promise<string> {
-  return buildContractCallOn(getContract(), sourcePublicKey, method, ...args);
+  return buildContractCallOn(getContract(), sourcePublicKey, method, args, onPhase);
 }
 
 /**
  * Sign a transaction XDR with the user's Freighter wallet.
  * @deprecated Use `signTransaction` parameter in `executeContractCall` instead.
  */
-async function signWithFreighter(xdr: string): Promise<string> {
+async function signWithFreighter(xdr: string, networkPassphrase: string): Promise<string> {
   const signed = await freighter.signTransaction(xdr, {
-    networkPassphrase: NETWORK_PASSPHRASE,
+    networkPassphrase,
   });
   const signedXdr = signed?.signedTxXdr;
   if (!signedXdr) throw new Error("Transaction was rejected by wallet");
@@ -134,7 +145,8 @@ async function signWithFreighter(xdr: string): Promise<string> {
  * Submit a signed transaction to the Soroban RPC and poll until
  * it reaches a terminal state.
  */
-async function submitAndPoll(signedXdr: string): Promise<TxResult> {
+async function submitAndPoll(signedXdr: string, onPhase?: TxPhaseCallback): Promise<TxResult> {
+  onPhase?.("submitting");
   const server = getServer();
   const tx = StellarSdk.TransactionBuilder.fromXDR(signedXdr, NETWORK_PASSPHRASE);
   const sendResponse = await server.sendTransaction(tx);
@@ -150,6 +162,7 @@ async function submitAndPoll(signedXdr: string): Promise<TxResult> {
   const deadline = Date.now() + POLL_TIMEOUT_MS;
   let result = await server.getTransaction(hash);
 
+  onPhase?.("polling");
   while (
     result.status === StellarSdk.rpc.Api.GetTransactionStatus.NOT_FOUND &&
     Date.now() < deadline
@@ -169,6 +182,26 @@ async function submitAndPoll(signedXdr: string): Promise<TxResult> {
   return { success: false, hash, error: "Transaction timed out" };
 }
 
+/**
+ * Submit an already-signed transaction XDR (e.g. governance multisig) and poll for inclusion.
+ */
+export async function submitSignedXdrAndPoll(
+  signedXdr: string,
+  onPhase?: TxPhaseCallback,
+): Promise<TxResult> {
+  try {
+    const result = await submitAndPoll(signedXdr, onPhase);
+    onPhase?.(result.success ? "success" : "failure");
+    return result;
+  } catch (err) {
+    onPhase?.("failure");
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 // ── Public API ──────────────────────────────────────────────────────────
 
 /**
@@ -177,7 +210,7 @@ async function submitAndPoll(signedXdr: string): Promise<TxResult> {
  * @param sourcePublicKey  - Caller's Stellar public key
  * @param method           - Contract method name (e.g. "deposit")
  * @param args             - ScVal arguments
- * @param onStatus         - Optional callback for status updates
+ * @param onPhase         - Optional callback for phase updates (timeline)
  * @param useFeeBump       - Whether to wrap the tx in a fee-bump via the relayer
  * @param signTx           - Optional signer function; defaults to Freighter for
  *                           backwards compatibility. Pass `wallet.signTransaction`
@@ -187,37 +220,35 @@ export async function executeContractCall(
   sourcePublicKey: string,
   method: string,
   args: StellarSdk.xdr.ScVal[],
-  onStatus?: (status: TxStatus) => void,
+  onPhase?: TxPhaseCallback,
   useFeeBump: boolean = false,
   signTx?: (xdr: string, networkPassphrase: string) => Promise<string>,
 ): Promise<TxResult> {
   try {
-    onStatus?.("building");
-    const xdr = await buildContractCall(sourcePublicKey, method, ...args);
+    const xdr = await buildContractCall(sourcePublicKey, method, args, onPhase);
 
-    onStatus?.("signing");
-    const signer = signTx ?? ((x: string) => signWithFreighter(x));
+    onPhase?.("waiting_for_wallet");
+    const signer = signTx ?? ((x: string, p: string) => signWithFreighter(x, p));
     const signedXdr = await signer(xdr, NETWORK_PASSPHRASE);
 
     let finalXdr = signedXdr;
     if (useFeeBump) {
-      onStatus?.("submitting");
-      const resp = await fetch('/api/relayer/fee-bump', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ innerTxXdr: signedXdr })
+      onPhase?.("submitting");
+      const resp = await fetch("/api/relayer/fee-bump", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ innerTxXdr: signedXdr }),
       });
       const { feeBumpXdr } = await resp.json();
       finalXdr = feeBumpXdr;
     }
 
-    onStatus?.("submitting");
-    const result = await submitAndPoll(finalXdr);
+    const result = await submitAndPoll(finalXdr, onPhase);
 
-    onStatus?.(result.success ? "success" : "error");
+    onPhase?.(result.success ? "success" : "failure");
     return result;
   } catch (err) {
-    onStatus?.("error");
+    onPhase?.("failure");
     return {
       success: false,
       error: err instanceof Error ? err.message : String(err),
@@ -234,19 +265,18 @@ export async function executeZapContractCall(
   sourcePublicKey: string,
   method: string,
   args: StellarSdk.xdr.ScVal[],
-  onStatus?: (status: TxStatus) => void,
-  useFeeBump: boolean = false
+  onPhase?: TxPhaseCallback,
+  useFeeBump: boolean = false,
 ): Promise<TxResult> {
   try {
-    onStatus?.("building");
-    const xdr = await buildContractCallOn(getZapContract(), sourcePublicKey, method, ...args);
+    const xdr = await buildContractCallOn(getZapContract(), sourcePublicKey, method, args, onPhase);
 
-    onStatus?.("signing");
-    const signedXdr = await signWithFreighter(xdr);
+    onPhase?.("waiting_for_wallet");
+    const signedXdr = await signWithFreighter(xdr, NETWORK_PASSPHRASE);
 
     let finalXdr = signedXdr;
     if (useFeeBump) {
-      onStatus?.("submitting");
+      onPhase?.("submitting");
       const resp = await fetch("/api/relayer/fee-bump", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -256,13 +286,12 @@ export async function executeZapContractCall(
       finalXdr = feeBumpXdr;
     }
 
-    onStatus?.("submitting");
-    const result = await submitAndPoll(finalXdr);
+    const result = await submitAndPoll(finalXdr, onPhase);
 
-    onStatus?.(result.success ? "success" : "error");
+    onPhase?.(result.success ? "success" : "failure");
     return result;
   } catch (err) {
-    onStatus?.("error");
+    onPhase?.("failure");
     return {
       success: false,
       error: err instanceof Error ? err.message : String(err),
@@ -292,8 +321,8 @@ export interface ZapDepositParams {
 export async function zapDeposit(
   userAddress: string,
   params: ZapDepositParams,
-  onStatus?: (status: TxStatus) => void,
-  useFeeBump: boolean = false
+  onPhase?: TxPhaseCallback,
+  useFeeBump: boolean = false,
 ): Promise<TxResult> {
   return executeZapContractCall(
     userAddress,
@@ -307,8 +336,8 @@ export async function zapDeposit(
       StellarSdk.nativeToScVal(params.minAmountOut, { type: "i128" }),
       StellarSdk.nativeToScVal(params.minSharesOut, { type: "i128" }),
     ],
-    onStatus,
-    useFeeBump
+    onPhase,
+    useFeeBump,
   );
 }
 
@@ -317,7 +346,7 @@ export async function zapDeposit(
  *
  * @param userAddress - Depositor's public key
  * @param amount      - Amount in stroops (1 XLM = 10_000_000 stroops)
- * @param onStatus    - Status callback for UI updates
+ * @param onPhase    - Phase callback for UI updates
  * @param useFeeBump  - Whether to wrap the tx in a fee-bump via the relayer
  * @param signTx      - Optional signer; pass `wallet.signTransaction` to use any wallet adapter
  */
@@ -325,7 +354,7 @@ export async function deposit(
   userAddress: string,
   amount: bigint,
   minSharesOut: bigint,
-  onStatus?: (status: TxStatus) => void,
+  onPhase?: TxPhaseCallback,
   useFeeBump: boolean = true,
   signTx?: (xdr: string, networkPassphrase: string) => Promise<string>,
 ): Promise<TxResult> {
@@ -337,7 +366,7 @@ export async function deposit(
       StellarSdk.nativeToScVal(amount, { type: "i128" }),
       StellarSdk.nativeToScVal(minSharesOut, { type: "i128" }),
     ],
-    onStatus,
+    onPhase,
     useFeeBump,
     signTx,
   );
@@ -348,13 +377,13 @@ export async function deposit(
  *
  * @param userAddress - Withdrawer's public key
  * @param shares      - Number of vault shares to redeem
- * @param onStatus    - Status callback for UI updates
+ * @param onPhase    - Phase callback for UI updates
  * @param signTx      - Optional signer; pass `wallet.signTransaction` to use any wallet adapter
  */
 export async function withdraw(
   userAddress: string,
   shares: bigint,
-  onStatus?: (status: TxStatus) => void,
+  onPhase?: TxPhaseCallback,
   signTx?: (xdr: string, networkPassphrase: string) => Promise<string>,
 ): Promise<TxResult> {
   return executeContractCall(
@@ -364,7 +393,7 @@ export async function withdraw(
       new StellarSdk.Address(userAddress).toScVal(),
       StellarSdk.nativeToScVal(shares, { type: "i128" }),
     ],
-    onStatus,
+    onPhase,
     false,
     signTx,
   );

--- a/client/src/services/transactionPhase.test.ts
+++ b/client/src/services/transactionPhase.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import {
+  TX_PHASE_PIPELINE,
+  TX_PHASE_SUBMIT_POLL,
+  stepIndexIn,
+  isStepCompleted,
+  isStepActive,
+  isTerminalPhase,
+} from "./transactionPhase";
+
+describe("transactionPhase helpers", () => {
+  it("marks success as past all steps", () => {
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "success")).toBe(TX_PHASE_PIPELINE.length);
+  });
+
+  it("resolves active indices in the full pipeline", () => {
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "building")).toBe(0);
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "simulating")).toBe(1);
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "waiting_for_wallet")).toBe(2);
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "submitting")).toBe(3);
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "polling")).toBe(4);
+  });
+
+  it("does not match idle or failure to a step index", () => {
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "idle")).toBe(-1);
+    expect(stepIndexIn(TX_PHASE_PIPELINE, "failure")).toBe(-1);
+  });
+
+  it("computes completed vs active steps during waiting_for_wallet", () => {
+    const phase = "waiting_for_wallet";
+    expect(isStepCompleted(TX_PHASE_PIPELINE, phase, 0)).toBe(true);
+    expect(isStepCompleted(TX_PHASE_PIPELINE, phase, 1)).toBe(true);
+    expect(isStepCompleted(TX_PHASE_PIPELINE, phase, 2)).toBe(false);
+    expect(isStepActive(TX_PHASE_PIPELINE, phase, 2)).toBe(true);
+    expect(isStepActive(TX_PHASE_PIPELINE, phase, 3)).toBe(false);
+  });
+
+  it("marks all steps complete on success", () => {
+    for (let i = 0; i < TX_PHASE_PIPELINE.length; i++) {
+      expect(isStepCompleted(TX_PHASE_PIPELINE, "success", i)).toBe(true);
+    }
+  });
+
+  it("submit/poll preset has two steps", () => {
+    expect(TX_PHASE_SUBMIT_POLL).toEqual(["submitting", "polling"]);
+  });
+
+  it("detects terminal phases", () => {
+    expect(isTerminalPhase("success")).toBe(true);
+    expect(isTerminalPhase("failure")).toBe(true);
+    expect(isTerminalPhase("polling")).toBe(false);
+  });
+});

--- a/client/src/services/transactionPhase.ts
+++ b/client/src/services/transactionPhase.ts
@@ -1,0 +1,80 @@
+/**
+ * Canonical phases for Soroban transaction UX (timeline + status callbacks).
+ */
+export type TxPhase =
+  | "idle"
+  | "building"
+  | "simulating"
+  | "waiting_for_wallet"
+  | "submitting"
+  | "polling"
+  | "success"
+  | "failure";
+
+/** Ordered pipeline steps shown on the full timeline (non-terminal). */
+export const TX_PHASE_PIPELINE: readonly Exclude<
+  TxPhase,
+  "idle" | "success" | "failure"
+>[] = [
+  "building",
+  "simulating",
+  "waiting_for_wallet",
+  "submitting",
+  "polling",
+];
+
+/** Governance “execute”: submit already-built multisig XDR, then poll. */
+export const TX_PHASE_SUBMIT_POLL: readonly TxPhase[] = ["submitting", "polling"];
+
+/** Wallet signature only (e.g. governance co-sign). */
+export const TX_PHASE_WALLET_ONLY: readonly TxPhase[] = ["waiting_for_wallet"];
+
+const TERMINAL: TxPhase[] = ["success", "failure"];
+
+export function isTerminalPhase(phase: TxPhase): boolean {
+  return TERMINAL.includes(phase);
+}
+
+/** Index of `phase` within `steps`, or -1 if idle / unknown. Success => past end. */
+export function stepIndexIn(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+): number {
+  if (phase === "idle") return -1;
+  if (phase === "success") return steps.length;
+  if (phase === "failure") return -1;
+  return steps.indexOf(phase);
+}
+
+/** Whether step at `stepIdx` is logically complete before `phase`. */
+export function isStepCompleted(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+  stepIdx: number,
+): boolean {
+  if (phase === "success") return stepIdx < steps.length;
+  const active = stepIndexIn(steps, phase);
+  if (active < 0) return false;
+  return stepIdx < active;
+}
+
+/** Whether step at `stepIdx` matches the current non-terminal phase. */
+export function isStepActive(
+  steps: readonly TxPhase[],
+  phase: TxPhase,
+  stepIdx: number,
+): boolean {
+  if (phase === "idle" || phase === "success" || phase === "failure") return false;
+  return steps[stepIdx] === phase;
+}
+
+export const TX_PHASE_LABELS: Record<TxPhase, string> = {
+  idle: "Idle",
+  building: "Building transaction",
+  simulating: "Simulating",
+  waiting_for_wallet: "Waiting for wallet",
+  submitting: "Submitting",
+  polling: "Confirming on network",
+  success: "Success",
+  failure: "Failed",
+};


### PR DESCRIPTION
closes #208

## Summary
Adds an explicit transaction lifecycle (TxPhase) across the Soroban layer, a reusable TxStatusTimeline UI with failure actions, and plugs it into Zap deposit and governance (sign + execute). Users always see where they are: build → simulate → wallet → submit → poll → success or failure.

## What changed
Lifecycle & Soroban (transactionPhase.ts, soroban.ts)
TxPhase: idle → building → simulating → waiting_for_wallet → submitting → polling → success | failure (legacy alias: TxStatus).
buildContractCallOn: emits building, then simulating before RPC simulate/assemble.
submitAndPoll: submitting before send, polling while waiting on ledger.
submitSignedXdrAndPoll: exported for governance—submit multisig-ready XDR, poll, then success / failure (with try/catch).
## UI
TxStatusTimeline: vertical steps with done / spinner / failed affordances; failure shows message + Copy error + optional Retry; optional tx hash on success.
ZapDepositPanel: full TX_PHASE_PIPELINE; tracks last non-terminal phase for failedAtPhase; Retry re-runs zap.
## Governance
Sign: TX_PHASE_WALLET_ONLY (waiting_for_wallet).
Execute: TX_PHASE_SUBMIT_POLL (submitting, polling) via submitSignedXdrAndPoll; separate sign vs execute errors and retries.
## Tests
transactionPhase.test.ts: step indexing, completion/active states, terminal phases, TX_PHASE_SUBMIT_POLL shape.
