### PR TITLE
feat(github): add issue templates for bugs, features, docs, and contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+      placeholder: What happened?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Provide minimal steps to reproduce the issue.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, browser, Node version, etc.
+      placeholder: e.g. macOS 14, Chrome 120, Node 20
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Screenshots
+      description: Add any relevant logs or screenshots.
+    validations:
+      required: false
+  - type: dropdown
+    id: affected
+    attributes:
+      label: Affected Package
+      description: Which package is affected?
+      options:
+        - frontend
+        - backend
+        - contracts
+        - docs
+        - other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/contract_task.yml
+++ b/.github/ISSUE_TEMPLATE/contract_task.yml
@@ -1,0 +1,46 @@
+name: Contract Task
+description: Propose a change to on-chain contracts or related infrastructure
+labels: [contracts]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What contract change is needed?
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why is this change necessary?
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What must be true for this task to be complete?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / Considerations
+      description: Any security or compatibility concerns?
+    validations:
+      required: false
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - low
+        - medium
+        - high
+        - critical
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,39 @@
+name: Documentation
+description: Report a documentation issue or request an improvement
+labels: [documentation]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is missing or incorrect in the documentation?
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Location
+      description: Where did you encounter the issue? (file, URL, section)
+      placeholder: e.g. README.md, API docs, inline comments
+    validations:
+      required: false
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested Change
+      description: What should the documentation say instead?
+    validations:
+      required: false
+  - type: dropdown
+    id: affected
+    attributes:
+      label: Affected Package
+      description: Which package is this for?
+      options:
+        - frontend
+        - backend
+        - contracts
+        - docs
+        - other
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: [enhancement]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What feature would you like to see?
+      placeholder: Describe the feature and its benefits.
+    validations:
+      required: true
+  - type: textarea
+    id: use_case
+    attributes:
+      label: Use Case
+      description: Describe the scenario where this feature would be useful.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: What conditions must be met for this feature to be considered complete?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: false
+  - type: dropdown
+    id: affected
+    attributes:
+      label: Affected Package
+      description: Which package is this for?
+      options:
+        - frontend
+        - backend
+        - contracts
+        - docs
+        - other
+    validations:
+      required: false


### PR DESCRIPTION
This PR adds structured GitHub issue templates to help contributors file actionable reports.

### Templates Added
- **Bug Report** – reproduction steps, expected vs actual behavior, environment, logs
- **Feature Request** – description, use case, acceptance criteria
- **Documentation** – docs gaps, location, suggested changes
- **Contract Task** – on-chain change proposals with risks and priority

### Notes
- Templates automatically apply labels where possible
- Each template includes an affected-package dropdown
- Kept concise to reduce contributor friction

Fixes #197