### PR TITLE
Add stale issue and PR triage workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,95 @@
+# GitHub Automation for StellarYield
+
+This directory contains GitHub workflows and automation scripts for the StellarYield repository.
+
+## 📁 Files Overview
+
+### Workflows (`.github/workflows/`)
+
+- **`ci.yml`** - Continuous integration for frontend, backend, and contracts
+- **`security.yml`** - Security analysis and vulnerability scanning
+- **`ipfs-deploy.yml`** - IPFS deployment automation
+- **`stale.yml`** - **NEW** - Stale issue and PR triage workflow
+
+### Configuration Files
+
+- **`labels.yml`** - **NEW** - Label definitions for issue triage
+- **`setup-labels.sh`** - **NEW** - Script to create GitHub labels
+- **`README.md`** - This file
+
+## 🚀 New Triage System
+
+The repository now includes an automated triage system to manage issues and pull requests effectively.
+
+### Features
+
+- ✅ **Automatic stale detection** (30 days for issues, 21 days for PRs)
+- ✅ **Stellar Wave exemptions** - Issues tagged as "stellar-wave" are never marked as stale
+- ✅ **New issue triage** - Issues automatically labeled `needs-triage` within 3 days
+- ✅ **Draft PR cleanup** - Old draft PRs closed after 30 days
+- ✅ **Comprehensive labeling system** with 15+ labels for proper categorization
+
+### Quick Start
+
+1. **Set up the labels:**
+   ```bash
+   cd .github
+   chmod +x setup-labels.sh
+   ./setup-labels.sh
+   ```
+
+2. **Test the workflow:**
+   - Go to GitHub Actions → Stale Issue and PR Triage
+   - Click "Run workflow" to test manually
+
+3. **Review the documentation:**
+   - See `docs/triage-process.md` for complete maintainer guide
+
+### Schedule
+
+The triage workflow runs daily at 9:00 AM UTC and includes:
+
+- New issue triage (last 3 days)
+- Stale issue marking (30+ days inactive)
+- Stale issue closure (14 days after marking)
+- Draft PR cleanup (30+ days old)
+
+## 📚 Documentation
+
+- **[Triage Process Guide](../docs/triage-process.md)** - Complete maintainer documentation
+- **[CONTRIBUTING.md](../CONTRIBUTING.md)** - General contribution guidelines
+
+## 🔧 Maintenance
+
+### Regular Tasks
+
+- **Weekly**: Review `needs-triage` and `stale` issues
+- **Monthly**: Update labels and check workflow performance
+- **Quarterly**: Review triage metrics and process improvements
+
+### Monitoring
+
+Check GitHub Actions regularly for:
+- Workflow execution failures
+- Rate limiting warnings
+- Label application errors
+
+## 🤝 Contributing
+
+When modifying the triage system:
+
+1. Test changes in a separate branch
+2. Verify workflow syntax with GitHub's tools
+3. Update documentation accordingly
+4. Coordinate with other maintainers
+
+## 📞 Support
+
+For questions about the triage system:
+- Create an issue with the `documentation` label
+- Tag maintainers for urgent matters
+- Review the triage documentation first
+
+---
+
+This automation helps maintain a healthy, manageable issue tracker while supporting the StellarYield community and Stellar Wave participants. 🚀

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,64 @@
+# GitHub Labels Configuration for StellarYield
+# Run this script with GitHub CLI to create/update labels:
+# gh label create --repo edehvictor/StellarYield --name "LABEL_NAME" --color "COLOR" --description "DESCRIPTION"
+
+labels:
+  # Triage Labels
+  - name: needs-triage
+    color: "fbca04"
+    description: "Issue needs maintainer review and classification"
+  
+  - name: blocked
+    color: "e11d21"
+    description: "Issue is blocked by dependencies or external factors"
+  
+  - name: keep-active
+    color: "1d76db"
+    description: "Issue should remain active and not be marked as stale"
+  
+  # Stellar Wave Specific
+  - name: stellar-wave
+    color: "795548"
+    description: "Stellar Wave program issue - exempt from stale triage"
+  
+  # Status Labels
+  - name: stale
+    color: "eeeeee"
+    description: "Issue has been inactive for an extended period"
+  
+  - name: work-in-progress
+    color: "ededed"
+    description: "Pull request is still being developed"
+  
+  - name: needs-review
+    color: "fbca04"
+    description: "Pull request needs maintainer review"
+  
+  # Priority Labels
+  - name: good-first-issue
+    color: "7057ff"
+    description: "Good for newcomers to the project"
+  
+  - name: help-wanted
+    color: "008672"
+    description: "Community help is needed"
+  
+  - name: enhancement
+    color: "a2eeef"
+    description: "New feature or improvement"
+  
+  - name: bug
+    color: "d73a4a"
+    description: "Something isn't working correctly"
+  
+  - name: documentation
+    color: "0075ca"
+    description: "Improvements or additions to documentation"
+  
+  - name: security
+    color: "ee0701"
+    description: "Security-related issue or vulnerability"
+  
+  - name: pinned
+    color: "ffffff"
+    description: "Important issue pinned to the top"

