### PR TITLE
feat: dynamic yield reliability badge system

### DIFF
--- a/client/src/components/ReliabilityBadge.tsx
+++ b/client/src/components/ReliabilityBadge.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export type ReliabilityBadge = 'high' | 'moderate' | 'low';
+
+interface Props {
+  badge: ReliabilityBadge;
+  reason?: string;
+}
+
+const CONFIG: Record<ReliabilityBadge, { label: string; className: string }> = {
+  high:     { label: '✓ High Reliability',     className: 'bg-green-100 text-green-800 border-green-300' },
+  moderate: { label: '~ Moderate Reliability', className: 'bg-yellow-100 text-yellow-800 border-yellow-300' },
+  // Low must be visually prominent — bold border, strong contrast
+  low:      { label: '⚠ Low Reliability',      className: 'bg-red-100 text-red-900 border-red-500 font-bold ring-2 ring-red-400' },
+};
+
+export function ReliabilityBadgeComponent({ badge, reason }: Props) {
+  const { label, className } = CONFIG[badge];
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs ${className}`}
+      title={reason}
+      aria-label={`Yield reliability: ${label}${reason ? `. ${reason}` : ''}`}
+    >
+      {label}
+    </span>
+  );
+}

--- a/server/src/services/__tests__/yieldReliabilityBadgeService.test.ts
+++ b/server/src/services/__tests__/yieldReliabilityBadgeService.test.ts
@@ -1,0 +1,39 @@
+import { YieldReliabilityBadgeService } from '../yieldReliabilityBadgeService';
+
+const svc = new YieldReliabilityBadgeService();
+
+describe('YieldReliabilityBadgeService', () => {
+  it('assigns high badge for strong signals', () => {
+    const r = svc.assignBadge({ freshness: 1, providerAgreement: 1, trustSignal: 1 });
+    expect(r.badge).toBe('high');
+  });
+
+  it('assigns moderate badge for mixed signals', () => {
+    const r = svc.assignBadge({ freshness: 0.6, providerAgreement: 0.5, trustSignal: 0.5 });
+    expect(r.badge).toBe('moderate');
+  });
+
+  it('assigns low badge for weak signals', () => {
+    const r = svc.assignBadge({ freshness: 0.1, providerAgreement: 0.2, trustSignal: 0.1 });
+    expect(r.badge).toBe('low');
+  });
+
+  it('low badge includes cautionary reason text', () => {
+    const r = svc.assignBadge({ freshness: 0, providerAgreement: 0, trustSignal: 0 });
+    expect(r.reason.toLowerCase()).toContain('caution');
+  });
+
+  it('batch assigns badges for multiple sources', () => {
+    const results = svc.assignBadges({
+      src1: { freshness: 1, providerAgreement: 1, trustSignal: 1 },
+      src2: { freshness: 0, providerAgreement: 0, trustSignal: 0 },
+    });
+    expect(results.src1.badge).toBe('high');
+    expect(results.src2.badge).toBe('low');
+  });
+
+  it('score is weighted sum of inputs', () => {
+    const r = svc.assignBadge({ freshness: 1, providerAgreement: 0, trustSignal: 0 });
+    expect(r.score).toBeCloseTo(0.4, 2); // freshness weight = 0.4
+  });
+});

--- a/server/src/services/yieldReliabilityBadgeService.ts
+++ b/server/src/services/yieldReliabilityBadgeService.ts
@@ -1,0 +1,63 @@
+/**
+ * Dynamic Yield Reliability Badge System (#386)
+ *
+ * Assigns High / Moderate / Low reliability badges based on data freshness,
+ * provider agreement, and trust signals. Low-reliability badges must be
+ * visually prominent — never understated.
+ */
+
+export type ReliabilityBadge = 'high' | 'moderate' | 'low';
+
+export interface BadgeInput {
+  /** 0–1: how recent the data is */
+  freshness: number;
+  /** 0–1: agreement across providers */
+  providerAgreement: number;
+  /** 0–1: composite trust signal (uptime, error rate, etc.) */
+  trustSignal: number;
+}
+
+export interface BadgeResult {
+  badge: ReliabilityBadge;
+  score: number;
+  /** Human-readable reason for the assigned badge */
+  reason: string;
+}
+
+/** Thresholds for badge assignment (inclusive lower bound) */
+const THRESHOLDS = { high: 0.75, moderate: 0.45 } as const;
+
+/** Weights for the composite score */
+const WEIGHTS = { freshness: 0.4, providerAgreement: 0.35, trustSignal: 0.25 } as const;
+
+export class YieldReliabilityBadgeService {
+  assignBadge(input: BadgeInput): BadgeResult {
+    const score =
+      input.freshness * WEIGHTS.freshness +
+      input.providerAgreement * WEIGHTS.providerAgreement +
+      input.trustSignal * WEIGHTS.trustSignal;
+
+    const rounded = Math.round(score * 1000) / 1000;
+
+    if (rounded >= THRESHOLDS.high) {
+      return { badge: 'high', score: rounded, reason: 'Fresh data with strong provider agreement and high trust.' };
+    }
+    if (rounded >= THRESHOLDS.moderate) {
+      return { badge: 'moderate', score: rounded, reason: 'Acceptable data quality; some signals are weaker than ideal.' };
+    }
+    return {
+      badge: 'low',
+      score: rounded,
+      reason: 'Data is stale, providers disagree, or trust signals are weak. Treat displayed yield with caution.',
+    };
+  }
+
+  /** Batch-assign badges for multiple sources */
+  assignBadges(inputs: Record<string, BadgeInput>): Record<string, BadgeResult> {
+    return Object.fromEntries(
+      Object.entries(inputs).map(([id, input]) => [id, this.assignBadge(input)])
+    );
+  }
+}
+
+export const yieldReliabilityBadgeService = new YieldReliabilityBadgeService();


### PR DESCRIPTION
Closes #386

## Changes
- `YieldReliabilityBadgeService.assignBadge()`: composite score from freshness (40%), providerAgreement (35%), trustSignal (25%); thresholds high≥0.75, moderate≥0.45, low<0.45
- `ReliabilityBadgeComponent`: low badge uses bold border + ring — visually prominent, cannot be ignored
- Tests: badge assignment, cautionary reason text, batch, weighted score