### PR TITLE
feat: add GitHub issue templates for bugs, features, docs, and contracts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: '[Bug]: '
+labels: ['bug']
+assignees: ''
+---
+
+## Bug Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+What should have happened instead.
+
+## Actual Behavior
+
+What actually happened. Include screenshots or logs if possible.
+
+## Environment
+
+- **OS**: [e.g. macOS 14, Ubuntu 22.04, Windows 11]
+- **Browser**: [e.g. Chrome 120, Firefox 121]
+- **Node Version**: [e.g. 20.x]
+- **Package**: [e.g. @stellarwave/sdk, frontend, contracts]
+
+## Screenshots / Logs
+
+<!-- If applicable, add screenshots or error logs to help explain the problem -->
+
+## Additional Context
+
+Add any other relevant context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Stellar Wave Community
+    url: https://github.com/edehvictor/StellarYield/discussions
+    about: Please ask and answer questions here.

--- a/.github/ISSUE_TEMPLATE/contract_task.md
+++ b/.github/ISSUE_TEMPLATE/contract_task.md
@@ -1,0 +1,28 @@
+---
+name: Contract Task
+about: A task related to Soroban smart contracts
+title: '[Contract]: '
+labels: ['contracts']
+assignees: ''
+---
+
+## Task Description
+
+What needs to be done in the smart contract.
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Tests pass
+- [ ] No new security concerns introduced
+
+## Technical Details
+
+- **Contract**: [e.g. yield-router, vault-manager]
+- **Network**: [e.g. testnet, mainnet]
+- **Dependencies**: [any related contracts or packages]
+
+## Additional Context
+
+<!-- Relevant specs, diagrams, or prior discussions -->

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,26 @@
+---
+name: Documentation
+about: Report a documentation gap, error, or improvement
+title: '[Docs]: '
+labels: ['documentation']
+assignees: ''
+---
+
+## What's the issue?
+
+- [ ] Missing documentation
+- [ ] Incorrect documentation
+- [ ] Typo / formatting
+- [ ] Needs examples / code snippets
+
+## Location
+
+Link or path to the affected documentation page/file.
+
+## Suggested Change
+
+What should the documentation say instead?
+
+## Additional Context
+
+<!-- Any screenshots, references, or related issues -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,41 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: '[Feature]: '
+labels: ['enhancement']
+assignees: ''
+---
+
+## Problem Statement
+
+Is your feature request related to a problem? Please describe clearly what the issue is.
+> Ex. I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternative Solutions
+
+A description of any alternative solutions or features you've considered.
+
+## Impact
+
+How would this feature benefit users or the project?
+- [ ] Improves user experience
+- [ ] Adds new functionality
+- [ ] Improves performance
+- [ ] Improves documentation
+
+## Affected Package
+
+<!-- Which part of the project is affected? -->
+- [ ] Frontend
+- [ ] Smart Contracts
+- [ ] SDK / API
+- [ ] Documentation
+- [ ] CI / DevEx
+
+## Additional Context
+
+Add any other context, mockups, or references here.


### PR DESCRIPTION
## Description

Adds standardized GitHub issue templates to help contributors file actionable reports with reproduction steps, environment details, and acceptance criteria.

## What was added

- **Bug Report** (`bug_report.md`): fields for reproduction steps, environment, screenshots
- **Feature Request** (`feature_request.md`): problem/solution/alternative format with package scoping
- **Documentation** (`documentation.md`): quick report for typos, gaps, and errors
- **Contract Task** (`contract_task.md`): Soroban-specific task template with network and acceptance criteria
- **Config** (`config.yml`): disables blank issues, links to Discussions

## Acceptance Criteria

- [x] Templates added to `.github/ISSUE_TEMPLATE/`
- [x] Automatic label assignment via YAML frontmatter
- [x] Short, readable templates for fast filing

Closes #197