### PR TITLE
feat: strategy recommendation cohort comparison tool

### DIFF
--- a/server/src/services/__tests__/cohortComparisonService.test.ts
+++ b/server/src/services/__tests__/cohortComparisonService.test.ts
@@ -1,0 +1,54 @@
+import { CohortComparisonService, UserProfile } from '../cohortComparisonService';
+
+const svc = new CohortComparisonService();
+
+const makeUser = (
+  id: string,
+  overrides: Partial<UserProfile> = {}
+): UserProfile => ({
+  userId: id,
+  riskProfile: 'moderate',
+  depositSize: 'medium',
+  horizon: 'medium',
+  recommendedStrategies: [{ strategyId: 'strat-A', allocationPct: 60 }, { strategyId: 'strat-B', allocationPct: 40 }],
+  expectedApy: 8,
+  riskScore: 0.5,
+  ...overrides,
+});
+
+const users: UserProfile[] = [
+  ...Array.from({ length: 6 }, (_, i) => makeUser(`u${i}`, { riskProfile: 'conservative', expectedApy: 5, riskScore: 0.2 })),
+  ...Array.from({ length: 6 }, (_, i) => makeUser(`a${i}`, { riskProfile: 'aggressive', expectedApy: 15, riskScore: 0.8 })),
+];
+
+describe('CohortComparisonService', () => {
+  it('returns aggregated summaries per cohort', () => {
+    const result = svc.compare(users, [
+      { riskProfile: 'conservative' },
+      { riskProfile: 'aggressive' },
+    ]);
+    expect(result.cohorts).toHaveLength(2);
+    expect(result.cohorts[0].avgExpectedApy).toBe(5);
+    expect(result.cohorts[1].avgExpectedApy).toBe(15);
+  });
+
+  it('excludes cohorts below MIN_COHORT_SIZE (privacy guard)', () => {
+    const small = [makeUser('x1'), makeUser('x2')]; // only 2 users
+    const result = svc.compare(small, [{ riskProfile: 'moderate' }]);
+    expect(result.cohorts).toHaveLength(0);
+  });
+
+  it('does not expose individual user data', () => {
+    const result = svc.compare(users, [{ riskProfile: 'conservative' }]);
+    const summary = result.cohorts[0];
+    expect(summary).not.toHaveProperty('userId');
+    expect(summary.userCount).toBeGreaterThanOrEqual(5);
+  });
+
+  it('aggregates top strategies correctly', () => {
+    const result = svc.compare(users, [{ riskProfile: 'conservative' }]);
+    const top = result.cohorts[0].topStrategies[0];
+    expect(top.strategyId).toBe('strat-A');
+    expect(top.allocationPct).toBe(60);
+  });
+});

--- a/server/src/services/cohortComparisonService.ts
+++ b/server/src/services/cohortComparisonService.ts
@@ -1,0 +1,103 @@
+/**
+ * Cohort Comparison Service (#385)
+ *
+ * Compares strategy recommendation behaviour across user cohorts.
+ * All outputs are aggregated — no individual user data is exposed.
+ */
+
+export type RiskProfile = 'conservative' | 'moderate' | 'aggressive';
+export type DepositSize = 'small' | 'medium' | 'large';
+export type Horizon = 'short' | 'medium' | 'long';
+
+export interface CohortDefinition {
+  riskProfile?: RiskProfile;
+  depositSize?: DepositSize;
+  horizon?: Horizon;
+}
+
+export interface CohortRecommendationSummary {
+  cohort: CohortDefinition;
+  /** Number of users in cohort (never < MIN_COHORT_SIZE to prevent re-identification) */
+  userCount: number;
+  topStrategies: Array<{ strategyId: string; allocationPct: number }>;
+  avgExpectedApy: number;
+  avgRiskScore: number;
+}
+
+export interface CohortComparisonResult {
+  cohorts: CohortRecommendationSummary[];
+  generatedAt: string;
+}
+
+/** Minimum cohort size to prevent individual re-identification */
+const MIN_COHORT_SIZE = 5;
+
+export interface UserProfile {
+  userId: string;
+  riskProfile: RiskProfile;
+  depositSize: DepositSize;
+  horizon: Horizon;
+  recommendedStrategies: Array<{ strategyId: string; allocationPct: number }>;
+  expectedApy: number;
+  riskScore: number;
+}
+
+function matchesCohort(user: UserProfile, cohort: CohortDefinition): boolean {
+  if (cohort.riskProfile && user.riskProfile !== cohort.riskProfile) return false;
+  if (cohort.depositSize && user.depositSize !== cohort.depositSize) return false;
+  if (cohort.horizon && user.horizon !== cohort.horizon) return false;
+  return true;
+}
+
+function aggregateStrategies(
+  users: UserProfile[]
+): Array<{ strategyId: string; allocationPct: number }> {
+  const totals: Record<string, number> = {};
+  for (const u of users) {
+    for (const s of u.recommendedStrategies) {
+      totals[s.strategyId] = (totals[s.strategyId] ?? 0) + s.allocationPct;
+    }
+  }
+  return Object.entries(totals)
+    .map(([strategyId, total]) => ({
+      strategyId,
+      allocationPct: Math.round(total / users.length),
+    }))
+    .sort((a, b) => b.allocationPct - a.allocationPct)
+    .slice(0, 5);
+}
+
+export class CohortComparisonService {
+  /**
+   * Compare recommendation behaviour across the given cohort definitions.
+   * Users that don't meet MIN_COHORT_SIZE are excluded to preserve privacy.
+   */
+  compare(
+    users: UserProfile[],
+    cohorts: CohortDefinition[]
+  ): CohortComparisonResult {
+    const summaries: CohortRecommendationSummary[] = [];
+
+    for (const cohort of cohorts) {
+      const members = users.filter((u) => matchesCohort(u, cohort));
+      if (members.length < MIN_COHORT_SIZE) continue; // privacy guard
+
+      const avgApy =
+        members.reduce((s, u) => s + u.expectedApy, 0) / members.length;
+      const avgRisk =
+        members.reduce((s, u) => s + u.riskScore, 0) / members.length;
+
+      summaries.push({
+        cohort,
+        userCount: members.length,
+        topStrategies: aggregateStrategies(members),
+        avgExpectedApy: Math.round(avgApy * 100) / 100,
+        avgRiskScore: Math.round(avgRisk * 100) / 100,
+      });
+    }
+
+    return { cohorts: summaries, generatedAt: new Date().toISOString() };
+  }
+}
+
+export const cohortComparisonService = new CohortComparisonService();


### PR DESCRIPTION
Closes #385

## Changes
- `CohortComparisonService.compare()`: groups users by riskProfile/depositSize/horizon, aggregates top strategies, avgApy, avgRiskScore
- Privacy guard: cohorts with < 5 members excluded — no individual user data exposed
- Tests: aggregation, privacy guard, no userId leakage, strategy ranking