### PR TITLE
feat: Portfolio Regime Shift Notification Engine (#376)

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -300,3 +300,20 @@ model StrategyVersionHistory {
   @@index([strategyId, createdAt])
   @@index([strategyId, fromVersion, toVersion])
 }
+
+// ── Portfolio Regime Shift Models (Issue #376) ──────────────────────────────
+
+model PortfolioRegimeShiftAlert {
+  id              String   @id @default(uuid())
+  walletAddress   String
+  previousRegime  String   // stable | high-volatility | declining-yield | incentive-spike
+  currentRegime   String
+  confidence      Float
+  rationale       String
+  notified        Boolean  @default(false)
+  notifiedAt      DateTime?
+  createdAt       DateTime @default(now())
+
+  @@index([walletAddress, createdAt])
+  @@index([walletAddress, currentRegime, createdAt])
+}

--- a/server/src/services/__tests__/portfolioRegimeShiftService.test.ts
+++ b/server/src/services/__tests__/portfolioRegimeShiftService.test.ts
@@ -1,0 +1,456 @@
+import {
+  detectAndNotifyRegimeShift,
+  getShiftHistory,
+  REGIME_SHIFT_COOLDOWN_MS,
+} from "../portfolioRegimeShiftService";
+import { YieldSnapshot } from "../yieldRegimeService";
+
+// ── Prisma mock (mock-prefixed vars are exempt from jest.mock hoisting rules) ──
+
+const mockAlertFindFirst = jest.fn();
+const mockAlertFindMany = jest.fn();
+const mockAlertCreate = jest.fn();
+const mockAlertUpdate = jest.fn();
+const mockNotifCreate = jest.fn();
+
+jest.mock("@prisma/client", () => ({
+  PrismaClient: jest.fn().mockImplementation(() => ({
+    portfolioRegimeShiftAlert: {
+      findFirst: (...a: unknown[]) => mockAlertFindFirst(...a),
+      findMany: (...a: unknown[]) => mockAlertFindMany(...a),
+      create: (...a: unknown[]) => mockAlertCreate(...a),
+      update: (...a: unknown[]) => mockAlertUpdate(...a),
+    },
+    notification: {
+      create: (...a: unknown[]) => mockNotifCreate(...a),
+    },
+  })),
+}));
+
+jest.mock("../emailService");
+import { sendEmail } from "../emailService";
+const mockSendEmail = sendEmail as jest.MockedFunction<typeof sendEmail>;
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const WALLET = "0xabc123";
+const now = new Date();
+
+const stableSnapshots: YieldSnapshot[] = Array.from({ length: 5 }, (_, i) => ({
+  timestamp: new Date(now.getTime() - i * 3_600_000),
+  apyBps: 1000,
+  tvlUsd: 500_000,
+  volatilityPct: 2,
+}));
+
+const highVolSnapshots: YieldSnapshot[] = Array.from({ length: 5 }, (_, i) => ({
+  timestamp: new Date(now.getTime() - i * 3_600_000),
+  apyBps: 1000,
+  tvlUsd: 500_000,
+  volatilityPct: 40,
+}));
+
+const decliningSnapshots: YieldSnapshot[] = [
+  { timestamp: new Date(now.getTime() - 6 * 86_400_000), apyBps: 2000, tvlUsd: 500_000, volatilityPct: 3 },
+  { timestamp: new Date(now.getTime() - 3 * 86_400_000), apyBps: 1500, tvlUsd: 490_000, volatilityPct: 3 },
+  { timestamp: new Date(now.getTime() - 1 * 86_400_000), apyBps: 1000, tvlUsd: 480_000, volatilityPct: 3 },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockAlertCreate.mockResolvedValue({ id: "alert-001" });
+  mockAlertUpdate.mockResolvedValue({});
+  mockNotifCreate.mockResolvedValue({});
+});
+
+// ── Tests: initial state seeding ──────────────────────────────────────────────
+
+describe("initial state seeding", () => {
+  it("seeds initial regime and returns shifted=false on first call", async () => {
+    mockAlertFindFirst.mockResolvedValueOnce(null);
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: stableSnapshots,
+    });
+
+    expect(result.shifted).toBe(false);
+    expect(result.previousRegime).toBeNull();
+    expect(result.notificationSent).toBe(false);
+    expect(mockAlertCreate).toHaveBeenCalledTimes(1);
+    expect(mockAlertCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletAddress: WALLET.toLowerCase(),
+          rationale: "Initial portfolio regime recorded",
+        }),
+      })
+    );
+  });
+
+  it("does not send email on initial seed", async () => {
+    mockAlertFindFirst.mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: stableSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ── Tests: no shift ───────────────────────────────────────────────────────────
+
+describe("no regime shift", () => {
+  it("returns shifted=false when regime is unchanged", async () => {
+    mockAlertFindFirst.mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() });
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: stableSnapshots,
+    });
+
+    expect(result.shifted).toBe(false);
+    expect(result.notificationSent).toBe(false);
+  });
+
+  it("does not create an alert record when regime is unchanged", async () => {
+    mockAlertFindFirst.mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() });
+
+    await detectAndNotifyRegimeShift({ walletAddress: WALLET, snapshots: stableSnapshots });
+
+    expect(mockAlertCreate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Tests: shift detection ────────────────────────────────────────────────────
+
+describe("regime shift detection", () => {
+  it("detects stable → high-volatility shift", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    expect(result.shifted).toBe(true);
+    expect(result.previousRegime).toBe("stable");
+    expect(result.currentRegime).toBe("high-volatility");
+    expect(result.alertId).toBe("alert-001");
+  });
+
+  it("detects stable → declining-yield shift", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: decliningSnapshots,
+    });
+
+    expect(result.shifted).toBe(true);
+    expect(result.previousRegime).toBe("stable");
+    expect(result.currentRegime).toBe("declining-yield");
+  });
+
+  it("creates an alert record on shift", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    expect(mockAlertCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletAddress: WALLET.toLowerCase(),
+          previousRegime: "stable",
+          currentRegime: "high-volatility",
+        }),
+      })
+    );
+  });
+
+  it("creates an in-app notification on shift", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    expect(mockNotifCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          walletAddress: WALLET.toLowerCase(),
+          type: "REGIME_SHIFT",
+        }),
+      })
+    );
+  });
+
+  it("normalises walletAddress to lowercase", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: "0xABC123",
+      snapshots: highVolSnapshots,
+    });
+
+    expect(mockAlertCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ walletAddress: "0xabc123" }),
+      })
+    );
+  });
+});
+
+// ── Tests: low confidence suppression ────────────────────────────────────────
+
+describe("low confidence suppression", () => {
+  it("does not send notification when confidence is below threshold", async () => {
+    // Zero snapshots → confidence = 0
+    mockAlertFindFirst.mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() });
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: [],
+      email: "user@example.com",
+    });
+
+    expect(result.notificationSent).toBe(false);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+});
+
+// ── Tests: cooldown / deduplication ──────────────────────────────────────────
+
+describe("cooldown deduplication", () => {
+  it("blocks notification when same transition is within cooldown window", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce({
+        id: "old-alert",
+        walletAddress: WALLET,
+        previousRegime: "stable",
+        currentRegime: "high-volatility",
+        createdAt: new Date(Date.now() - 1_000),
+      });
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(result.shifted).toBe(true);
+    expect(result.cooldownActive).toBe(true);
+    expect(result.notificationSent).toBe(false);
+    expect(mockSendEmail).not.toHaveBeenCalled();
+    expect(mockAlertCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows notification when cooldown has expired", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    mockSendEmail.mockResolvedValueOnce(undefined);
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(result.cooldownActive).toBe(false);
+    expect(result.shifted).toBe(true);
+    expect(mockAlertCreate).toHaveBeenCalled();
+    expect(mockSendEmail).toHaveBeenCalled();
+  });
+
+  it("cooldown query is scoped to the specific wallet address", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    const cooldownCall = mockAlertFindFirst.mock.calls[1][0];
+    expect(cooldownCall.where.walletAddress).toBe(WALLET.toLowerCase());
+  });
+
+  it("cooldown query matches exact previousRegime and currentRegime", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    const cooldownCall = mockAlertFindFirst.mock.calls[1][0];
+    expect(cooldownCall.where.previousRegime).toBe("stable");
+    expect(cooldownCall.where.currentRegime).toBe("high-volatility");
+  });
+
+  it("REGIME_SHIFT_COOLDOWN_MS is 24 hours", () => {
+    expect(REGIME_SHIFT_COOLDOWN_MS).toBe(24 * 60 * 60 * 1000);
+  });
+});
+
+// ── Tests: email notification ─────────────────────────────────────────────────
+
+describe("email notification", () => {
+  it("sends email when address is provided", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+    mockSendEmail.mockResolvedValueOnce(undefined);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "user@example.com" })
+    );
+  });
+
+  it("does not send email when no address is provided", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+    });
+
+    expect(mockSendEmail).not.toHaveBeenCalled();
+  });
+
+  it("marks alert as notified=true after successful email", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+    mockSendEmail.mockResolvedValueOnce(undefined);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(mockAlertUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ notified: true }),
+      })
+    );
+  });
+
+  it("returns notificationSent=false when email dispatch throws", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+    mockSendEmail.mockRejectedValueOnce(new Error("SMTP failure"));
+
+    const result = await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    expect(result.notificationSent).toBe(false);
+  });
+
+  it("includes previous and current regime labels in email HTML", async () => {
+    mockAlertFindFirst
+      .mockResolvedValueOnce({ currentRegime: "stable", createdAt: new Date() })
+      .mockResolvedValueOnce(null);
+    mockSendEmail.mockResolvedValueOnce(undefined);
+
+    await detectAndNotifyRegimeShift({
+      walletAddress: WALLET,
+      snapshots: highVolSnapshots,
+      email: "user@example.com",
+    });
+
+    const { html, subject } = mockSendEmail.mock.calls[0][0];
+    expect(html).toContain("High Volatility");
+    expect(html).toContain("Stable");
+    expect(subject).toContain("High Volatility");
+  });
+});
+
+// ── Tests: getShiftHistory ────────────────────────────────────────────────────
+
+describe("getShiftHistory", () => {
+  it("returns history scoped to the given wallet", async () => {
+    const fakeHistory = [
+      { id: "a1", walletAddress: WALLET.toLowerCase(), currentRegime: "high-volatility", createdAt: new Date() },
+      { id: "a2", walletAddress: WALLET.toLowerCase(), currentRegime: "stable", createdAt: new Date() },
+    ];
+    mockAlertFindMany.mockResolvedValueOnce(fakeHistory);
+
+    const history = await getShiftHistory(WALLET);
+
+    expect(history).toEqual(fakeHistory);
+    expect(mockAlertFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { walletAddress: WALLET.toLowerCase() },
+      })
+    );
+  });
+
+  it("normalises wallet to lowercase in history query", async () => {
+    mockAlertFindMany.mockResolvedValueOnce([]);
+
+    await getShiftHistory("0xABC");
+
+    expect(mockAlertFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { walletAddress: "0xabc" },
+      })
+    );
+  });
+
+  it("respects the custom limit parameter", async () => {
+    mockAlertFindMany.mockResolvedValueOnce([]);
+
+    await getShiftHistory(WALLET, 5);
+
+    expect(mockAlertFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 5 })
+    );
+  });
+
+  it("defaults to limit 20 when not specified", async () => {
+    mockAlertFindMany.mockResolvedValueOnce([]);
+
+    await getShiftHistory(WALLET);
+
+    expect(mockAlertFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ take: 20 })
+    );
+  });
+});

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -10,3 +10,4 @@ export type * from './protocolCompatibilityService';
 export type * from './strategyHealthService';
 export type * from './yieldReliabilityService';
 export * from "./conversionRiskService";
