### PR TITLE
Add vault metadata IPFS admin endpoint and close assigned issues

### DIFF
--- a/server/src/__tests__/vaultMetadataService.test.ts
+++ b/server/src/__tests__/vaultMetadataService.test.ts
@@ -1,0 +1,41 @@
+import {
+  sanitizeSvg,
+  uploadVaultMetadata,
+} from "../services/ipfs/vaultMetadataService";
+
+describe("vaultMetadataService", () => {
+  it("sanitizes dangerous SVG content", () => {
+    const raw =
+      '<svg onload="alert(1)"><script>alert("xss")</script><rect width="10" height="10" /></svg>';
+    const cleaned = sanitizeSvg(raw);
+
+    expect(cleaned).toContain("<svg");
+    expect(cleaned).not.toContain("<script");
+    expect(cleaned).not.toContain("onload=");
+  });
+
+  it("returns deterministic local fallback CID without Pinata config", async () => {
+    const previousPinata = process.env.PINATA_JWT;
+    delete process.env.PINATA_JWT;
+
+    const first = await uploadVaultMetadata({
+      vaultName: "Core Vault",
+      description: "Stable yield strategy",
+      iconSvg: "<svg><rect width='10' height='10' /></svg>",
+    });
+    const second = await uploadVaultMetadata({
+      vaultName: "Core Vault",
+      description: "Stable yield strategy",
+      iconSvg: "<svg><rect width='10' height='10' /></svg>",
+    });
+
+    expect(first.uploadMode).toBe("local-fallback");
+    expect(first.metadataUri.startsWith("ipfs://")).toBe(true);
+    expect(first.cid).toBe(second.cid);
+    expect(first.iconUri).toBe(second.iconUri);
+
+    if (previousPinata) {
+      process.env.PINATA_JWT = previousPinata;
+    }
+  });
+});

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -6,6 +6,7 @@ import {
   exportAuditLogsToCSV,
   verifyAuditTrailIntegrity,
 } from "../middleware/audit";
+import { uploadVaultMetadata } from "../services/ipfs/vaultMetadataService";
 
 const adminRouter = Router();
 
@@ -60,6 +61,73 @@ adminRouter.post(
           error instanceof Error
             ? error.message
             : "Failed to update vault parameters",
+      });
+    }
+  },
+);
+
+/**
+ * Upload vault metadata to IPFS and return metadata URI for contract updates
+ * POST /api/admin/vaults/:vaultId/metadata
+ */
+adminRouter.post(
+  "/vaults/:vaultId/metadata",
+  requireAdmin,
+  async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { vaultId } = req.params;
+      const { vaultName, description, iconSvg } = req.body as {
+        vaultName?: string;
+        description?: string;
+        iconSvg?: string;
+      };
+
+      if (!vaultName || !description || !iconSvg) {
+        res.status(400).json({
+          error: "vaultName, description, and iconSvg are required",
+        });
+        return;
+      }
+
+      const uploadResult = await uploadVaultMetadata({
+        vaultName,
+        description,
+        iconSvg,
+      });
+
+      setAuditContext(req, {
+        action: "UPDATE_VAULT_METADATA_URI",
+        resource: "VAULT",
+        resourceId: vaultId,
+        changes: {
+          metadataUri: uploadResult.metadataUri,
+          cid: uploadResult.cid,
+          uploadMode: uploadResult.uploadMode,
+        },
+      });
+
+      res.json({
+        success: true,
+        vaultId,
+        cid: uploadResult.cid,
+        metadataUri: uploadResult.metadataUri,
+        iconUri: uploadResult.iconUri,
+        uploadMode: uploadResult.uploadMode,
+        metadata: uploadResult.metadata,
+        transactionPayload: {
+          method: "set_metadata_uri",
+          args: {
+            vaultId,
+            metadataUri: uploadResult.metadataUri,
+          },
+        },
+      });
+    } catch (error) {
+      res.status(500).json({
+        error:
+          error instanceof Error
+            ? error.message
+            : "Failed to upload vault metadata",
       });
     }
   },

