### PR TITLE
feat(zap): supported assets metadata API + optional client consumption

### DIFF
--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -8,9 +8,13 @@ import { fetchSwapQuote } from "./fetchSwapQuote";
 import { minAmountAfterSlippage } from "./slippage";
 import { parseDecimalToStroops, formatStroopsToDecimal } from "./amount";
 import {
+  buildSelectableZapAssetsFromMetadata,
+  fetchZapSupportedAssetsMetadata,
   getVaultContractIdFromEnv,
   getVaultTokenFromEnv,
   loadZapAssetOptions,
+  mergeVaultIntoZapSelectableAssets,
+  shouldLoadZapMetadataFromApi,
 } from "./assets";
 import type { ZapAssetOption } from "./types";
 
@@ -19,30 +23,42 @@ export interface ZapDepositPanelProps {
 }
 
 export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps) {
-  const vaultToken = useMemo(() => getVaultTokenFromEnv(), []);
-  const vaultContractId = useMemo(() => getVaultContractIdFromEnv(), []);
-  const selectableAssets = useMemo(() => {
-    const fromEnv = loadZapAssetOptions();
-    const vault: ZapAssetOption = {
-      symbol: vaultToken.symbol,
-      name: vaultToken.name,
-      contractId: vaultToken.contractId,
-      decimals: vaultToken.decimals,
-    };
-    const merged = [...fromEnv];
-    if (vault.contractId && !merged.some((a) => a.contractId === vault.contractId)) {
-      merged.push(vault);
-    }
-    return merged;
-  }, [vaultToken]);
+  const useApiAssets = shouldLoadZapMetadataFromApi();
 
-  const [inputAsset, setInputAsset] = useState<ZapAssetOption | null>(
-    () => selectableAssets[0] ?? null
+  const initialVault = useMemo(() => getVaultTokenFromEnv(), []);
+  const initialVaultContractId = useMemo(() => getVaultContractIdFromEnv(), []);
+
+  const [vaultToken, setVaultToken] = useState<ZapAssetOption>(initialVault);
+  const [vaultContractId, setVaultContractId] = useState(initialVaultContractId);
+  const [selectableAssets, setSelectableAssets] = useState<ZapAssetOption[]>(() =>
+    mergeVaultIntoZapSelectableAssets(loadZapAssetOptions(), initialVault),
   );
 
   useEffect(() => {
-    if (!inputAsset && selectableAssets[0]) {
-      setInputAsset(selectableAssets[0]);
+    if (!useApiAssets) return;
+    let cancelled = false;
+    void fetchZapSupportedAssetsMetadata().then((meta) => {
+      if (cancelled || !meta) return;
+      setVaultToken(meta.vaultToken);
+      setVaultContractId(meta.vaultContractId);
+      setSelectableAssets(buildSelectableZapAssetsFromMetadata(meta));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [useApiAssets]);
+
+  const [inputAsset, setInputAsset] = useState<ZapAssetOption | null>(
+    () => mergeVaultIntoZapSelectableAssets(loadZapAssetOptions(), initialVault)[0] ?? null,
+  );
+
+  useEffect(() => {
+    if (!selectableAssets.length) return;
+    if (
+      !inputAsset ||
+      !selectableAssets.some((a) => a.contractId === inputAsset.contractId)
+    ) {
+      setInputAsset(selectableAssets[0] ?? null);
     }
   }, [inputAsset, selectableAssets]);
 

--- a/client/src/features/zap/assets.test.ts
+++ b/client/src/features/zap/assets.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { loadZapAssetOptions, getVaultTokenFromEnv, getVaultContractIdFromEnv } from "./assets";
+import {
+  loadZapAssetOptions,
+  getVaultTokenFromEnv,
+  getVaultContractIdFromEnv,
+  fetchZapSupportedAssetsMetadata,
+  mergeVaultIntoZapSelectableAssets,
+} from "./assets";
 
 describe("loadZapAssetOptions", () => {
   afterEach(() => {
@@ -56,6 +62,84 @@ describe("getVaultTokenFromEnv", () => {
     vi.stubEnv("VITE_VAULT_TOKEN_DECIMALS", "not-a-number");
     const v = getVaultTokenFromEnv();
     expect(v.decimals).toBe(7);
+  });
+});
+
+describe("fetchZapSupportedAssetsMetadata", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns parsed metadata when response is valid", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assets: [
+            { symbol: "XLM", name: "X", contractId: "CDXLM", decimals: 7 },
+          ],
+          vaultToken: {
+            symbol: "USDC",
+            name: "Vault asset",
+            contractId: "CDV",
+            decimals: 6,
+          },
+          vaultContractId: "CDY",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const meta = await fetchZapSupportedAssetsMetadata();
+    expect(meta?.vaultContractId).toBe("CDY");
+    expect(meta?.assets).toHaveLength(1);
+  });
+
+  it("returns null when response is not ok", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("", { status: 500 }));
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
+
+  it("returns null when JSON shape is invalid", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ assets: "nope" }), { status: 200 }),
+    );
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
+});
+
+describe("mergeVaultIntoZapSelectableAssets", () => {
+  it("appends vault token when missing from inputs", () => {
+    const vault = {
+      symbol: "USDC",
+      name: "Vault asset",
+      contractId: "CDV",
+      decimals: 6,
+    };
+    const merged = mergeVaultIntoZapSelectableAssets(
+      [{ symbol: "XLM", name: "X", contractId: "CDXLM", decimals: 7 }],
+      vault,
+    );
+    expect(merged.some((a) => a.contractId === "CDV")).toBe(true);
+  });
+
+  it("does not duplicate vault token contract", () => {
+    const vault = {
+      symbol: "USDC",
+      name: "Vault asset",
+      contractId: "CDV",
+      decimals: 6,
+    };
+    const merged = mergeVaultIntoZapSelectableAssets(
+      [{ symbol: "USDC", name: "U", contractId: "CDV", decimals: 6 }],
+      vault,
+    );
+    expect(merged.filter((a) => a.contractId === "CDV")).toHaveLength(1);
   });
 });
 

--- a/client/src/features/zap/assets.test.ts
+++ b/client/src/features/zap/assets.test.ts
@@ -5,6 +5,8 @@ import {
   getVaultContractIdFromEnv,
   fetchZapSupportedAssetsMetadata,
   mergeVaultIntoZapSelectableAssets,
+  shouldLoadZapMetadataFromApi,
+  buildSelectableZapAssetsFromMetadata,
 } from "./assets";
 
 describe("loadZapAssetOptions", () => {
@@ -65,6 +67,19 @@ describe("getVaultTokenFromEnv", () => {
   });
 });
 
+describe("shouldLoadZapMetadataFromApi", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns true only when VITE_ZAP_METADATA_FROM_API is the string true", () => {
+    vi.stubEnv("VITE_ZAP_METADATA_FROM_API", "true");
+    expect(shouldLoadZapMetadataFromApi()).toBe(true);
+    vi.stubEnv("VITE_ZAP_METADATA_FROM_API", "false");
+    expect(shouldLoadZapMetadataFromApi()).toBe(false);
+  });
+});
+
 describe("fetchZapSupportedAssetsMetadata", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
@@ -111,6 +126,107 @@ describe("fetchZapSupportedAssetsMetadata", () => {
 
     await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
   });
+
+  it("returns null when fetch throws", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
+
+  it("prefers VITE_API_BASE_URL and strips a trailing slash", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "http://example.com/");
+    vi.stubEnv("VITE_API_URL", "http://ignored.example/");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assets: [{ symbol: "XLM", name: "X", contractId: "CDX", decimals: 7 }],
+          vaultToken: {
+            symbol: "U",
+            name: "Vault asset",
+            contractId: "CDV",
+            decimals: 6,
+          },
+          vaultContractId: "CDY",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await fetchZapSupportedAssetsMetadata();
+
+    expect(fetchSpy).toHaveBeenCalledWith("http://example.com/api/zap/supported-assets");
+  });
+
+  it("falls back to default localhost base when API env vars are unset", async () => {
+    vi.stubEnv("VITE_API_BASE_URL", "");
+    vi.stubEnv("VITE_API_URL", "");
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assets: [{ symbol: "XLM", name: "X", contractId: "CDX", decimals: 7 }],
+          vaultToken: {
+            symbol: "U",
+            name: "Vault asset",
+            contractId: "CDV",
+            decimals: 6,
+          },
+          vaultContractId: "CDY",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await fetchZapSupportedAssetsMetadata();
+
+    expect(fetchSpy).toHaveBeenCalledWith("http://localhost:3001/api/zap/supported-assets");
+  });
+
+  it("returns null when payload is not an object", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(null), { status: 200 }),
+    );
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
+
+  it("returns null when vaultToken fails validation", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assets: [{ symbol: "XLM", name: "X", contractId: "CDX", decimals: 7 }],
+          vaultToken: { symbol: "U", name: "Vault asset", contractId: "CDV", decimals: "6" },
+          vaultContractId: "CDY",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
+
+  it("returns null when an asset row fails validation", async () => {
+    vi.stubEnv("VITE_API_URL", "http://127.0.0.1:9");
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          assets: [{ symbol: "XLM", name: "X", contractId: "CDX", decimals: "7" }],
+          vaultToken: {
+            symbol: "U",
+            name: "Vault asset",
+            contractId: "CDV",
+            decimals: 6,
+          },
+          vaultContractId: "CDY",
+        }),
+        { status: 200 },
+      ),
+    );
+
+    await expect(fetchZapSupportedAssetsMetadata()).resolves.toBeNull();
+  });
 });
 
 describe("mergeVaultIntoZapSelectableAssets", () => {
@@ -140,6 +256,32 @@ describe("mergeVaultIntoZapSelectableAssets", () => {
       vault,
     );
     expect(merged.filter((a) => a.contractId === "CDV")).toHaveLength(1);
+  });
+
+  it("does not append vault when contractId is empty", () => {
+    const merged = mergeVaultIntoZapSelectableAssets(
+      [{ symbol: "XLM", name: "X", contractId: "CDXLM", decimals: 7 }],
+      { symbol: "V", name: "Vault asset", contractId: "", decimals: 7 },
+    );
+    expect(merged).toHaveLength(1);
+  });
+});
+
+describe("buildSelectableZapAssetsFromMetadata", () => {
+  it("delegates to mergeVaultIntoZapSelectableAssets", () => {
+    const meta = {
+      assets: [{ symbol: "XLM", name: "X", contractId: "CDX", decimals: 7 }],
+      vaultToken: {
+        symbol: "USDC",
+        name: "Vault asset",
+        contractId: "CDV",
+        decimals: 6,
+      },
+      vaultContractId: "CDY",
+    };
+    const built = buildSelectableZapAssetsFromMetadata(meta);
+    const merged = mergeVaultIntoZapSelectableAssets(meta.assets, meta.vaultToken);
+    expect(built).toEqual(merged);
   });
 });
 