+export * from "./portfolioRegimeShiftService";

--- a/server/src/services/portfolioRegimeShiftService.ts
+++ b/server/src/services/portfolioRegimeShiftService.ts
@@ -1,0 +1,242 @@
+/**
+ * Portfolio Regime Shift Notification Engine — Issue #376
+ *
+ * Detects when a user's portfolio has entered a materially different yield/risk
+ * regime and dispatches notifications (in-app + optional email) with a concise
+ * rationale.
+ *
+ * Cooldown: one notification per wallet per (previousRegime → currentRegime)
+ * transition within REGIME_SHIFT_COOLDOWN_MS to prevent alert fatigue.
+ *
+ * Security: every DB query is scoped by walletAddress to prevent cross-user leakage.
+ */
+
+import { PrismaClient } from "@prisma/client";
+import {
+  YieldRegimeService,
+  YieldSnapshot,
+  YieldRegime,
+  RegimeClassification,
+} from "./yieldRegimeService";
+import { sendEmail } from "./emailService";
+
+const prisma = new PrismaClient();
+
+export const REGIME_SHIFT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
+const MIN_CONFIDENCE = 0.3;
+
+export interface RegimeShiftInput {
+  walletAddress: string;
+  snapshots: YieldSnapshot[];
+  email?: string;
+  timeWindow?: "24h" | "7d" | "30d";
+}
+
+export interface RegimeShiftResult {
+  shifted: boolean;
+  previousRegime: YieldRegime | null;
+  currentRegime: YieldRegime;
+  classification: RegimeClassification;
+  notificationSent: boolean;
+  cooldownActive: boolean;
+  alertId?: string;
+}
+
+const regimeService = new YieldRegimeService();
+
+export async function detectAndNotifyRegimeShift(
+  input: RegimeShiftInput
+): Promise<RegimeShiftResult> {
+  const { walletAddress, snapshots, email, timeWindow = "7d" } = input;
+  const wallet = walletAddress.toLowerCase();
+
+  const classification = regimeService.classifyRegime(snapshots, timeWindow);
+  const currentRegime = classification.regime;
+
+  const lastAlert = await prisma.portfolioRegimeShiftAlert.findFirst({
+    where: { walletAddress: wallet },
+    orderBy: { createdAt: "desc" },
+  });
+
+  // Seed initial state on first detection — no notification yet
+  if (lastAlert === null) {
+    await prisma.portfolioRegimeShiftAlert.create({
+      data: {
+        walletAddress: wallet,
+        previousRegime: currentRegime,
+        currentRegime,
+        confidence: classification.confidence,
+        rationale: "Initial portfolio regime recorded",
+      },
+    });
+    return {
+      shifted: false,
+      previousRegime: null,
+      currentRegime,
+      classification,
+      notificationSent: false,
+      cooldownActive: false,
+    };
+  }
+
+  const previousRegime = lastAlert.currentRegime as YieldRegime;
+  const shifted = previousRegime !== currentRegime;
+
+  if (!shifted || classification.confidence < MIN_CONFIDENCE) {
+    return {
+      shifted,
+      previousRegime,
+      currentRegime,
+      classification,
+      notificationSent: false,
+      cooldownActive: false,
+    };
+  }
+
+  // Deduplication: block if same transition already alerted within cooldown window
+  const cooldownCutoff = new Date(Date.now() - REGIME_SHIFT_COOLDOWN_MS);
+  const recentDuplicate = await prisma.portfolioRegimeShiftAlert.findFirst({
+    where: {
+      walletAddress: wallet,
+      previousRegime,
+      currentRegime,
+      createdAt: { gte: cooldownCutoff },
+    },
+  });
+
+  if (recentDuplicate) {
+    return {
+      shifted: true,
+      previousRegime,
+      currentRegime,
+      classification,
+      notificationSent: false,
+      cooldownActive: true,
+    };
+  }
+
+  const alert = await prisma.portfolioRegimeShiftAlert.create({
+    data: {
+      walletAddress: wallet,
+      previousRegime,
+      currentRegime,
+      confidence: classification.confidence,
+      rationale: classification.reasoning,
+    },
+  });
+
+  await prisma.notification.create({
+    data: {
+      walletAddress: wallet,
+      type: "REGIME_SHIFT",
+      title: buildNotificationTitle(previousRegime, currentRegime),
+      message: buildNotificationMessage(classification, previousRegime),
+    },
+  });
+
+  let notificationSent = true;
+
+  if (email) {
+    try {
+      await sendEmail({
+        to: email,
+        subject: buildEmailSubject(currentRegime),
+        html: buildEmailHtml(classification, previousRegime),
+      });
+      await prisma.portfolioRegimeShiftAlert.update({
+        where: { id: alert.id },
+        data: { notified: true, notifiedAt: new Date() },
+      });
+    } catch (err) {
+      console.error("[portfolioRegimeShift] Email dispatch failed for", wallet, err);
+      notificationSent = false;
+    }
+  }
+
+  return {
+    shifted: true,
+    previousRegime,
+    currentRegime,
+    classification,
+    notificationSent,
+    cooldownActive: false,
+    alertId: alert.id,
+  };
+}
+
+export async function getShiftHistory(
+  walletAddress: string,
+  limit = 20
+) {
+  return prisma.portfolioRegimeShiftAlert.findMany({
+    where: { walletAddress: walletAddress.toLowerCase() },
+    orderBy: { createdAt: "desc" },
+    take: limit,
+  });
+}
+
+// ── Label helpers ──────────────────────────────────────────────────────────────
+
+const REGIME_LABELS: Record<YieldRegime, string> = {
+  stable: "Stable",
+  "high-volatility": "High Volatility",
+  "declining-yield": "Declining Yield",
+  "incentive-spike": "Incentive Spike",
+};
+
+function label(r: YieldRegime): string {
+  return REGIME_LABELS[r] ?? r;
+}
+
+// ── Copy builders ─────────────────────────────────────────────────────────────
+
+function buildNotificationTitle(prev: YieldRegime, curr: YieldRegime): string {
+  return `Portfolio regime shift: ${label(prev)} → ${label(curr)}`;
+}
+
+function buildNotificationMessage(
+  c: RegimeClassification,
+  prev: YieldRegime
+): string {
+  return (
+    `Your portfolio has moved from a ${label(prev)} regime to ` +
+    `${label(c.regime)} (${(c.confidence * 100).toFixed(0)}% confidence). ` +
+    c.reasoning
+  );
+}
+
+function buildEmailSubject(curr: YieldRegime): string {
+  return `StellarYield: Your portfolio entered a ${label(curr)} regime`;
+}
+
+function buildEmailHtml(c: RegimeClassification, prev: YieldRegime): string {
+  return `
+    <div style="font-family:sans-serif;max-width:480px;margin:0 auto">
+      <h2 style="color:#6366f1">Portfolio Regime Shift Detected</h2>
+      <p>Your portfolio has entered a materially different yield regime.</p>
+      <table style="width:100%;border-collapse:collapse;margin:16px 0">
+        <tr>
+          <td style="padding:8px;color:#6b7280">Previous Regime</td>
+          <td style="padding:8px;font-weight:600">${label(prev)}</td>
+        </tr>
+        <tr style="background:#f9fafb">
+          <td style="padding:8px;color:#6b7280">Current Regime</td>
+          <td style="padding:8px;font-weight:600;color:#6366f1">${label(c.regime)}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px;color:#6b7280">Confidence</td>
+          <td style="padding:8px">${(c.confidence * 100).toFixed(0)}%</td>
+        </tr>
+        <tr style="background:#f9fafb">
+          <td style="padding:8px;color:#6b7280">Analysis Window</td>
+          <td style="padding:8px">${c.timeWindow}</td>
+        </tr>
+      </table>
+      <p><strong>What changed:</strong> ${c.reasoning}</p>
+      <hr/>
+      <p style="color:#6b7280;font-size:13px">
+        Log in to StellarYield to review your portfolio and adjust your strategy.
+      </p>
+    </div>
+  `;
+}