--- a/.github/setup-labels.sh
+++ b/.github/setup-labels.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Setup script for GitHub labels in StellarYield repository
+# Usage: ./setup-labels.sh
+# Requires: GitHub CLI (gh) to be installed and authenticated
+
+set -e
+
+REPO="edehvictor/StellarYield"
+
+echo "Setting up labels for $REPO..."
+
+# Define labels with their properties
+declare -A labels=(
+    ["needs-triage"]="fbca04|Issue needs maintainer review and classification"
+    ["blocked"]="e11d21|Issue is blocked by dependencies or external factors"
+    ["keep-active"]="1d76db|Issue should remain active and not be marked as stale"
+    ["stellar-wave"]="795548|Stellar Wave program issue - exempt from stale triage"
+    ["stale"]="eeeeee|Issue has been inactive for an extended period"
+    ["work-in-progress"]="ededed|Pull request is still being developed"
+    ["needs-review"]="fbca04|Pull request needs maintainer review"
+    ["good-first-issue"]="7057ff|Good for newcomers to the project"
+    ["help-wanted"]="008672|Community help is needed"
+    ["enhancement"]="a2eeef|New feature or improvement"
+    ["bug"]="d73a4a|Something isn't working correctly"
+    ["documentation"]="0075ca|Improvements or additions to documentation"
+    ["security"]="ee0701|Security-related issue or vulnerability"
+    ["pinned"]="ffffff|Important issue pinned to the top"
+)
+
+# Create or update each label
+for label in "${!labels[@]}"; do
+    IFS='|' read -r color description <<< "${labels[$label]}"
+    
+    echo "Creating/updating label: $label"
+    
+    # Check if label exists
+    if gh label list --repo "$REPO" --search "$label" --limit 1 | grep -q "$label"; then
+        # Update existing label
+        gh label edit "$label" --repo "$REPO" --color "$color" --description "$description"
+        echo "✅ Updated existing label: $label"
+    else
+        # Create new label
+        gh label create "$label" --repo "$REPO" --color "$color" --description "$description"
+        echo "✅ Created new label: $label"
+    fi
+done
+
+echo ""
+echo "🎉 All labels have been set up successfully!"
+echo ""
+echo "Next steps:"
+echo "1. Review the labels in your GitHub repository"
+echo "2. Check the triage documentation at docs/triage-process.md"
+echo "3. Test the stale workflow by running it manually"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,218 @@
+name: Stale Issue and PR Triage
+
+on:
+  schedule:
+    # Run daily at 9:00 AM UTC
+    - cron: '0 9 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale-issues:
+    runs-on: ubuntu-latest
+    if: github.repository == 'edehvictor/StellarYield'
+    
+    steps:
+      - name: Mark stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          
+          # Issue configuration
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: 'stale'
+          stale-issue-message: |
+            This issue has been inactive for 30 days and will be marked as stale.
+            
+            To keep it active:
+            - Add a comment with updates or questions
+            - Add the `keep-active` label to prevent auto-closure
+            
+            If no activity occurs in 14 days, this issue will be automatically closed.
+            
+            Thank you for your contributions to StellarYield! 🚀
+          close-issue-message: |
+            This issue was closed due to inactivity.
+            
+            If you believe this issue is still relevant, please:
+            1. Reopen the issue
+            2. Add a comment explaining why it should remain open
+            3. Remove the `stale` label
+            
+            We appreciate your understanding in keeping our issue tracker manageable.
+            
+          # PR configuration  
+          days-before-pr-stale: 21
+          days-before-pr-close: 7
+          stale-pr-label: 'stale'
+          stale-pr-message: |
+            This pull request has been inactive for 21 days and will be marked as stale.
+            
+            To keep it active:
+            - Add a comment with updates or questions
+            - Address any pending review comments
+            - Add the `keep-active` label to prevent auto-closure
+            
+            If no activity occurs in 7 days, this PR will be automatically closed.
+            
+            Thank you for contributing to StellarYield! 🚀
+          close-pr-message: |
+            This pull request was closed due to inactivity.
+            
+            If you'd like to continue working on this:
+            1. Reopen the PR
+            2. Add a comment explaining the current status
+            3. Remove the `stale` label
+            4. Address any outstanding feedback
+            
+            We appreciate your understanding in keeping our PR queue manageable.
+          
+          # Exemptions
+          exempt-issue-labels: |
+            pinned,
+            security,
+            good-first-issue,
+            help-wanted,
+            enhancement,
+            bug,
+            documentation,
+            needs-triage,
+            blocked,
+            keep-active,
+            stellar-wave
+          exempt-pr-labels: |
+            pinned,
+            security,
+            work-in-progress,
+            needs-review,
+            needs-triage,
+            blocked,
+            keep-active
+          
+          # Don't close issues/PRs with milestones
+          exempt-all-milestones: true
+          
+          # Limit operations per run to avoid overwhelming the repository
+          operations-per-run: 30
+
+  triage-new-issues:
+    runs-on: ubuntu-latest
+    if: github.repository == 'edehvictor/StellarYield'
+    
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        
+      - name: Triage new issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: [],
+              sort: 'created',
+              direction: 'desc',
+              per_page: 50
+            });
+            
+            const threeDaysAgo = new Date();
+            threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+            
+            for (const issue of issues) {
+              if (issue.pull_request) continue; // Skip PRs
+              
+              const createdAt = new Date(issue.created_at);
+              const hasLabels = issue.labels.length > 0;
+              
+              // Only triage issues created in the last 3 days without labels
+              if (createdAt > threeDaysAgo && !hasLabels) {
+                // Check if it's a Stellar Wave issue (exempt from triage)
+                const isStellarWave = issue.title.toLowerCase().includes('stellar wave') || 
+                                     issue.body.toLowerCase().includes('stellar wave');
+                
+                if (isStellarWave) {
+                  // Add stellar-wave label and skip triage
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['stellar-wave']
+                  });
+                  
+                  // Add a comment for Stellar Wave issues
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `🌟 **Stellar Wave Issue Detected**\n\nThis issue has been tagged as a Stellar Wave issue and will remain active for the duration of the wave program.\n\nThank you for participating in Stellar Wave! 🚀`
+                  });
+                } else {
+                  // Add needs-triage label for regular issues
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    labels: ['needs-triage']
+                  });
+                  
+                  // Add a triage comment
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `🏷️ **Issue Needs Triage**\n\nThis issue has been marked as \`needs-triage\` and will be reviewed by maintainers.\n\n**What happens next:**\n- A maintainer will assess the issue and add appropriate labels\n- The issue may be assigned to someone or marked as \`good-first-issue\`\n- If it's a duplicate, it will be closed with a reference\n\nThank you for opening this issue! 🎯`
+                  });
+                }
+              }
+            }
+
+  cleanup-old-drafts:
+    runs-on: ubuntu-latest
+    if: github.repository == 'edehvictor/StellarYield'
+    
+    steps:
+      - name: Close old draft PRs
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pulls } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'created',
+              direction: 'desc',
+              per_page: 50
+            });
+            
+            const thirtyDaysAgo = new Date();
+            thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30);
+            
+            for (const pr of pulls) {
+              if (pr.draft) {
+                const createdAt = new Date(pr.created_at);
+                
+                if (createdAt < thirtyDaysAgo) {
+                  // Close old draft PRs
+                  await github.rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    state: 'closed'
+                  });
+                  
+                  // Add a comment explaining the closure
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: `📝 **Draft PR Closed**\n\nThis draft pull request was automatically closed after 30 days of inactivity.\n\nIf you'd like to continue working on this:\n1. Reopen the PR\n2. Remove the draft status\n3. Add a comment with your current progress\n\nWe appreciate your contribution! 💫`
+                  });
+                }
+              }
+            }

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -1,0 +1,214 @@
+# Issue and PR Triage Process
+
+This document outlines the triage process for maintaining a healthy and manageable issue tracker in the StellarYield repository.
+
+## 🎯 Overview
+
+The triage system helps maintainers:
+- Categorize new issues quickly
+- Identify and prioritize important work
+- Keep the issue tracker clean and focused
+- Support Stellar Wave participants effectively
+- Prevent issue tracker bloat from stale issues
+
+## 🤖 Automated Triage
+
+### Daily Workflow (runs at 9:00 AM UTC)
+
+1. **New Issue Triage**: Issues created in the last 3 days without labels are automatically tagged with `needs-triage`
+2. **Stale Detection**: Issues inactive for 30 days are marked as `stale`
+3. **Stale Closure**: Issues marked `stale` for 14 days without activity are closed
+4. **Draft PR Cleanup**: Draft PRs older than 30 days are automatically closed
+
+### Stellar Wave Exemptions
+
+Issues containing "Stellar Wave" in the title or body are:
+- Automatically tagged with `stellar-wave` label
+- Exempt from stale triage
+- Receive special acknowledgment comments
+
+## 🏷️ Label System
+
+### Triage Labels
+- **`needs-triage`**: New issues awaiting maintainer review
+- **`blocked`**: Issues blocked by dependencies or external factors
+- **`keep-active`**: Issues that should never be marked as stale
+- **`stellar-wave`**: Stellar Wave program issues (exempt from stale triage)
+
+### Status Labels
+- **`stale`**: Issues inactive for extended periods
+- **`work-in-progress`**: PRs still being developed
+- **`needs-review`**: PRs ready for maintainer review
+
+### Priority Labels
+- **`good-first-issue`**: Ideal for newcomers
+- **`help-wanted`**: Community assistance needed
+- **`enhancement`**: New features or improvements
+- **`bug`**: Something isn't working correctly
+- **`documentation`**: Documentation improvements
+- **`security`**: Security-related issues
+- **`pinned`**: Important issues pinned to top
+
+## 📋 Maintainer Triage Checklist
+
+### For New Issues (`needs-triage`)
+
+1. **Review Issue Content**
+   - [ ] Clear problem statement?
+   - [ ] Reproduction steps provided (for bugs)?
+   - [ ] Expected vs actual behavior described?
+   - [ ] Relevant environment details included?
+
+2. **Classify and Label**
+   - [ ] Add appropriate priority label (`bug`, `enhancement`, `documentation`, etc.)
+   - [ ] Add `good-first-issue` if appropriate for newcomers
+   - [ ] Add `help-wanted` if community help is needed
+   - [ ] Remove `needs-triage` label
+
+3. **Assess Priority**
+   - [ ] Is this a security issue? Add `security` label and respond immediately
+   - [ ] Is this blocking other work? Add `blocked` or block other issues
+   - [ ] Should this be pinned? Add `pinned` label
+
+4. **Assign and Respond**
+   - [ ] Assign to appropriate maintainer if possible
+   - [ ] Provide initial response or next steps
+   - [ ] Link related issues or pull requests
+
+### For Stale Issues (`stale`)
+
+1. **Evaluate Relevance**
+   - [ ] Is this issue still relevant to the project?
+   - [ ] Has the underlying problem been resolved?
+   - [ ] Are there newer related issues?
+
+2. **Take Action**
+   - [ ] **Keep Active**: Add `keep-active` label and comment why
+   - [ ] **Refresh**: Remove `stale` label and add updated information
+   - [ ] **Close**: Let auto-close happen or close manually with explanation
+
+### For Pull Requests
+
+1. **Initial Triage**
+   - [ ] Check for proper issue linking
+   - [ ] Verify CI checks are passing
+   - [ ] Add appropriate labels (`needs-review`, `work-in-progress`)
+   - [ ] Assign reviewers if needed
+
+2. **Review Process**
+   - [ ] Provide constructive feedback
+   - [ ] Request changes if needed
+   - [ ] Approve when ready
+   - [ ] Merge after approval and CI pass
+
+## 🔄 Manual Triage Process
+
+### Weekly Review (Recommended)
+
+1. **Check `needs-triage` Issues**
+   ```bash
+   # View all issues needing triage
+   gh issue list --repo edehvictor/StellarYield --label "needs-triage"
+   ```
+
+2. **Review `stale` Issues**
+   ```bash
+   # View stale issues
+   gh issue list --repo edehvictor/StellarYield --label "stale"
+   ```
+
+3. **Check `blocked` Issues**
+   ```bash
+   # View blocked issues
+   gh issue list --repo edehvictor/StellarYield --label "blocked"
+   ```
+
+### Monthly Cleanup
+
+1. **Review Old Draft PRs**
+   - Contact authors about inactive drafts
+   - Close drafts with no response after 30 days
+
+2. **Update Milestones**
+   - Review issues with upcoming milestones
+   - Update or remove outdated milestones
+
+3. **Label Maintenance**
+   - Remove duplicate or misapplied labels
+   - Update label descriptions if needed
+
+## 🛠️ Setup and Maintenance
+
+### Initial Setup
+
+1. **Install Required Labels**
+   ```bash
+   cd .github
+   chmod +x setup-labels.sh
+   ./setup-labels.sh
+   ```
+
+2. **Test Workflow**
+   - Manually trigger the stale workflow from GitHub Actions
+   - Verify labels are applied correctly
+   - Check that comments are posted as expected
+
+### Workflow Maintenance
+
+- **Monitor workflow runs** in GitHub Actions tab
+- **Update timing** if the schedule needs adjustment
+- **Modify exemptions** if new label categories are added
+- **Review message templates** for clarity and tone
+
+## 📊 Metrics and Reporting
+
+### Key Metrics to Track
+
+1. **Triage Efficiency**
+   - Time to first response on new issues
+   - Percentage of issues triaged within 48 hours
+   - Number of stale issues resolved
+
+2. **Issue Health**
+   - Ratio of open vs closed issues
+   - Age distribution of open issues
+   - Frequency of stale issue creation
+
+3. **Community Engagement**
+   - Number of `good-first-issue` items completed
+   - Participation from new contributors
+   - Stellar Wave issue resolution rate
+
+### Reporting
+
+Generate monthly reports using:
+```bash
+# Example: Get issue statistics
+gh issue list --repo edehvictor/StellarYield --state all --limit 1000 | \
+  jq -r '.[] | "\(.state),\(.labels[]?.name // "no-label"),\(.created_at)"' | \
+  sort | uniq -c
+```
+
+## 🚨 Special Cases
+
+### Security Issues
+- Never apply `stale` to security issues
+- Respond within 24 hours
+- Consider private disclosure if needed
+
+### Breaking Changes
+- Mark with `keep-active` to prevent auto-close
+- Ensure proper communication and migration plans
+
+### Stellar Wave Issues
+- Always exempt from stale triage
+- Provide additional support and guidance
+- Track separately for program reporting
+
+## 📞 Getting Help
+
+- **GitHub Issues**: For triage process improvements
+- **Discussions**: For general questions about issue management
+- **Maintainer Team**: For urgent triage decisions
+
+Remember: Good triage helps contributors feel heard and keeps the project moving forward! 🚀


### PR DESCRIPTION
This PR introduces an automated workflow to identify and manage stale issues and pull requests. It helps maintain repository hygiene by flagging inactive threads and closing them when appropriate, reducing backlog noise and improving contributor focus.

Closes #198