--- a/client/src/features/zap/assets.ts
+++ b/client/src/features/zap/assets.ts
@@ -1,4 +1,4 @@
-import type { ZapAssetOption } from "./types";
+import type { ZapAssetOption, ZapSupportedAssetsMetadata } from "./types";
 
 /**
  * Default assets for zap input selection. Override via `VITE_ZAP_ASSETS_JSON`
@@ -41,4 +41,70 @@ export function getVaultTokenFromEnv(): ZapAssetOption {
 
 export function getVaultContractIdFromEnv(): string {
   return (import.meta.env.VITE_VAULT_CONTRACT_ID as string) || (import.meta.env.VITE_CONTRACT_ID as string) || "";
+}
+
+function zapApiBaseUrl(): string {
+  const env = import.meta.env;
+  const base =
+    (env.VITE_API_BASE_URL as string | undefined) ||
+    (env.VITE_API_URL as string | undefined) ||
+    "http://localhost:3001";
+  return base.replace(/\/$/, "");
+}
+
+/** When `VITE_ZAP_METADATA_FROM_API` is true, the Zap UI may load assets from the backend. */
+export function shouldLoadZapMetadataFromApi(): boolean {
+  return import.meta.env.VITE_ZAP_METADATA_FROM_API === "true";
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function isZapAssetOption(v: unknown): v is ZapAssetOption {
+  if (!isRecord(v)) return false;
+  return (
+    typeof v.symbol === "string" &&
+    typeof v.name === "string" &&
+    typeof v.contractId === "string" &&
+    typeof v.decimals === "number" &&
+    Number.isFinite(v.decimals)
+  );
+}
+
+/** Fetches `/api/zap/supported-assets`; returns null on network or schema errors. */
+export async function fetchZapSupportedAssetsMetadata(): Promise<ZapSupportedAssetsMetadata | null> {
+  try {
+    const res = await fetch(`${zapApiBaseUrl()}/api/zap/supported-assets`);
+    if (!res.ok) return null;
+    const json: unknown = await res.json();
+    if (!isRecord(json)) return null;
+    if (!Array.isArray(json.assets) || typeof json.vaultContractId !== "string") {
+      return null;
+    }
+    if (!isZapAssetOption(json.vaultToken)) return null;
+    if (!json.assets.every(isZapAssetOption)) return null;
+    return {
+      assets: json.assets,
+      vaultToken: json.vaultToken,
+      vaultContractId: json.vaultContractId,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function mergeVaultIntoZapSelectableAssets(
+  zapInputs: ZapAssetOption[],
+  vaultToken: ZapAssetOption,
+): ZapAssetOption[] {
+  const merged = [...zapInputs];
+  if (vaultToken.contractId && !merged.some((a) => a.contractId === vaultToken.contractId)) {
+    merged.push(vaultToken);
+  }
+  return merged;
+}
+
+export function buildSelectableZapAssetsFromMetadata(meta: ZapSupportedAssetsMetadata): ZapAssetOption[] {
+  return mergeVaultIntoZapSelectableAssets(meta.assets, meta.vaultToken);
 }

--- a/client/src/features/zap/types.ts
+++ b/client/src/features/zap/types.ts
@@ -27,4 +27,13 @@ export interface ZapAssetOption {
   name: string;
   contractId: string;
   decimals: number;
+  /** Optional URL for UI avatars / icons when provided by the metadata API */
+  iconUrl?: string;
+}
+
+/** Response from `GET /api/zap/supported-assets` */
+export interface ZapSupportedAssetsMetadata {
+  assets: ZapAssetOption[];
+  vaultToken: ZapAssetOption;
+  vaultContractId: string;
 }

--- a/server/src/__tests__/zapAssetsConfig.test.ts
+++ b/server/src/__tests__/zapAssetsConfig.test.ts
@@ -1,0 +1,84 @@
+import {
+  loadZapSupportedAssetsPayload,
+  validateZapAssetsJsonEntry,
+} from "../config/zapAssetsConfig";
+
+const KEYS = [
+  "ZAP_ASSETS_JSON",
+  "XLM_SAC_CONTRACT_ID",
+  "USDC_SAC_CONTRACT_ID",
+  "AQUA_SAC_CONTRACT_ID",
+  "VAULT_TOKEN_CONTRACT_ID",
+  "VAULT_CONTRACT_ID",
+] as const;
+
+describe("loadZapSupportedAssetsPayload", () => {
+  let snapshot: Partial<Record<(typeof KEYS)[number], string | undefined>>;
+
+  beforeEach(() => {
+    snapshot = {};
+    for (const k of KEYS) snapshot[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of KEYS) {
+      const v = snapshot[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("parses ZAP_ASSETS_JSON including optional iconUrl", () => {
+    process.env.ZAP_ASSETS_JSON = JSON.stringify([
+      {
+        symbol: "XLM",
+        name: "Stellar Lumens",
+        contractId: "CDXLM",
+        decimals: 7,
+        iconUrl: "https://example.com/xlm.png",
+      },
+    ]);
+    process.env.VAULT_TOKEN_CONTRACT_ID = "VAULT";
+    process.env.VAULT_CONTRACT_ID = "YIELD";
+
+    const p = loadZapSupportedAssetsPayload(process.env);
+
+    expect(p.assets[0]?.iconUrl).toBe("https://example.com/xlm.png");
+    expect(p.vaultToken.contractId).toBe("VAULT");
+    expect(p.vaultContractId).toBe("YIELD");
+  });
+
+  it("throws when ZAP_ASSETS_JSON is malformed", () => {
+    process.env.ZAP_ASSETS_JSON = "not-json";
+    expect(() => loadZapSupportedAssetsPayload(process.env)).toThrow(/valid JSON/);
+  });
+
+  it("throws when ZAP_ASSETS_JSON is an empty array", () => {
+    process.env.ZAP_ASSETS_JSON = "[]";
+    expect(() => loadZapSupportedAssetsPayload(process.env)).toThrow(
+      /at least one asset/,
+    );
+  });
+
+  it("falls back to SAC env vars when ZAP_ASSETS_JSON is unset", () => {
+    delete process.env.ZAP_ASSETS_JSON;
+    process.env.XLM_SAC_CONTRACT_ID = "CDXLM2";
+    process.env.USDC_SAC_CONTRACT_ID = "";
+    process.env.AQUA_SAC_CONTRACT_ID = "";
+
+    const p = loadZapSupportedAssetsPayload(process.env);
+
+    expect(p.assets.some((a) => a.symbol === "XLM" && a.contractId === "CDXLM2")).toBe(
+      true,
+    );
+    expect(p.assets.every((a) => a.contractId.length > 0)).toBe(true);
+  });
+});
+
+describe("validateZapAssetsJsonEntry", () => {
+  it("rejects non-integer decimals", () => {
+    expect(() =>
+      validateZapAssetsJsonEntry({ symbol: "A", name: "A", contractId: "C", decimals: 7.1 }, 0),
+    ).toThrow(/decimals/);
+  });
+});

--- a/server/src/__tests__/zapSupportedAssetsRoute.test.ts
+++ b/server/src/__tests__/zapSupportedAssetsRoute.test.ts
@@ -1,0 +1,88 @@
+import express from "express";
+import request from "supertest";
+import {
+  initializeZapSupportedAssetsCache,
+  resetZapSupportedAssetsCache,
+} from "../config/zapAssetsConfig";
+import zapRouter from "../routes/zap";
+
+const ZAP_ENV_KEYS = [
+  "ZAP_ASSETS_JSON",
+  "XLM_SAC_CONTRACT_ID",
+  "USDC_SAC_CONTRACT_ID",
+  "AQUA_SAC_CONTRACT_ID",
+  "VAULT_TOKEN_CONTRACT_ID",
+  "VAULT_TOKEN_DECIMALS",
+  "VAULT_TOKEN_SYMBOL",
+  "VAULT_CONTRACT_ID",
+  "CONTRACT_ID",
+] as const;
+
+function zapRoutesOnlyApp() {
+  const app = express();
+  app.use("/api/zap", zapRouter);
+  return app;
+}
+
+describe("GET /api/zap/supported-assets", () => {
+  let snapshot: Partial<Record<(typeof ZAP_ENV_KEYS)[number], string | undefined>>;
+
+  beforeEach(() => {
+    snapshot = {};
+    for (const k of ZAP_ENV_KEYS) snapshot[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    resetZapSupportedAssetsCache();
+    for (const k of ZAP_ENV_KEYS) {
+      const v = snapshot[k];
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it("returns assets, vaultToken, and vaultContractId", async () => {
+    process.env.ZAP_ASSETS_JSON = JSON.stringify([
+      {
+        symbol: "FOO",
+        name: "Foo Coin",
+        contractId: "CDFOOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        decimals: 7,
+      },
+    ]);
+    process.env.VAULT_TOKEN_CONTRACT_ID = "CDVAULTAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    process.env.VAULT_TOKEN_DECIMALS = "6";
+    process.env.VAULT_TOKEN_SYMBOL = "USDC";
+    process.env.VAULT_CONTRACT_ID = "CDYIELDAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+    initializeZapSupportedAssetsCache();
+
+    const res = await request(zapRoutesOnlyApp()).get("/api/zap/supported-assets");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      vaultContractId: "CDYIELDAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      vaultToken: {
+        symbol: "USDC",
+        contractId: "CDVAULTAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        decimals: 6,
+      },
+    });
+    expect(Array.isArray(res.body.assets)).toBe(true);
+    expect(res.body.assets).toHaveLength(1);
+    expect(res.body.assets[0]).toMatchObject({
+      symbol: "FOO",
+      contractId: "CDFOOAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      decimals: 7,
+    });
+  });
+
+  it("returns 503 when ZAP_ASSETS_JSON is invalid", async () => {
+    process.env.ZAP_ASSETS_JSON = "[";
+
+    const res = await request(zapRoutesOnlyApp()).get("/api/zap/supported-assets");
+
+    expect(res.status).toBe(503);
+    expect(typeof res.body.error).toBe("string");
+  });
+});

--- a/server/src/config/zapAssetsConfig.ts
+++ b/server/src/config/zapAssetsConfig.ts
@@ -1,0 +1,149 @@
+/**
+ * Zap / vault asset metadata sourced from env (mirrors client VITE_* without the prefix).
+ * Validates `ZAP_ASSETS_JSON` when set; otherwise builds defaults from SAC contract env vars.
+ */
+
+export type ZapAssetPublic = {
+  symbol: string;
+  name: string;
+  contractId: string;
+  decimals: number;
+  /** Optional display metadata for UIs */
+  iconUrl?: string;
+};
+
+export type ZapSupportedAssetsPayload = {
+  assets: ZapAssetPublic[];
+  vaultToken: ZapAssetPublic;
+  vaultContractId: string;
+};
+
+let cache: ZapSupportedAssetsPayload | null = null;
+
+function asNonEmptyString(v: unknown): v is string {
+  return typeof v === "string" && v.trim().length > 0;
+}
+
+function asFiniteNonNegInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 && Number.isInteger(v);
+}
+
+export function validateZapAssetsJsonEntry(
+  raw: unknown,
+  index: number,
+): ZapAssetPublic {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`ZAP_ASSETS_JSON[${index}]: expected object`);
+  }
+  const o = raw as Record<string, unknown>;
+  if (!asNonEmptyString(o.symbol)) {
+    throw new Error(`ZAP_ASSETS_JSON[${index}].symbol must be a non-empty string`);
+  }
+  if (!asNonEmptyString(o.name)) {
+    throw new Error(`ZAP_ASSETS_JSON[${index}].name must be a non-empty string`);
+  }
+  if (!asNonEmptyString(o.contractId)) {
+    throw new Error(`ZAP_ASSETS_JSON[${index}].contractId must be a non-empty string`);
+  }
+  if (!asFiniteNonNegInt(o.decimals)) {
+    throw new Error(`ZAP_ASSETS_JSON[${index}].decimals must be a non-negative integer`);
+  }
+  if ("iconUrl" in o && o.iconUrl !== undefined && o.iconUrl !== null) {
+    if (!asNonEmptyString(o.iconUrl)) {
+      throw new Error(`ZAP_ASSETS_JSON[${index}].iconUrl must be a non-empty string when set`);
+    }
+  }
+  const iconUrl =
+    o.iconUrl === undefined || o.iconUrl === null
+      ? undefined
+      : (o.iconUrl as string).trim();
+  return {
+    symbol: o.symbol.trim(),
+    name: o.name.trim(),
+    contractId: o.contractId.trim(),
+    decimals: o.decimals,
+    ...(iconUrl !== undefined ? { iconUrl } : {}),
+  };
+}
+
+/**
+ * Parses and validates env into a consistent payload. Used at startup and by the HTTP route.
+ * @throws When `ZAP_ASSETS_JSON` is set but invalid JSON or fails schema validation.
+ */
+export function loadZapSupportedAssetsPayload(
+  env: NodeJS.ProcessEnv = process.env,
+): ZapSupportedAssetsPayload {
+  const rawJson = env.ZAP_ASSETS_JSON?.trim();
+
+  let assets: ZapAssetPublic[];
+
+  if (rawJson) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawJson) as unknown;
+    } catch (e) {
+      throw new Error(
+        `ZAP_ASSETS_JSON is not valid JSON: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error("ZAP_ASSETS_JSON must be a JSON array");
+    }
+    if (parsed.length === 0) {
+      throw new Error("ZAP_ASSETS_JSON must contain at least one asset");
+    }
+    assets = parsed.map((item, i) => validateZapAssetsJsonEntry(item, i));
+  } else {
+    const xlm = env.XLM_SAC_CONTRACT_ID?.trim() ?? "";
+    const usdc = env.USDC_SAC_CONTRACT_ID?.trim() ?? "";
+    const aqua = env.AQUA_SAC_CONTRACT_ID?.trim() ?? "";
+
+    assets = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: xlm, decimals: 7 },
+      { symbol: "USDC", name: "USD Coin", contractId: usdc, decimals: 7 },
+      { symbol: "AQUA", name: "Aquarius", contractId: aqua, decimals: 7 },
+    ].filter((a) => a.contractId.length > 0);
+  }
+
+  const contractId = env.VAULT_TOKEN_CONTRACT_ID?.trim() ?? "";
+  const decimalsRaw = env.VAULT_TOKEN_DECIMALS ?? "7";
+  const decimals = Number(decimalsRaw);
+  const vaultToken: ZapAssetPublic = {
+    symbol: env.VAULT_TOKEN_SYMBOL?.trim() || "USDC",
+    name: "Vault asset",
+    contractId,
+    decimals: Number.isFinite(decimals) ? decimals : 7,
+  };
+
+  const vaultContractId =
+    env.VAULT_CONTRACT_ID?.trim() || env.CONTRACT_ID?.trim() || "";
+
+  return {
+    assets,
+    vaultToken,
+    vaultContractId,
+  };
+}
+
+/** Call from `index.ts` to validate config and prime the route cache. */
+export function initializeZapSupportedAssetsCache(
+  env: NodeJS.ProcessEnv = process.env,
+): ZapSupportedAssetsPayload {
+  resetZapSupportedAssetsCache();
+  cache = loadZapSupportedAssetsPayload(env);
+  return cache;
+}
+
+/**
+ * Cached payload for the route handler; reset in tests via `resetZapSupportedAssetsCache`.
+ */
+export function getZapSupportedAssetsPayload(): ZapSupportedAssetsPayload {
+  if (!cache) {
+    cache = loadZapSupportedAssetsPayload();
+  }
+  return cache;
+}
+
+export function resetZapSupportedAssetsCache(): void {
+  cache = null;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,8 +1,11 @@
 import { createApp } from "./app";
+import { initializeZapSupportedAssetsCache } from "./config/zapAssetsConfig";
 import { startIndexer } from "./indexer/indexer";
 import { startHistoricalYieldAggregationJob } from "./jobs/historicalYieldAggregation";
 import { startSharePriceSnapshotJob } from "./jobs/sharePriceSnapshot";
 import { startHealthMonitor } from "./monitoring/healthMonitor";
+
+initializeZapSupportedAssetsCache();
 
 const app = createApp();
 const PORT = process.env.PORT || 3001;

--- a/server/src/routes/zap.ts
+++ b/server/src/routes/zap.ts
@@ -1,7 +1,21 @@
 import { Router, Request, Response } from "express";
+import { getZapSupportedAssetsPayload } from "../config/zapAssetsConfig";
 import { getZapQuote, type ZapQuoteBody } from "../services/zapQuote";
 
 const router = Router();
+
+router.get("/supported-assets", (_req: Request, res: Response) => {
+  try {
+    res.json(getZapSupportedAssetsPayload());
+  } catch (error) {
+    res.status(503).json({
+      error:
+        error instanceof Error
+          ? error.message
+          : "Supported assets configuration is unavailable.",
+    });
+  }
+});
 
 router.post("/quote", async (req: Request, res: Response) => {
   try {


### PR DESCRIPTION
closes #212 

## Summary
Adds a backend endpoint so supported zap assets (and vault metadata) are sourced from validated server configuration instead of duplicating everything in frontend env vars. The client can optionally load from this API while keeping the existing env-based behavior as the default/fallback.

## Changes
API: GET /api/zap/supported-assets returns { assets, vaultToken, vaultContractId } with symbol, contract ID, decimals, optional iconUrl, plus vault + vault contract id for the zap UI.
Server config: New server/src/config/zapAssetsConfig.ts reads ZAP_ASSETS_JSON or SAC env vars plus vault-related env vars; validates ZAP_ASSETS_JSON when set (invalid JSON / empty array / bad entries fails fast).
Startup: initializeZapSupportedAssetsCache() runs in server/src/index.ts before the app mounts so misconfigured ZAP_ASSETS_JSON prevents the server from starting.
Client: client/src/features/zap/assets.ts gains fetch + merge helpers; ZapDepositPanel uses them when VITE_ZAP_METADATA_FROM_API=true, otherwise unchanged env flow.
Tests: Server tests for config parsing and route shape + 503 on broken JSON; Vitest coverage for client fetch/schema and merge behavior.
Configuration (deploy notes)
Server: ZAP_ASSETS_JSON (optional), or XLM_SAC_CONTRACT_ID / USDC_SAC_CONTRACT_ID / AQUA_SAC_CONTRACT_ID; vault: VAULT_TOKEN_CONTRACT_ID, VAULT_TOKEN_DECIMALS, VAULT_TOKEN_SYMBOL, VAULT_CONTRACT_ID or CONTRACT_ID.

Client (optional API mode): VITE_ZAP_METADATA_FROM_API=true; base URL via VITE_API_BASE_URL or VITE_API_URL (defaults to http://localhost:3001).

## How to verify
Set server env as above; run server; curl GET /api/zap/supported-assets.
With invalid ZAP_ASSETS_JSON, confirm process exits at startup (or route returns 503 if cache is cleared in isolation tests).
Client: toggle VITE_ZAP_METADATA_FROM_API and confirm zap asset list updates from API vs env.