--- a/server/src/services/ipfs/vaultMetadataService.ts
+++ b/server/src/services/ipfs/vaultMetadataService.ts
@@ -1,0 +1,149 @@
+import crypto from "crypto";
+
+export interface VaultMetadataInput {
+  vaultName: string;
+  description: string;
+  iconSvg: string;
+}
+
+export interface VaultMetadataPayload {
+  name: string;
+  description: string;
+  icon: string;
+  createdAt: string;
+}
+
+export interface UploadVaultMetadataResult {
+  cid: string;
+  metadataUri: string;
+  iconUri: string;
+  metadata: VaultMetadataPayload;
+  uploadMode: "pinata" | "local-fallback";
+}
+
+const PINATA_FILE_API = "https://api.pinata.cloud/pinning/pinFileToIPFS";
+const PINATA_JSON_API = "https://api.pinata.cloud/pinning/pinJSONToIPFS";
+
+function requireNonEmpty(value: string, field: string): string {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  return trimmed;
+}
+
+export function sanitizeSvg(svg: string): string {
+  const normalized = requireNonEmpty(svg, "iconSvg");
+
+  if (!normalized.includes("<svg")) {
+    throw new Error("iconSvg must be a valid SVG string");
+  }
+
+  return normalized
+    .replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, "")
+    .replace(/\son\w+="[^"]*"/gi, "")
+    .replace(/\son\w+='[^']*'/gi, "")
+    .replace(/javascript:/gi, "");
+}
+
+function makeDeterministicCid(seed: string): string {
+  return crypto.createHash("sha256").update(seed).digest("hex").slice(0, 46);
+}
+
+function buildMetadata(input: VaultMetadataInput, iconCid: string): VaultMetadataPayload {
+  return {
+    name: requireNonEmpty(input.vaultName, "vaultName"),
+    description: requireNonEmpty(input.description, "description"),
+    icon: `ipfs://${iconCid}`,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+async function uploadSvgToPinata(svg: string, pinataJwt: string): Promise<string> {
+  const body = new FormData();
+  const svgBlob = new Blob([svg], { type: "image/svg+xml" });
+  body.append("file", svgBlob, "vault-icon.svg");
+
+  const response = await fetch(PINATA_FILE_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${pinataJwt}`,
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Pinata SVG upload failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as { IpfsHash?: string };
+  if (!data.IpfsHash) {
+    throw new Error("Pinata SVG upload did not return IpfsHash");
+  }
+
+  return data.IpfsHash;
+}
+
+async function uploadJsonToPinata(
+  metadata: VaultMetadataPayload,
+  pinataJwt: string,
+): Promise<string> {
+  const response = await fetch(PINATA_JSON_API, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${pinataJwt}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      pinataContent: metadata,
+    }),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Pinata metadata upload failed: ${response.status} ${text}`);
+  }
+
+  const data = (await response.json()) as { IpfsHash?: string };
+  if (!data.IpfsHash) {
+    throw new Error("Pinata metadata upload did not return IpfsHash");
+  }
+
+  return data.IpfsHash;
+}
+
+export async function uploadVaultMetadata(
+  input: VaultMetadataInput,
+): Promise<UploadVaultMetadataResult> {
+  const sanitizedSvg = sanitizeSvg(input.iconSvg);
+  const pinataJwt = process.env.PINATA_JWT?.trim();
+
+  if (!pinataJwt) {
+    const iconCid = makeDeterministicCid(`icon:${sanitizedSvg}`);
+    const metadata = buildMetadata(input, iconCid);
+    const metadataCid = makeDeterministicCid(
+      `meta:${JSON.stringify(metadata)}:${sanitizedSvg}`,
+    );
+
+    return {
+      cid: metadataCid,
+      metadataUri: `ipfs://${metadataCid}`,
+      iconUri: `ipfs://${iconCid}`,
+      metadata,
+      uploadMode: "local-fallback",
+    };
+  }
+
+  const iconCid = await uploadSvgToPinata(sanitizedSvg, pinataJwt);
+  const metadata = buildMetadata(input, iconCid);
+  const metadataCid = await uploadJsonToPinata(metadata, pinataJwt);
+
+  return {
+    cid: metadataCid,
+    metadataUri: `ipfs://${metadataCid}`,
+    iconUri: `ipfs://${iconCid}`,
+    metadata,
+    uploadMode: "pinata",
+  };
+}


### PR DESCRIPTION
Closes #26
Closes #85
Closes #152

## Changes
- Added a backend IPFS metadata service at `server/src/services/ipfs/vaultMetadataService.ts`.
- Added SVG sanitization to strip script tags and inline event-handler attributes before upload.
- Added a new admin endpoint: `POST /api/admin/vaults/:vaultId/metadata` in `server/src/routes/admin.ts`.
- Endpoint accepts `vaultName`, `description`, and `iconSvg`; returns `cid`, `metadataUri`, `iconUri`, and a transaction payload for `set_metadata_uri`.
- Integrated audit context logging for metadata URI updates.
- Added focused tests in `server/src/__tests__/vaultMetadataService.test.ts`.

## Testing
- Attempted: `npm test -- vaultMetadataService.test.ts`
- Result: failed locally because `jest` is not installed in this clone (`sh: jest: command not found`).
- Per request, no dependency installation was performed.
