### PR TITLE
fix: resolve issues #363, #367, #371, #375

### DIFF
--- a/client/src/features/analytics/PortfolioAttributionPanel.tsx
+++ b/client/src/features/analytics/PortfolioAttributionPanel.tsx
@@ -23,11 +23,19 @@ interface AttributionBreakdown {
   confidence: number;
 }
 
+interface RewardSourceMixEntry {
+  rewardSource: string;
+  contribution: number;
+  percentage: number;
+  confidence: number;
+}
+
 interface AttributionReport {
   walletAddress: string;
   totalReturn: number;
   totalDeposited: number;
   attributionBreakdown: AttributionBreakdown[];
+  rewardSourceMix?: RewardSourceMixEntry[];
   timeWindow: {
     start: string;
     end: string;
@@ -54,6 +62,20 @@ const DECISION_TYPE_LABELS = {
   rotation: "Strategy Rotation",
   incentive_capture: "Incentive Capture",
   hold: "Hold Strategy",
+};
+
+const REWARD_SOURCE_COLORS: Record<string, string> = {
+  base_protocol_yield: "#6C5DD3",
+  incentive_emissions: "#F5A623",
+  tactical_routing: "#3EAC75",
+  fees: "#FF5E5E",
+};
+
+const REWARD_SOURCE_LABELS: Record<string, string> = {
+  base_protocol_yield: "Base Protocol Yield",
+  incentive_emissions: "Incentive Emissions",
+  tactical_routing: "Tactical Routing",
+  fees: "Embedded Fees",
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -167,12 +189,34 @@ export default function PortfolioAttributionPanel({ walletAddress }: PortfolioAt
   }
 
   // Prepare chart data
-  const pieChartData = report.attributionBreakdown.map(breakdown => ({
-    name: DECISION_TYPE_LABELS[breakdown.decisionType as keyof typeof DECISION_TYPE_LABELS] || breakdown.decisionType,
-    value: breakdown.contribution,
-    percentage: breakdown.percentage,
-    color: DECISION_TYPE_COLORS[breakdown.decisionType as keyof typeof DECISION_TYPE_COLORS] || "#6C5DD3",
-  }));
+  const pieChartData = (report.rewardSourceMix?.length
+    ? report.rewardSourceMix
+    : report.attributionBreakdown
+  ).map((entry: any) => {
+    if ("rewardSource" in entry) {
+      return {
+        name:
+          REWARD_SOURCE_LABELS[entry.rewardSource] || entry.rewardSource,
+        value: entry.contribution,
+        percentage: entry.percentage,
+        color:
+          REWARD_SOURCE_COLORS[entry.rewardSource] || "#6C5DD3",
+      };
+    }
+
+    return {
+      name:
+        DECISION_TYPE_LABELS[
+          entry.decisionType as keyof typeof DECISION_TYPE_LABELS
+        ] || entry.decisionType,
+      value: entry.contribution,
+      percentage: entry.percentage,
+      color:
+        DECISION_TYPE_COLORS[
+          entry.decisionType as keyof typeof DECISION_TYPE_COLORS
+        ] || "#6C5DD3",
+    };
+  });
 
   const barChartData = report.attributionBreakdown.map(breakdown => ({
     name: DECISION_TYPE_LABELS[breakdown.decisionType as keyof typeof DECISION_TYPE_LABELS] || breakdown.decisionType,
@@ -267,7 +311,9 @@ export default function PortfolioAttributionPanel({ walletAddress }: PortfolioAt
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         {/* Pie Chart */}
         <div className="glass-panel p-6">
-          <h3 className="text-lg font-semibold mb-4">Return Attribution by Decision Type</h3>
+          <h3 className="text-lg font-semibold mb-4">
+            Return Attribution by Reward Source
+          </h3>
           <ResponsiveContainer width="100%" height={300}>
             <PieChart>
               <Pie

--- a/client/src/pages/leaderboard/StrategyLeaderboard.tsx
+++ b/client/src/pages/leaderboard/StrategyLeaderboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Trophy, Medal, TrendingUp, Filter } from "lucide-react";
 import { apiUrl } from "../../lib/api";
+import { ConfidenceBadge } from "../../components/AIAdvisor/ConfidenceBadge";
 
 interface RankedStrategy {
   rank: number;
@@ -30,6 +31,25 @@ const StrategyLeaderboard: React.FC = () => {
   const [timeWindow, setTimeWindow] = useState<string>("all");
   const [strategyType, setStrategyType] = useState<string>("all");
 
+  // #375 Rotation Confidence Explorer
+  const [rotationData, setRotationData] = useState<{
+    current: { id: string | null; score: number | null; lastRotatedAt: string | null };
+    decisions: Array<{
+      action: string;
+      reason: string;
+      fromId: string | null;
+      toId: string | null;
+      scoreDelta: number | null;
+      detail: string;
+      evaluatedAt: string;
+      confidenceBreakdown?: any;
+      confidenceStrength?: "borderline" | "strongly_favored";
+      confidenceWhy?: string[];
+    }>;
+  } | null>(null);
+  const [rotationLoading, setRotationLoading] = useState(true);
+  const [rotationError, setRotationError] = useState<string | null>(null);
+
   useEffect(() => {
     setLoading(true);
     const params = new URLSearchParams({ timeWindow, strategyType });
@@ -44,6 +64,26 @@ const StrategyLeaderboard: React.FC = () => {
         setLoading(false);
       });
   }, [timeWindow, strategyType]);
+
+  useEffect(() => {
+    setRotationLoading(true);
+    setRotationError(null);
+    fetch(apiUrl("/api/strategies/rotation?limit=10"))
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as {
+          current: { id: string | null; score: number | null; lastRotatedAt: string | null };
+          decisions: any[];
+        };
+      })
+      .then((d) => setRotationData(d))
+      .catch((err) => setRotationError(err instanceof Error ? err.message : "Failed to load rotation data"))
+      .finally(() => setRotationLoading(false));
+  }, []);
+
+  const latestDecision =
+    rotationData?.decisions?.find((d) => d.action === "rotate") ??
+    rotationData?.decisions?.[0];
 
   return (
     <div className="space-y-8 max-w-5xl mx-auto">
@@ -172,6 +212,70 @@ const StrategyLeaderboard: React.FC = () => {
           </table>
         </div>
       )}
+
+      {/* #375 Rotation Confidence Explorer */}
+      <div className="glass-panel p-6 border border-white/10 shadow-2xl mt-8">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-xl font-bold text-white">Rotation Confidence Explorer</h3>
+            <p className="text-xs text-gray-400 mt-1">
+              Confidence decomposition for the most recent rotation evaluation.
+            </p>
+          </div>
+        </div>
+
+        {rotationLoading ? (
+          <div className="flex justify-center items-center py-10">
+            <div className="animate-spin rounded-full h-10 w-10 border-t-2 border-b-2 border-indigo-500" />
+          </div>
+        ) : rotationError ? (
+          <div className="py-6 text-center text-red-400 text-sm">{rotationError}</div>
+        ) : !latestDecision ? (
+          <div className="py-6 text-center text-gray-400 text-sm">No rotation decisions available.</div>
+        ) : (
+          <div className="space-y-4 mt-4">
+            <div className="rounded-xl border border-white/10 bg-black/20 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <p className="text-xs text-gray-400 uppercase tracking-widest">Decision</p>
+                  <p className="text-lg font-bold text-white">
+                    {latestDecision.action === "rotate"
+                      ? `Rotate → ${latestDecision.toId}`
+                      : `Hold (${latestDecision.reason})`}
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    {latestDecision.detail}
+                  </p>
+                </div>
+                {latestDecision.confidenceBreakdown ? (
+                  <span className="px-3 py-1 rounded-full bg-white/5 border border-white/10 text-xs text-gray-300">
+                    {(latestDecision.confidenceStrength === "borderline")
+                      ? "Borderline"
+                      : "Strongly favored"}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+
+            {latestDecision.confidenceBreakdown ? (
+              <>
+                <ConfidenceBadge confidence={latestDecision.confidenceBreakdown} compact />
+                {latestDecision.confidenceWhy?.length ? (
+                  <ul className="text-xs text-gray-300 space-y-0.5">
+                    {latestDecision.confidenceWhy.slice(0, 3).map((w: string, i: number) => (
+                      <li key={i}>• {w}</li>
+                    ))}
+                  </ul>
+                ) : null}
+              </>
+            ) : (
+              <p className="text-xs text-gray-400">
+                Confidence decomposition is only shown when a rotation candidate is selected.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/server/src/routes/admin.ts
+++ b/server/src/routes/admin.ts
@@ -8,6 +8,8 @@ import {
 } from "../middleware/audit";
 import { uploadVaultMetadata } from "../services/ipfs/vaultMetadataService";
 import { freezeService } from "../services/freezeService";
+import { PROTOCOLS } from "../config/protocols";
+import { strategyStateTransitionAuditService } from "../services/strategyStateTransitionAuditService";
 
 const adminRouter = Router();
 
@@ -500,8 +502,34 @@ adminRouter.post(
       let state;
       if (protocol) {
         state = await freezeService.freezeProtocol(protocol, reason, actor);
+
+        // #371 operator intervention: record lifecycle transition to frozen.
+        try {
+          strategyStateTransitionAuditService.recordOperatorIntervention(
+            String(protocol).toLowerCase(),
+            "frozen",
+            `freeze_reason=${reason}`,
+            actor,
+          );
+        } catch (err) {
+          console.warn("Failed to record frozen transition:", err);
+        }
       } else {
         state = await freezeService.freezeGlobal(reason, actor);
+
+        // #371 operator intervention: record frozen transition for all known strategies.
+        for (const p of PROTOCOLS) {
+          try {
+            strategyStateTransitionAuditService.recordOperatorIntervention(
+              p.protocolName.toLowerCase(),
+              "frozen",
+              `freeze_reason=${reason}`,
+              actor,
+            );
+          } catch {
+            // Best-effort only; never break the admin endpoint.
+          }
+        }
       }
 
       setAuditContext(req, {
@@ -533,8 +561,33 @@ adminRouter.post(
       let state;
       if (protocol) {
         state = await freezeService.resumeProtocol(protocol, actor);
+
+        // #371 operator intervention: record lifecycle transition to recovered.
+        try {
+          strategyStateTransitionAuditService.recordOperatorIntervention(
+            String(protocol).toLowerCase(),
+            "recovered",
+            "resume_reason=operator",
+            actor,
+          );
+        } catch (err) {
+          console.warn("Failed to record recovered transition:", err);
+        }
       } else {
         state = await freezeService.resumeGlobal(actor);
+
+        for (const p of PROTOCOLS) {
+          try {
+            strategyStateTransitionAuditService.recordOperatorIntervention(
+              p.protocolName.toLowerCase(),
+              "recovered",
+              "resume_reason=operator",
+              actor,
+            );
+          } catch {
+            // Best-effort only; never break the admin endpoint.
+          }
+        }
       }
 
       setAuditContext(req, {

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -5,6 +5,11 @@ import {
   strategyHealthEngine,
   yieldReliabilityEngine,
 } from '../services';
+import { strategyStateTransitionAuditService } from '../services/strategyStateTransitionAuditService';
+import {
+  generateRecommendationStabilityReport,
+  type RecommendationOutput,
+} from "../services/recommendationStabilityService";
 import {
   validateAttributionRequest,
   formatAttributionReport,
@@ -540,5 +545,81 @@ router.get('/dashboard', async (req, res) => {
     });
   }
 });
+
+/**
+ * GET /api/analytics/strategy-state-transitions/:strategyId
+ * Returns an audit graph of lifecycle transitions for a strategy.
+ */
+router.get('/strategy-state-transitions/:strategyId', async (req, res) => {
+  try {
+    const { strategyId } = req.params;
+    const limit = Math.max(1, Math.min(500, Number(req.query.limit) || 100));
+
+    const graph = strategyStateTransitionAuditService.getGraph(
+      String(strategyId),
+      limit,
+    );
+
+    res.json({
+      success: true,
+      data: graph,
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Failed to fetch strategy state transitions',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+});
+
+/**
+ * POST /api/analytics/recommendation-stability/compare
+ * Compares recommendation outputs from "before" vs "after" backend releases.
+ *
+ * Request body:
+ * {
+ *   before: RecommendationOutput[],
+ *   after: RecommendationOutput[],
+ *   baseline?: { testSetId?: string, beforeRelease?: string, afterRelease?: string },
+ *   config?: Partial<RecommendationStabilityConfig>
+ * }
+ */
+router.post(
+  "/recommendation-stability/compare",
+  async (req, res) => {
+    try {
+      const { before, after, baseline, config } = req.body as {
+        before?: RecommendationOutput[];
+        after?: RecommendationOutput[];
+        baseline?: { testSetId?: string; beforeRelease?: string; afterRelease?: string };
+        config?: Record<string, unknown>;
+      };
+
+      if (!Array.isArray(before) || !Array.isArray(after)) {
+        return res.status(400).json({
+          success: false,
+          error: "Missing or invalid request body: expected { before: RecommendationOutput[], after: RecommendationOutput[] }",
+        });
+      }
+
+      const report = generateRecommendationStabilityReport(
+        before,
+        after,
+        baseline ?? {},
+        config as any,
+      );
+
+      res.json({
+        success: true,
+        data: report,
+      });
+    } catch (error) {
+      res.status(500).json({
+        error: "Failed to compare recommendation stability",
+        message: error instanceof Error ? error.message : "Unknown error",
+      });
+    }
+  },
+);
 
 export default router;

--- a/server/src/services/__tests__/portfolioAttributionService.test.ts
+++ b/server/src/services/__tests__/portfolioAttributionService.test.ts
@@ -132,6 +132,7 @@ describe('PortfolioAttributionService', () => {
         expect(report).toHaveProperty('walletAddress', walletAddress);
         expect(report).toHaveProperty('timeWindow');
         expect(report).toHaveProperty('attributionBreakdown');
+        expect(report).toHaveProperty('rewardSourceMix');
         expect(report).toHaveProperty('totalReturn');
         expect(report).toHaveProperty('totalDeposited');
         expect(report).toHaveProperty('dataCompleteness');
@@ -159,6 +160,13 @@ describe('PortfolioAttributionService', () => {
         const report = await engine.generateAttributionReport(walletAddress, startTime, endTime);
 
         const totalPercentage = report.attributionBreakdown.reduce((sum, b) => sum + b.percentage, 0);
+        expect(totalPercentage).toBeCloseTo(100, 2);
+      });
+
+      it('should calculate rewardSourceMix percentages that sum to ~100', async () => {
+        const report = await engine.generateAttributionReport(walletAddress, startTime, endTime);
+
+        const totalPercentage = report.rewardSourceMix.reduce((sum, b) => sum + b.percentage, 0);
         expect(totalPercentage).toBeCloseTo(100, 2);
       });
 
@@ -279,6 +287,15 @@ describe('PortfolioAttributionService', () => {
 
         expect(report.attributionBreakdown).toHaveLength(1);
         expect(report.totalReturn).toBeGreaterThan(0);
+
+        // Missing actual APY is treated as incomplete price inputs.
+        // Confidence should be reduced by the incomplete-input multiplier.
+        const expectedEffective = 0.85 * 0.85;
+        expect(report.attributionBreakdown[0].confidence).toBeCloseTo(expectedEffective, 4);
+
+        expect(report.rewardSourceMix).toHaveLength(1);
+        expect(report.rewardSourceMix[0].rewardSource).toBe('base_protocol_yield');
+        expect(report.rewardSourceMix[0].confidence).toBeCloseTo(expectedEffective, 4);
       });
     });
   });
@@ -305,6 +322,14 @@ describe('PortfolioAttributionService', () => {
         },
         generatedAt: '2026-04-01T12:00:00Z',
         dataCompleteness: 0.856789,
+        rewardSourceMix: [
+          {
+            rewardSource: 'base_protocol_yield' as const,
+            contribution: 50.123456,
+            percentage: 40.123456,
+            confidence: 0.856789,
+          },
+        ],
       };
 
       const formatted = formatAttributionReport(mockReport);

--- a/server/src/services/__tests__/recommendationStabilityService.test.ts
+++ b/server/src/services/__tests__/recommendationStabilityService.test.ts
@@ -1,0 +1,60 @@
+import {
+  compareRecommendationSets,
+  generateRecommendationStabilityReport,
+  type RecommendationOutput,
+} from "../recommendationStabilityService";
+
+describe("recommendationStabilityService (#367)", () => {
+  const before: RecommendationOutput[] = [
+    { id: "vaultA", rank: 1, score: 0.5, confidence: 0.8 },
+    { id: "vaultB", rank: 2, score: 0.4, confidence: 0.7 },
+  ];
+
+  const after: RecommendationOutput[] = [
+    { id: "vaultA", rank: 4, score: 0.2, confidence: 0.5 }, // large rank/score/conf shift
+    { id: "vaultB", rank: 2, score: 0.41, confidence: 0.68 }, // small changes
+    { id: "vaultC", rank: 1, score: 0.9, confidence: 0.95 }, // missing in before
+  ];
+
+  it("flags large changes and sorts them", () => {
+    const changes = compareRecommendationSets(before, after, {
+      rankChangeThreshold: 3,
+      scoreChangeThreshold: 0.1,
+      confidenceChangeThreshold: 0.1,
+      topK: 10,
+    });
+
+    const vaultA = changes.find((c) => c.id === "vaultA");
+    const vaultC = changes.find((c) => c.id === "vaultC");
+
+    expect(vaultA).toBeDefined();
+    expect(vaultA?.isLargeChange).toBe(true);
+
+    expect(vaultC).toBeDefined();
+    expect(vaultC?.before).toBeNull();
+    expect(vaultC?.after).not.toBeNull();
+    expect(vaultC?.isLargeChange).toBe(true);
+
+    // The most unstable item by rank delta should come first.
+    expect(changes[0].id).toBe("vaultA");
+  });
+
+  it("generates a stability report with summary + topChanges", () => {
+    const report = generateRecommendationStabilityReport(
+      before,
+      after,
+      { testSetId: "ts-1", beforeRelease: "v1", afterRelease: "v2" },
+      { topK: 2, rankChangeThreshold: 3, scoreChangeThreshold: 0.1, confidenceChangeThreshold: 0.1 },
+    );
+
+    expect(report.baseline.testSetId).toBe("ts-1");
+    expect(report.summary.totalItems).toBe(3);
+    expect(report.summary.largeChanges).toBeGreaterThan(0);
+    expect(report.summary.stabilityScore).toBeGreaterThanOrEqual(0);
+    expect(report.summary.stabilityScore).toBeLessThanOrEqual(1);
+
+    expect(report.topChanges.length).toBeLessThanOrEqual(2);
+    expect(report.topChanges.every((c) => c.isLargeChange)).toBe(true);
+  });
+});
+

--- a/server/src/services/__tests__/strategyStateTransitionAuditService.test.ts
+++ b/server/src/services/__tests__/strategyStateTransitionAuditService.test.ts
@@ -1,0 +1,51 @@
+import {
+  StrategyStateTransitionAuditService,
+  type StrategyLifecycleState,
+} from "../strategyStateTransitionAuditService";
+
+describe("StrategyStateTransitionAuditService (#371)", () => {
+  let service: StrategyStateTransitionAuditService;
+
+  beforeEach(() => {
+    service = new StrategyStateTransitionAuditService();
+    service.reset();
+  });
+
+  it("stores initial state without creating a synthetic edge", () => {
+    const rec = service.recordTransition("s1", "healthy", {
+      type: "health",
+      condition: "initial",
+    });
+    expect(rec).toBeNull();
+    expect(service.getLastState("s1")).toBe("healthy");
+  });
+
+  it("records a valid chain of transitions and produces graph nodes/edges", () => {
+    service.recordTransition(
+      "s1",
+      "frozen",
+      { type: "operator", condition: "freeze_reason=maintenance", operator: "admin" },
+      { fromStateOverride: "degraded" as StrategyLifecycleState },
+    );
+    service.recordTransition("s1", "recovered", { type: "operator", condition: "resume_reason=operator" });
+    service.recordTransition("s1", "healthy", { type: "health", condition: "health_status=healthy" });
+
+    const graph = service.getGraph("s1", 10);
+    expect(graph.nodes.length).toBe(4);
+    expect(graph.edges.length).toBe(3);
+    expect(graph.edges[0].label).toContain("Degraded");
+    expect(graph.edges[2].label).toContain("Recovered");
+  });
+
+  it("rejects invalid transition frozen -> healthy", () => {
+    expect(() =>
+      service.recordTransition(
+        "s1",
+        "healthy",
+        { type: "health", condition: "health_status=healthy" },
+        { fromStateOverride: "frozen" as StrategyLifecycleState },
+      ),
+    ).toThrow(/Invalid lifecycle transition/);
+  });
+});
+

--- a/server/src/services/portfolioAttributionService.ts
+++ b/server/src/services/portfolioAttributionService.ts
@@ -12,6 +12,23 @@ export interface StrategyDecision {
   actualApy?: number;
   duration: number; // days
   confidence: number; // 0-1
+
+  /**
+   * Input completeness hints.
+   * - If `actualApy` is missing, we treat price inputs as incomplete by default.
+   * - For incentive emissions, callers may set `hasEmissionsInputs=false` when emissions data is missing.
+   */
+  hasPriceInputs?: boolean;
+  hasEmissionsInputs?: boolean;
+}
+
+export type RewardSource = 'base_protocol_yield' | 'incentive_emissions' | 'fees' | 'tactical_routing';
+
+export interface RewardSourceMixEntry {
+  rewardSource: RewardSource;
+  contribution: number; // USD value contribution (already confidence-weighted)
+  percentage: number; // of total return
+  confidence: number; // 0-1 (weighted by contribution)
 }
 
 export interface AttributionBreakdown {
@@ -28,6 +45,7 @@ export interface AttributionReport {
   totalReturn: number;
   totalDeposited: number;
   attributionBreakdown: AttributionBreakdown[];
+  rewardSourceMix: RewardSourceMixEntry[];
   timeWindow: {
     start: string;
     end: string;
@@ -52,6 +70,21 @@ const DEFAULT_CONFIG: AttributionConfig = {
   requireMinDecisions: 3,
   weightByAmount: true,
   includeIncompleteData: false,
+};
+
+const INCOMPLETE_INPUT_CONFIDENCE_MULTIPLIER = 0.85;
+
+const REWARD_SOURCE_SHARES: Record<
+  string,
+  Array<{ rewardSource: RewardSource; share: number }>
+> = {
+  initial_routing: [{ rewardSource: 'base_protocol_yield', share: 1 }],
+  hold: [{ rewardSource: 'base_protocol_yield', share: 1 }],
+  rotation: [
+    { rewardSource: 'tactical_routing', share: 0.7 },
+    { rewardSource: 'fees', share: 0.3 },
+  ],
+  incentive_capture: [{ rewardSource: 'incentive_emissions', share: 1 }],
 };
 
 const cache = new NodeCache({
@@ -93,18 +126,33 @@ export class PortfolioAttributionEngine {
       // Calculate returns and attribution
       const attributionBreakdown = this.calculateAttribution(decisions);
       
+      // Assess data completeness.
+      // If we have very few decisions, we treat the overall view as less precise,
+      // but we still return a breakdown so dashboards can explain "incomplete" signals.
+      let dataCompleteness = this.assessDataCompleteness(decisions, startTime, endTime);
+      if (!this.config.includeIncompleteData && decisions.length < this.config.requireMinDecisions) {
+        const scarcityFactor = decisions.length / Math.max(1, this.config.requireMinDecisions);
+        dataCompleteness = Math.min(dataCompleteness, scarcityFactor);
+      }
+
       // Calculate total metrics
-      const totalReturn = attributionBreakdown.reduce((sum, breakdown) => sum + breakdown.contribution, 0);
-      const totalDeposited = decisions.reduce((sum, decision) => sum + decision.amount, 0);
-      
-      // Assess data completeness
-      const dataCompleteness = this.assessDataCompleteness(decisions, startTime, endTime);
+      const totalReturn = attributionBreakdown.reduce(
+        (sum, breakdown) => sum + breakdown.contribution,
+        0,
+      );
+      const totalDeposited = decisions.reduce(
+        (sum, decision) => sum + decision.amount,
+        0,
+      );
+
+      const rewardSourceMix = this.calculateRewardSourceMix(attributionBreakdown);
 
       const report: AttributionReport = {
         walletAddress,
         totalReturn,
         totalDeposited,
         attributionBreakdown,
+        rewardSourceMix,
         timeWindow: { start: startTime, end: endTime },
         generatedAt: new Date().toISOString(),
         dataCompleteness,
@@ -146,6 +194,8 @@ export class PortfolioAttributionEngine {
         actualApy: 6.8,
         duration: 30,
         confidence: 0.85,
+        hasPriceInputs: true,
+        hasEmissionsInputs: true,
       },
       {
         id: "decision_2", 
@@ -157,6 +207,8 @@ export class PortfolioAttributionEngine {
         actualApy: 12.2,
         duration: 25,
         confidence: 0.75,
+        hasPriceInputs: true,
+        hasEmissionsInputs: true,
       },
       {
         id: "decision_3",
@@ -168,6 +220,8 @@ export class PortfolioAttributionEngine {
         actualApy: 8.9,
         duration: 20,
         confidence: 0.90,
+        hasPriceInputs: true,
+        hasEmissionsInputs: true,
       },
       {
         id: "decision_4",
@@ -179,6 +233,8 @@ export class PortfolioAttributionEngine {
         actualApy: 6.7,
         duration: 15,
         confidence: 0.95,
+        hasPriceInputs: true,
+        hasEmissionsInputs: true,
       },
     ];
 
@@ -187,11 +243,33 @@ export class PortfolioAttributionEngine {
       const decisionTime = new Date(decision.timestamp);
       const start = new Date(startTime);
       const end = new Date(endTime);
+      const effectiveConfidence = this.getDecisionEffectiveConfidence(decision);
       
       return decisionTime >= start && 
              decisionTime <= end && 
-             decision.confidence >= this.config.minConfidenceThreshold;
+             (effectiveConfidence >= this.config.minConfidenceThreshold || this.config.includeIncompleteData);
     });
+  }
+
+  private getDecisionEffectiveConfidence(decision: StrategyDecision): number {
+    const baseConfidence = decision.confidence;
+
+    // If we had to fall back to expected APY, price inputs are incomplete by definition.
+    const hasPriceInputs = decision.hasPriceInputs ?? decision.actualApy !== undefined;
+
+    // Incentive capture decisions depend on emissions inputs.
+    const hasEmissionsInputs = decision.hasEmissionsInputs ?? true;
+
+    let effective = baseConfidence;
+    if (!hasPriceInputs) {
+      effective *= INCOMPLETE_INPUT_CONFIDENCE_MULTIPLIER;
+    }
+    if (!hasEmissionsInputs) {
+      effective *= INCOMPLETE_INPUT_CONFIDENCE_MULTIPLIER;
+    }
+
+    // Always clamp to a valid range so UI math stays safe.
+    return Math.max(0, Math.min(1, effective));
   }
 
   /**
@@ -248,8 +326,9 @@ export class PortfolioAttributionEngine {
       const durationFactor = decision.duration / 365; // Convert days to years
       const contribution = annualReturn * durationFactor;
       
-      // Apply confidence weighting
-      const weightedContribution = contribution * decision.confidence;
+      // Apply confidence weighting (but don't overstate precision when inputs are incomplete).
+      const effectiveConfidence = this.getDecisionEffectiveConfidence(decision);
+      const weightedContribution = contribution * effectiveConfidence;
       
       // Apply amount weighting if configured
       return this.config.weightByAmount ? weightedContribution : weightedContribution / decision.amount;
@@ -264,10 +343,11 @@ export class PortfolioAttributionEngine {
     
     const totalWeightedApy = decisions.reduce((sum, decision) => {
       const actualApy = decision.actualApy || decision.expectedApy;
-      return sum + (actualApy * decision.confidence);
+      const effectiveConfidence = this.getDecisionEffectiveConfidence(decision);
+      return sum + (actualApy * effectiveConfidence);
     }, 0);
     
-    const totalConfidence = decisions.reduce((sum, decision) => sum + decision.confidence, 0);
+    const totalConfidence = decisions.reduce((sum, decision) => sum + this.getDecisionEffectiveConfidence(decision), 0);
     
     return totalConfidence > 0 ? totalWeightedApy / totalConfidence : 0;
   }
@@ -278,8 +358,59 @@ export class PortfolioAttributionEngine {
   private calculateAverageConfidence(decisions: StrategyDecision[]): number {
     if (decisions.length === 0) return 0;
     
-    const totalConfidence = decisions.reduce((sum, decision) => sum + decision.confidence, 0);
+    const totalConfidence = decisions.reduce((sum, decision) => sum + this.getDecisionEffectiveConfidence(decision), 0);
     return totalConfidence / decisions.length;
+  }
+
+  private calculateRewardSourceMix(
+    attributionBreakdown: AttributionBreakdown[],
+  ): RewardSourceMixEntry[] {
+    const contributionBySource: Record<RewardSource, number> = {
+      base_protocol_yield: 0,
+      incentive_emissions: 0,
+      fees: 0,
+      tactical_routing: 0,
+    };
+
+    const weightedConfidenceBySource: Record<RewardSource, number> = {
+      base_protocol_yield: 0,
+      incentive_emissions: 0,
+      fees: 0,
+      tactical_routing: 0,
+    };
+
+    for (const breakdown of attributionBreakdown) {
+      const decisionType = breakdown.decisionType;
+      const shares = REWARD_SOURCE_SHARES[decisionType] ?? [
+        { rewardSource: 'tactical_routing' as RewardSource, share: 1 },
+      ];
+
+      for (const { rewardSource, share } of shares) {
+        const shareContribution = breakdown.contribution * share;
+        contributionBySource[rewardSource] += shareContribution;
+        weightedConfidenceBySource[rewardSource] += breakdown.confidence * shareContribution;
+      }
+    }
+
+    const totalContribution = Object.values(contributionBySource).reduce((s, v) => s + v, 0);
+    if (totalContribution <= 0) {
+      return [];
+    }
+
+    const result: RewardSourceMixEntry[] = [];
+    (Object.keys(contributionBySource) as RewardSource[]).forEach((source) => {
+      const contribution = contributionBySource[source];
+      if (contribution <= 0) return;
+      result.push({
+        rewardSource: source,
+        contribution,
+        percentage: (contribution / totalContribution) * 100,
+        confidence:
+          contribution > 0 ? weightedConfidenceBySource[source] / contribution : 0,
+      });
+    });
+
+    return result.sort((a, b) => b.contribution - a.contribution);
   }
 
   /**
@@ -396,6 +527,12 @@ export function formatAttributionReport(report: AttributionReport): AttributionR
       percentage: Math.round(breakdown.percentage * 100) / 100,
       apyImpact: Math.round(breakdown.apyImpact * 100) / 100,
       confidence: Math.round(breakdown.confidence * 100) / 100,
+    })),
+    rewardSourceMix: report.rewardSourceMix.map((entry) => ({
+      ...entry,
+      contribution: Math.round(entry.contribution * 100) / 100,
+      percentage: Math.round(entry.percentage * 100) / 100,
+      confidence: Math.round(entry.confidence * 100) / 100,
     })),
     totalReturn: Math.round(report.totalReturn * 100) / 100,
     totalDeposited: Math.round(report.totalDeposited * 100) / 100,

--- a/server/src/services/recommendationStabilityService.ts
+++ b/server/src/services/recommendationStabilityService.ts
@@ -1,0 +1,173 @@
+export interface RecommendationOutput {
+  /**
+   * Stable identifier for matching items across releases (e.g. vault id).
+   */
+  id: string;
+  rank: number;
+  score: number;
+  confidence: number; // 0-1
+}
+
+export interface RecommendationStabilityChange {
+  id: string;
+  before: RecommendationOutput | null;
+  after: RecommendationOutput | null;
+  rankDelta: number | null;
+  scoreDelta: number | null;
+  confidenceDelta: number | null;
+  isLargeChange: boolean;
+}
+
+export interface RecommendationStabilityConfig {
+  topK: number;
+  rankChangeThreshold: number;
+  scoreChangeThreshold: number;
+  confidenceChangeThreshold: number;
+}
+
+export interface RecommendationStabilityReport {
+  baseline: {
+    testSetId?: string;
+    beforeRelease?: string;
+    afterRelease?: string;
+    comparedAt: string;
+  };
+  summary: {
+    totalItems: number;
+    largeChanges: number;
+    stabilityScore: number; // 0-1, higher = more stable
+  };
+  changes: RecommendationStabilityChange[];
+  topChanges: RecommendationStabilityChange[];
+}
+
+const DEFAULT_CONFIG: RecommendationStabilityConfig = {
+  topK: 10,
+  rankChangeThreshold: 3,
+  scoreChangeThreshold: 0.1,
+  confidenceChangeThreshold: 0.1,
+};
+
+function absFinite(n: number | null): number {
+  if (n === null) return 1;
+  return Math.abs(n);
+}
+
+export function compareRecommendationSets(
+  before: RecommendationOutput[],
+  after: RecommendationOutput[],
+  config: Partial<RecommendationStabilityConfig> = {},
+): RecommendationStabilityChange[] {
+  const cfg: RecommendationStabilityConfig = { ...DEFAULT_CONFIG, ...config };
+
+  const beforeMap = new Map(before.map((r) => [r.id, r]));
+  const afterMap = new Map(after.map((r) => [r.id, r]));
+  const ids = new Set<string>([...beforeMap.keys(), ...afterMap.keys()]);
+
+  const changes: RecommendationStabilityChange[] = [];
+
+  for (const id of ids) {
+    const b = beforeMap.get(id) ?? null;
+    const a = afterMap.get(id) ?? null;
+
+    const rankDelta = b && a ? a.rank - b.rank : null;
+    const scoreDelta = b && a ? a.score - b.score : null;
+    const confidenceDelta = b && a ? a.confidence - b.confidence : null;
+
+    const isMissing = !b || !a;
+
+    const isLargeChange =
+      isMissing ||
+      (rankDelta !== null && Math.abs(rankDelta) >= cfg.rankChangeThreshold) ||
+      (scoreDelta !== null && Math.abs(scoreDelta) >= cfg.scoreChangeThreshold) ||
+      (confidenceDelta !== null &&
+        Math.abs(confidenceDelta) >= cfg.confidenceChangeThreshold);
+
+    changes.push({
+      id,
+      before: b,
+      after: a,
+      rankDelta,
+      scoreDelta,
+      confidenceDelta,
+      isLargeChange,
+    });
+  }
+
+  // Sort: largest absolute rank changes first, then score/confidence deltas.
+  changes.sort((x, y) => {
+    const rankAbsX = absFinite(x.rankDelta);
+    const rankAbsY = absFinite(y.rankDelta);
+    if (rankAbsY !== rankAbsX) return rankAbsY - rankAbsX;
+
+    const scoreAbsX = absFinite(x.scoreDelta);
+    const scoreAbsY = absFinite(y.scoreDelta);
+    if (scoreAbsY !== scoreAbsX) return scoreAbsY - scoreAbsX;
+
+    const confAbsX = absFinite(x.confidenceDelta);
+    const confAbsY = absFinite(y.confidenceDelta);
+    if (confAbsY !== confAbsX) return confAbsY - confAbsX;
+
+    return x.id.localeCompare(y.id);
+  });
+
+  return changes;
+}
+
+export function generateRecommendationStabilityReport(
+  before: RecommendationOutput[],
+  after: RecommendationOutput[],
+  baseline: {
+    testSetId?: string;
+    beforeRelease?: string;
+    afterRelease?: string;
+  } = {},
+  config: Partial<RecommendationStabilityConfig> = {},
+): RecommendationStabilityReport {
+  const cfg: RecommendationStabilityConfig = { ...DEFAULT_CONFIG, ...config };
+
+  const changes = compareRecommendationSets(before, after, cfg);
+  const topChanges = changes.filter((c) => c.isLargeChange).slice(0, cfg.topK);
+
+  const totalItems = changes.length;
+  const largeChanges = changes.filter((c) => c.isLargeChange).length;
+
+  // Stability score: 1 - average normalized change severity.
+  // Missing items count as maximum instability.
+  const severitySum = changes.reduce((sum, c) => {
+    const rankSev =
+      c.rankDelta === null
+        ? 1
+        : Math.min(1, Math.abs(c.rankDelta) / cfg.rankChangeThreshold);
+    const scoreSev =
+      c.scoreDelta === null
+        ? 1
+        : Math.min(1, Math.abs(c.scoreDelta) / cfg.scoreChangeThreshold);
+    const confidenceSev =
+      c.confidenceDelta === null
+        ? 1
+        : Math.min(1, Math.abs(c.confidenceDelta) / cfg.confidenceChangeThreshold);
+
+    // Rank tends to be most user-visible, so slightly weight it.
+    const severity = 0.5 * rankSev + 0.3 * scoreSev + 0.2 * confidenceSev;
+    return sum + severity;
+  }, 0);
+
+  const avgSeverity = totalItems > 0 ? severitySum / totalItems : 0;
+  const stabilityScore = Math.round((1 - avgSeverity) * 1000) / 1000;
+
+  return {
+    baseline: {
+      ...baseline,
+      comparedAt: new Date().toISOString(),
+    },
+    summary: {
+      totalItems,
+      largeChanges,
+      stabilityScore: Math.max(0, Math.min(1, stabilityScore)),
+    },
+    changes,
+    topChanges,
+  };
+}
+

--- a/server/src/services/strategyHealthService.ts
+++ b/server/src/services/strategyHealthService.ts
@@ -1,5 +1,9 @@
 import NodeCache from "node-cache";
 import { freezeService } from "./freezeService";
+import {
+  strategyStateTransitionAuditService,
+  type StrategyLifecycleState,
+} from "./strategyStateTransitionAuditService";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -121,6 +125,27 @@ export class StrategyHealthEngine {
       
       // Determine status
       const status = this.determineHealthStatus(overallScore, metrics);
+
+      // Map health status + freeze flag into lifecycle state for audit graph.
+      const lifecycleState: StrategyLifecycleState = freezeService.isFrozen(strategyId)
+        ? "frozen"
+        : status === "healthy"
+          ? "healthy"
+          : "degraded";
+
+      // #371 append-only lifecycle transition audit (must never block health rendering).
+      try {
+        strategyStateTransitionAuditService.updateFromHealth(
+          strategyId,
+          lifecycleState,
+          `health_status=${status}`,
+        );
+      } catch (err) {
+        console.warn(
+          `Failed to record lifecycle transition for ${strategyId}:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
       
       // Analyze trend
       const trend = this.analyzeTrend(strategyId, overallScore);

--- a/server/src/services/strategyRotationService.ts
+++ b/server/src/services/strategyRotationService.ts
@@ -1,3 +1,10 @@
+import {
+  computeConfidenceScore,
+  computeDecayedFreshnessConfidence,
+  type ConfidenceFactors,
+  type ConfidenceScore,
+} from "./confidenceService";
+
 /**
  * Autonomous Strategy Rotation Service
  *
@@ -34,6 +41,11 @@ export interface RotationCandidate {
   volatility?: number;
   /** Confidence in [0,1]. Defaults to 1 when missing. */
   confidence?: number;
+  /**
+   * Optional factor hints used to render a confidence decomposition.
+   * If omitted, the service will estimate factors from what it has.
+   */
+  confidenceFactors?: Partial<ConfidenceFactors>;
   /** ISO-8601 timestamp of when the score was computed. */
   fetchedAt: string;
 }
@@ -79,6 +91,21 @@ export interface RotationDecision {
   scoreDelta: number | null;
   /** Human-readable detail safe to surface to operators. */
   detail: string;
+  /**
+   * Confidence decomposition for the winning candidate.
+   * Present only when `action === "rotate"` and a candidate was selected.
+   */
+  confidenceBreakdown?: ConfidenceScore;
+  /**
+   * Interprets how “close” the winner was to the min confidence bar.
+   * Present only when `confidenceBreakdown` exists.
+   */
+  confidenceStrength?: "borderline" | "strongly_favored";
+  /**
+   * Short list of driver strings explaining the borderline/strongly-favored
+   * interpretation (safe for UI; no secrets).
+   */
+  confidenceWhy?: string[];
   /** ISO-8601 decision timestamp. */
   evaluatedAt: string;
 }
@@ -196,7 +223,53 @@ export function evaluateRotation(
 
   const best = eligible[0];
 
+  const buildConfidenceInterpretation = (candidate: RotationCandidate): {
+    confidenceBreakdown: ConfidenceScore;
+    confidenceStrength: "borderline" | "strongly_favored";
+    confidenceWhy: string[];
+  } => {
+    const ageMs = now - Date.parse(candidate.fetchedAt);
+    const freshness = computeDecayedFreshnessConfidence(Math.max(0, ageMs)).confidence;
+
+    const defaultOtherFactor = candidate.confidence ?? 1;
+    const liquidityQualityEstimate =
+      candidate.volatility === undefined
+        ? defaultOtherFactor
+        : Math.max(0, Math.min(1, 1 - candidate.volatility / 10));
+
+    const factors: ConfidenceFactors = {
+      freshness,
+      providerAgreement:
+        candidate.confidenceFactors?.providerAgreement ?? defaultOtherFactor,
+      liquidityQuality:
+        candidate.confidenceFactors?.liquidityQuality ?? liquidityQualityEstimate,
+      modelCompleteness:
+        candidate.confidenceFactors?.modelCompleteness ?? defaultOtherFactor,
+    };
+
+    const confidenceBreakdown = computeConfidenceScore(factors);
+    const delta = confidenceBreakdown.score - policy.minConfidence;
+
+    const confidenceStrength =
+      delta < 0.15 ? "borderline" : "strongly_favored";
+
+    // Prefer “why” strings derived from the caveats; this ensures we
+    // explain drivers users can understand without implying guarantees.
+    const confidenceWhy = [
+      `Confidence label: ${confidenceBreakdown.label}.`,
+      ...(confidenceBreakdown.caveats.length > 0
+        ? confidenceBreakdown.caveats.map((c) => c)
+        : [
+            "All confidence factors look strong for this rotation evaluation.",
+          ]),
+    ];
+
+    return { confidenceBreakdown, confidenceStrength, confidenceWhy };
+  };
+
   if (context.currentId === null || context.currentScore === null) {
+    const { confidenceBreakdown, confidenceStrength, confidenceWhy } =
+      buildConfidenceInterpretation(best);
     return {
       action: "rotate",
       reason: "no_current_strategy",
@@ -204,6 +277,9 @@ export function evaluateRotation(
       toId: best.id,
       scoreDelta: best.score,
       detail: `No incumbent strategy; allocating into ${best.id} (score=${best.score}).`,
+      confidenceBreakdown,
+      confidenceStrength,
+      confidenceWhy,
       evaluatedAt: ts,
     };
   }
@@ -221,6 +297,8 @@ export function evaluateRotation(
     };
   }
 
+  const { confidenceBreakdown, confidenceStrength, confidenceWhy } =
+    buildConfidenceInterpretation(best);
   return {
     action: "rotate",
     reason: "candidate_better",
@@ -228,6 +306,9 @@ export function evaluateRotation(
     toId: best.id,
     scoreDelta: delta,
     detail: `Rotating ${context.currentId} → ${best.id} (delta=${delta.toFixed(3)}).`,
+    confidenceBreakdown,
+    confidenceStrength,
+    confidenceWhy,
     evaluatedAt: ts,
   };
 }

--- a/server/src/services/strategyStateTransitionAuditService.ts
+++ b/server/src/services/strategyStateTransitionAuditService.ts
@@ -1,0 +1,208 @@
+export type StrategyLifecycleState =
+  | "healthy"
+  | "degraded"
+  | "frozen"
+  | "recovered";
+
+export interface StrategyStateTransitionTrigger {
+  type: "health" | "operator";
+  /**
+   * Human-readable trigger context (reason/condition) safe for UI tooling.
+   * Must not include secrets.
+   */
+  condition: string;
+  operator?: string;
+}
+
+export interface StrategyStateTransitionRecord {
+  id: string;
+  strategyId: string;
+  fromState: StrategyLifecycleState;
+  toState: StrategyLifecycleState;
+  triggeredAt: string; // ISO-8601
+  trigger: StrategyStateTransitionTrigger;
+}
+
+export interface StrategyStateTransitionNode {
+  id: string;
+  strategyId: string;
+  state: StrategyLifecycleState;
+  timestamp: string; // ISO-8601
+  label: string;
+}
+
+export interface StrategyStateTransitionEdge {
+  id: string;
+  fromNodeId: string;
+  toNodeId: string;
+  transitionId: string;
+  label: string;
+}
+
+export interface StrategyStateTransitionGraph {
+  strategyId: string;
+  nodes: StrategyStateTransitionNode[];
+  edges: StrategyStateTransitionEdge[];
+}
+
+const STATE_ORDER: StrategyLifecycleState[] = ["healthy", "degraded", "frozen", "recovered"];
+
+// State machine for lifecycle auditing.
+// We explicitly disallow some direct edges to keep semantics consistent.
+const ALLOWED_TRANSITIONS: Record<StrategyLifecycleState, StrategyLifecycleState[]> = {
+  healthy: ["healthy", "degraded", "frozen", "recovered"],
+  degraded: ["healthy", "degraded", "frozen", "recovered"],
+  frozen: ["frozen", "recovered"],
+  recovered: ["healthy", "degraded", "frozen", "recovered"],
+};
+
+function formatStateLabel(state: StrategyLifecycleState): string {
+  if (state === "frozen") return "Frozen";
+  if (state === "recovered") return "Recovered";
+  if (state === "degraded") return "Degraded";
+  return "Healthy";
+}
+
+export class StrategyStateTransitionAuditService {
+  private history: StrategyStateTransitionRecord[] = [];
+  private lastStateByStrategy: Map<string, StrategyLifecycleState> = new Map();
+
+  reset(): void {
+    this.history = [];
+    this.lastStateByStrategy.clear();
+  }
+
+  getLastState(strategyId: string): StrategyLifecycleState | undefined {
+    return this.lastStateByStrategy.get(strategyId);
+  }
+
+  recordTransition(
+    strategyId: string,
+    toState: StrategyLifecycleState,
+    trigger: StrategyStateTransitionTrigger,
+    opts?: {
+      /**
+       * Used mainly for testing and backfills.
+       * When omitted, the service uses the last recorded state.
+       */
+      fromStateOverride?: StrategyLifecycleState;
+    },
+  ): StrategyStateTransitionRecord | null {
+    const fromState =
+      opts?.fromStateOverride ?? this.lastStateByStrategy.get(strategyId);
+
+    // Initial state for a strategy: store state but avoid creating a synthetic edge.
+    if (!fromState) {
+      this.lastStateByStrategy.set(strategyId, toState);
+      return null;
+    }
+
+    if (fromState === toState) {
+      return null;
+    }
+
+    const allowed = new Set(ALLOWED_TRANSITIONS[fromState]);
+    if (!allowed.has(toState)) {
+      throw new Error(
+        `Invalid lifecycle transition ${fromState} → ${toState} for strategy ${strategyId}`,
+      );
+    }
+
+    const record: StrategyStateTransitionRecord = {
+      id: `state-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+      strategyId,
+      fromState,
+      toState,
+      triggeredAt: new Date().toISOString(),
+      trigger,
+    };
+
+    this.history.push(record);
+    this.lastStateByStrategy.set(strategyId, toState);
+
+    return record;
+  }
+
+  updateFromHealth(
+    strategyId: string,
+    toState: StrategyLifecycleState,
+    triggerCondition: string,
+  ): StrategyStateTransitionRecord | null {
+    return this.recordTransition(strategyId, toState, {
+      type: "health",
+      condition: triggerCondition,
+    });
+  }
+
+  recordOperatorIntervention(
+    strategyId: string,
+    toState: StrategyLifecycleState,
+    condition: string,
+    operator?: string,
+  ): StrategyStateTransitionRecord | null {
+    return this.recordTransition(strategyId, toState, {
+      type: "operator",
+      condition,
+      operator,
+    });
+  }
+
+  getGraph(strategyId: string, limitTransitions = 100): StrategyStateTransitionGraph {
+    const transitions = this.history.filter((r) => r.strategyId === strategyId);
+    const sliced = transitions.slice(-Math.max(1, limitTransitions));
+
+    const nodes: StrategyStateTransitionNode[] = [];
+    const edges: StrategyStateTransitionEdge[] = [];
+
+    let cursorNodeId: string | null = null;
+    let cursorState: StrategyLifecycleState | null = null;
+
+    for (const t of sliced) {
+      if (!cursorState || cursorState !== t.fromState) {
+        const nodeId = `node-${t.id}-from`;
+        nodes.push({
+          id: nodeId,
+          strategyId,
+          state: t.fromState,
+          timestamp: t.triggeredAt,
+          label: formatStateLabel(t.fromState),
+        });
+        cursorNodeId = nodeId;
+        cursorState = t.fromState;
+      }
+
+      const toNodeId = `node-${t.id}-to`;
+      nodes.push({
+        id: toNodeId,
+        strategyId,
+        state: t.toState,
+        timestamp: t.triggeredAt,
+        label: formatStateLabel(t.toState),
+      });
+
+      edges.push({
+        id: `edge-${t.id}`,
+        fromNodeId: cursorNodeId!,
+        toNodeId,
+        transitionId: t.id,
+        label: `${formatStateLabel(t.fromState)} → ${formatStateLabel(t.toState)}`,
+      });
+
+      cursorNodeId = toNodeId;
+      cursorState = t.toState;
+    }
+
+    return { strategyId, nodes, edges };
+  }
+
+  /**
+   * Useful for tooling/debug. Intended for non-sensitive internal diagnostics.
+   */
+  getHistory(strategyId: string): StrategyStateTransitionRecord[] {
+    return this.history.filter((r) => r.strategyId === strategyId).slice();
+  }
+}
+
+export const strategyStateTransitionAuditService =
+  new StrategyStateTransitionAuditService();
+


### PR DESCRIPTION
## 📌 Summary
Implements the combined set of StellarYield issues (#363, #367, #371, #375) in a single coherent slice: improved vault reward source attribution, release-to-release recommendation stability comparison tooling, strategy lifecycle transition auditing with graph output, and rotation confidence decomposition surfaced in the UI.

## 🎯 Purpose / Motivation
#363/#375 add operator-facing explainability (what drove returns; why a rotation is borderline vs favored).
#367 adds regression detection tooling across releases.
#371 adds append-only strategy lifecycle auditing with provenance and tooling-friendly graph output.

## 🛠️ Changes Made
- #363: Vault Reward Source Mix Analyzer
- Added `rewardSourceMix` to the `/api/analytics/attribution/:walletAddress` response.
- Improved incomplete-input handling by reducing effective confidence when inputs are missing (never overstating precision).
- Added unit tests covering reward source mix math + missing-input confidence behavior.
- Updated `client/src/features/analytics/PortfolioAttributionPanel.tsx` to visualize return attribution by reward source.

- #367: Recommendation Stability Monitor Across Releases
- Added `recommendationStabilityService` with `compareRecommendationSets` + `generateRecommendationStabilityReport`.
- Exposed a release-facing API endpoint: `POST /api/analytics/recommendation-stability/compare`.
- Added unit tests covering large-change detection + report generation.

- #371: Strategy State Transition Audit Graph
- Added `strategyStateTransitionAuditService` (append-only lifecycle transitions).
- Integrated lifecycle recording into:
  - `StrategyHealthEngine` (health-derived transitions)
  - admin freeze/resume endpoints (operator interventions)
- Exposed graph output via API: `GET /api/analytics/strategy-state-transitions/:strategyId`.
- Added unit tests covering valid chains + invalid transition rejection.

- #375: Strategy Rotation Confidence Explorer
- Extended `evaluateRotation` to attach:
  - `confidenceBreakdown` (freshness/trust/liquidity/forecast completeness factors)
  - `confidenceStrength` (“borderline” vs “strongly favored”)
  - `confidenceWhy` (UI-safe explanation from confidence caveats)
- Updated `client/src/pages/leaderboard/StrategyLeaderboard.tsx` with a “Rotation Confidence Explorer” section using `/api/strategies/rotation`.
- Add any key implementation details and trade-offs.

## 🧪 How to Test
1. Backend attribution (#363):
   - Call `GET /api/analytics/attribution/:walletAddress?startTime=...&endTime=...`
   - Confirm the response includes `rewardSourceMix` and `rewardSourceMix[].percentage` sums to ~100.
2. UI reward source mix (#363):
   - Open the dashboard panel that renders `PortfolioAttributionPanel`.
   - Confirm the pie chart is labeled “Return Attribution by Reward Source”.
3. Rotation confidence explorer (#375):
   - Visit the `/strategy-leaderboard` page.
   - Confirm the “Rotation Confidence Explorer” card shows either a rotate decision with `ConfidenceBadge` or “No rotation decisions available”.
4. Strategy state transitions graph (#371):
   - Call `GET /api/analytics/strategy-state-transitions/:strategyId`
   - Confirm graph nodes/edges exist after health updates and operator freeze/resume actions.
5. Recommendation stability compare (#367):
   - Call `POST /api/analytics/recommendation-stability/compare` with JSON body `{ before: [...], after: [...] }`.
   - Confirm response includes `summary` and `topChanges` with largest ranking/score/confidence deltas.

Automated:
- `npx jest src/services/__tests__/portfolioAttributionService.test.ts src/services/__tests__/recommendationStabilityService.test.ts src/services/__tests__/strategyStateTransitionAuditService.test.ts`

## 📸 Screenshots (if applicable)
Optional: screenshots of the updated attribution pie chart (#363) and rotation confidence explorer (#375).

## ⚠️ Breaking Changes
- None.
- If any, describe migration steps clearly.

## 🔗 Related Issues
Closes edehvictor/StellarYield#363
Closes edehvictor/StellarYield#367
Closes edehvictor/StellarYield#371
Closes edehvictor/StellarYield#375

## ✅ Checklist
- [ ] Code builds successfully
- [ ] Tests added/updated
- [ ] No console errors
- [ ] Documentation updated (if needed)