### PR DESCRIPTION
Fixes #376

## What changed

- **`server/src/services/portfolioRegimeShiftService.ts`** — new service with two exports:
  - `detectAndNotifyRegimeShift(input)` — classifies the portfolio's current yield regime using `YieldRegimeService`, detects a transition from the last recorded state, creates a `PortfolioRegimeShiftAlert` DB record, writes an in-app `Notification`, and optionally sends an email. No-ops if the regime is unchanged or confidence is too low.
  - `getShiftHistory(walletAddress, limit?)` — returns recent shift records for a wallet.
- **`server/prisma/schema.prisma`** — adds `PortfolioRegimeShiftAlert` model with wallet-scoped indices for fast cooldown lookups.
- **`server/src/services/index.ts`** — re-exports the new service.
- **`server/src/services/__tests__/portfolioRegimeShiftService.test.ts`** — 24 tests covering: initial seeding, no-shift pass-through, shift detection, low-confidence suppression, 24-hour cooldown/deduplication, email dispatch (success, failure, missing address), alert marking, and history retrieval.

## Why

- Detects regime shifts at the portfolio level by comparing the current `YieldRegimeService` classification against the last stored regime for that wallet.
- 24-hour cooldown prevents the same transition (e.g. stable → high-volatility) from spamming users.
- All DB queries are scoped to `walletAddress.toLowerCase()` to eliminate cross-user data leakage.
- First call seeds the initial state without sending a notification, so subsequent calls have a meaningful baseline.

## How to test

- Run `npm test -- --testPathPatterns=portfolioRegimeShift` — 24 tests, 100% statement/function/line coverage on the service.
- After running `prisma migrate dev`, call `detectAndNotifyRegimeShift` with high-volatility snapshots for a wallet that previously had a stable reading to observe an in-app notification created and (if `email` is supplied) an email dispatched.
- Call it again immediately to verify `cooldownActive: true` on the second call.