### PR TITLE
feat: protocol health weighted allocation normalizer

### DIFF
--- a/server/src/services/__tests__/healthWeightedNormalizerService.test.ts
+++ b/server/src/services/__tests__/healthWeightedNormalizerService.test.ts
@@ -1,0 +1,60 @@
+import { HealthWeightedNormalizerService, ProtocolHealth } from '../healthWeightedNormalizerService';
+
+const svc = new HealthWeightedNormalizerService();
+
+const health = (id: string, score: number, hardBlocked = false, frozen = false): [string, ProtocolHealth] =>
+  [id, { protocolId: id, healthScore: score, hardBlocked, frozen }];
+
+describe('HealthWeightedNormalizerService', () => {
+  it('healthy protocols retain full weight', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 50 }, { protocolId: 'B', rawWeight: 50 }],
+      Object.fromEntries([health('A', 1), health('B', 1)])
+    );
+    expect(result[0].normalizedPct).toBe(0.5);
+    expect(result[1].normalizedPct).toBe(0.5);
+  });
+
+  it('degraded protocol loses allocation weight', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 50 }, { protocolId: 'B', rawWeight: 50 }],
+      Object.fromEntries([health('A', 1), health('B', 0.2)])
+    );
+    expect(result[0].normalizedPct).toBeGreaterThan(result[1].normalizedPct);
+  });
+
+  it('hard-blocked protocol gets 0 allocation', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 50 }, { protocolId: 'B', rawWeight: 50 }],
+      Object.fromEntries([health('A', 1), health('B', 0.9, true)])
+    );
+    expect(result.find(r => r.protocolId === 'B')!.normalizedPct).toBe(0);
+  });
+
+  it('frozen protocol gets 0 allocation', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 50 }, { protocolId: 'B', rawWeight: 50 }],
+      Object.fromEntries([health('A', 1), health('B', 1, false, true)])
+    );
+    expect(result.find(r => r.protocolId === 'B')!.normalizedPct).toBe(0);
+  });
+
+  it('mixed-health allocation sums to 1', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 40 }, { protocolId: 'B', rawWeight: 30 }, { protocolId: 'C', rawWeight: 30 }],
+      Object.fromEntries([health('A', 1), health('B', 0.5), health('C', 0.8)])
+    );
+    const sum = result.reduce((s, r) => s + r.normalizedPct, 0);
+    expect(sum).toBeCloseTo(1, 3);
+  });
+
+  it('tunable weightingStrength=0 leaves weights unchanged', () => {
+    const result = svc.normalize(
+      [{ protocolId: 'A', rawWeight: 50 }, { protocolId: 'B', rawWeight: 50 }],
+      Object.fromEntries([health('A', 1), health('B', 0)]),
+      { weightingStrength: 0 }
+    );
+    expect(result[0].normalizedPct).toBeCloseTo(0.5, 2);
+    expect(result[1].normalizedPct).toBeCloseTo(0.5, 2);
+  });
+});

--- a/server/src/services/healthWeightedNormalizerService.ts
+++ b/server/src/services/healthWeightedNormalizerService.ts
@@ -1,0 +1,93 @@
+/**
+ * Health-Weighted Allocation Normalizer (#384)
+ *
+ * Blends protocol health scores into allocation weights before explicit
+ * exclusion kicks in. Hard safety blocks and freeze conditions are never
+ * overridden by health weighting.
+ */
+
+export interface ProtocolHealth {
+  protocolId: string;
+  /** 0–1: 1 = fully healthy, 0 = completely degraded */
+  healthScore: number;
+  /** Hard block — allocation must be 0 regardless of health score */
+  hardBlocked: boolean;
+  /** Freeze condition — treated same as hardBlocked */
+  frozen: boolean;
+}
+
+export interface AllocationInput {
+  protocolId: string;
+  /** Raw allocation weight before health adjustment */
+  rawWeight: number;
+}
+
+export interface NormalizedAllocation {
+  protocolId: string;
+  adjustedWeight: number;
+  /** Final allocation as a fraction of total (0–1) */
+  normalizedPct: number;
+}
+
+export interface NormalizerConfig {
+  /**
+   * How strongly health score influences weight reduction.
+   * 0 = no effect, 1 = full effect (degraded protocol gets 0 weight).
+   * Default: 0.5
+   */
+  weightingStrength: number;
+  /** Minimum allocation fraction for non-blocked protocols (0–1). Default: 0.01 */
+  floor: number;
+  /** Maximum allocation fraction for any single protocol (0–1). Default: 1 */
+  ceiling: number;
+}
+
+const DEFAULT_CONFIG: NormalizerConfig = {
+  weightingStrength: 0.5,
+  floor: 0.01,
+  ceiling: 1,
+};
+
+export class HealthWeightedNormalizerService {
+  normalize(
+    allocations: AllocationInput[],
+    healthMap: Record<string, ProtocolHealth>,
+    config: Partial<NormalizerConfig> = {}
+  ): NormalizedAllocation[] {
+    const cfg = { ...DEFAULT_CONFIG, ...config };
+
+    // Step 1: apply health weighting; hard blocks / freezes → 0
+    const adjusted = allocations.map((a) => {
+      const health = healthMap[a.protocolId];
+      if (!health || health.hardBlocked || health.frozen) {
+        return { protocolId: a.protocolId, adjustedWeight: 0 };
+      }
+      // weight = rawWeight * (1 - weightingStrength * (1 - healthScore))
+      const multiplier = 1 - cfg.weightingStrength * (1 - health.healthScore);
+      return { protocolId: a.protocolId, adjustedWeight: a.rawWeight * multiplier };
+    });
+
+    const total = adjusted.reduce((s, a) => s + a.adjustedWeight, 0);
+
+    if (total === 0) {
+      return adjusted.map((a) => ({ ...a, normalizedPct: 0 }));
+    }
+
+    // Step 2: normalize to fractions, apply floor/ceiling
+    const raw = adjusted.map((a) => ({
+      ...a,
+      normalizedPct: a.adjustedWeight > 0
+        ? Math.min(cfg.ceiling, Math.max(cfg.floor, a.adjustedWeight / total))
+        : 0,
+    }));
+
+    // Step 3: re-normalize so fractions sum to 1
+    const sum = raw.reduce((s, a) => s + a.normalizedPct, 0);
+    return raw.map((a) => ({
+      ...a,
+      normalizedPct: sum > 0 ? Math.round((a.normalizedPct / sum) * 10000) / 10000 : 0,
+    }));
+  }
+}
+
+export const healthWeightedNormalizerService = new HealthWeightedNormalizerService();


### PR DESCRIPTION
Closes #384

## Changes
- `HealthWeightedNormalizerService.normalize()`: blends healthScore into weights via tunable `weightingStrength`
- Hard-blocked and frozen protocols always get 0 allocation — health weighting never overrides safety blocks
- Configurable floor/ceiling; re-normalizes to sum=1
- Tests: healthy, degraded, hard-blocked, frozen, mixed-health, weightingStrength=0