### PR TITLE
feat(taxes): preview, rotation dry-run CLI, Vercel deploy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,30 @@ node scripts/verify-readme-commands.js
 
 When the pull request workflow fails, GitHub Actions uploads frontend failure artifacts and contract test logs for a short retention window. Open the failed workflow run in the GitHub Actions tab and look for the **Artifacts** section near the bottom of the run summary.
 
+## Vercel Deployment Settings
+
+The frontend is deployed via Vercel. To avoid the recurring `client/client/...` path failures that have appeared in past preview deployments, the Vercel project must be configured against the `client/` directory and not the repository root. The committed `vercel.json` already encodes the install, build, and output paths *relative to that root*, so misconfiguring the Vercel root re-introduces the doubled path.
+
+Use these values when creating or auditing the Vercel project:
+
+| Setting              | Value                                             |
+| -------------------- | ------------------------------------------------- |
+| Framework Preset     | Vite                                              |
+| Root Directory       | `client`                                          |
+| Install Command      | `npm ci --no-audit`                               |
+| Build Command        | `npm run build`                                   |
+| Output Directory     | `dist`                                            |
+| Node.js Version      | 20.x                                              |
+
+These match the committed [`vercel.json`](./vercel.json) at the repository root. Vercel resolves the install/build/output paths *inside* the configured Root Directory, so leaving the root unset (or pointing it at the repo root) makes Vercel run `npm run build` from a folder that has no `build` script.
+
+### Troubleshooting
+
+- **Build fails with `client/client/...` paths.** The Vercel Root Directory is set to the repo root instead of `client`. Update the project settings, redeploy, and confirm the build logs now start with `Running install command: npm ci --no-audit` inside `client/`.
+- **Preview deployment fails while production succeeds (or vice versa).** Compare the **Environment Variables** scoped to Production vs Preview in the Vercel dashboard. Frontend builds only see variables prefixed `VITE_`; anything else is invisible to the client bundle. Re-promote a known-good build from the **Deployments** tab while you investigate.
+- **Custom domain stuck on a stale deployment.** Re-promote the desired deployment from the Vercel dashboard or roll back via the **Deployments → … → Promote to Production** menu. See [`docs/release-checklist.md`](./docs/release-checklist.md) for the documented rollback path.
+- **Missing assets in production.** Confirm the asset lives under `client/public/` (served at the site root) or is imported from `client/src/` so Vite bundles it. Assets placed at the repo root are not picked up by the build.
+
 ## Contributor and Release Docs
 
    The mock API will be available at http://localhost:3001

--- a/client/src/features/taxes/TaxExport.test.tsx
+++ b/client/src/features/taxes/TaxExport.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import TaxExport from "./TaxExport";
+
+vi.mock("../../context/useWallet", () => ({
+  useWallet: () => ({
+    isConnected: true,
+    walletAddress: "GDETESTWALLET123",
+  }),
+}));
+
+vi.mock("../../lib/api", () => ({
+  getApiBaseUrl: () => "http://test",
+}));
+
+const cleanPreview = {
+  rows: [
+    {
+      date: "2026-01-01T00:00:00.000Z",
+      action: "DEPOSIT",
+      asset: "USDC",
+      amount: 100,
+      costBasisUsd: 100,
+      realizedYieldUsd: null,
+      txHash: "tx-1",
+      warnings: [],
+    },
+  ],
+  warnings: [],
+  totals: { costBasisUsd: 100, realizedYieldUsd: 0, rows: 1 },
+  canDownload: true,
+};
+
+const warningPreview = {
+  rows: [
+    {
+      date: null,
+      action: "DEPOSIT",
+      asset: "AQUA",
+      amount: 5,
+      costBasisUsd: null,
+      realizedYieldUsd: null,
+      txHash: "tx-broken",
+      warnings: ["MISSING_TIMESTAMP", "UNSUPPORTED_TOKEN"],
+    },
+  ],
+  warnings: [
+    {
+      code: "MISSING_TIMESTAMP",
+      message: "Row 1 (tx tx-broken) is missing a usable timestamp.",
+      rowIndex: 0,
+    },
+    {
+      code: "UNSUPPORTED_TOKEN",
+      message: 'Row 1 uses unsupported asset "AQUA".',
+      rowIndex: 0,
+    },
+  ],
+  totals: { costBasisUsd: 0, realizedYieldUsd: 0, rows: 1 },
+  canDownload: false,
+};
+
+const respondWith = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+describe("TaxExport", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("requires a preview before the download button activates", () => {
+    render(<TaxExport />);
+    const download = screen.getByRole("button", {
+      name: /preview required before download/i,
+    });
+    expect(download).toBeDisabled();
+  });
+
+  it("renders the preview table and enables download when canDownload is true", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      respondWith(cleanPreview),
+    );
+
+    render(<TaxExport />);
+    fireEvent.click(screen.getByRole("button", { name: /preview tax lots/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tax-preview")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Rows: 1/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /download tax report/i }),
+    ).not.toBeDisabled();
+  });
+
+  it("surfaces warnings and keeps download disabled when canDownload is false", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      respondWith(warningPreview),
+    );
+
+    render(<TaxExport />);
+    fireEvent.click(screen.getByRole("button", { name: /preview tax lots/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tax-preview")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/2 warning\(s\) found/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /resolve warnings to download/i }),
+    ).toBeDisabled();
+  });
+
+  it("shows a user-friendly message when the preview returns 404", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("", { status: 404 }),
+    );
+
+    render(<TaxExport />);
+    fireEvent.click(screen.getByRole("button", { name: /preview tax lots/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /No transactions found/i,
+      );
+    });
+  });
+});

--- a/client/src/features/taxes/TaxExport.tsx
+++ b/client/src/features/taxes/TaxExport.tsx
@@ -1,48 +1,156 @@
 import { useState } from "react";
 import { useWallet } from "../../context/useWallet";
-import { FileSpreadsheet, Download, Loader2, AlertCircle } from "lucide-react";
+import {
+  FileSpreadsheet,
+  Download,
+  Loader2,
+  AlertCircle,
+  Eye,
+  AlertTriangle,
+} from "lucide-react";
 import { getApiBaseUrl } from "../../lib/api";
 
 const API_BASE = getApiBaseUrl();
 
+type PreviewWarningCode =
+  | "MISSING_BASIS"
+  | "MISSING_TIMESTAMP"
+  | "UNSUPPORTED_TOKEN";
+
+interface TaxLotPreviewRow {
+  date: string | null;
+  action: string;
+  asset: string;
+  amount: number;
+  costBasisUsd: number | null;
+  realizedYieldUsd: number | null;
+  txHash: string;
+  warnings: PreviewWarningCode[];
+}
+
+interface PreviewWarning {
+  code: PreviewWarningCode;
+  message: string;
+  rowIndex: number | null;
+}
+
+interface TaxLotPreview {
+  rows: TaxLotPreviewRow[];
+  warnings: PreviewWarning[];
+  totals: {
+    costBasisUsd: number;
+    realizedYieldUsd: number;
+    rows: number;
+  };
+  canDownload: boolean;
+}
+
+function formatUsd(value: number | null): string {
+  if (value === null) return "—";
+  return value.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatAmount(value: number): string {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 7 });
+}
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  try {
+    return new Date(value).toLocaleDateString();
+  } catch {
+    return value;
+  }
+}
+
+const WARNING_LABEL: Record<PreviewWarningCode, string> = {
+  MISSING_BASIS: "missing basis",
+  MISSING_TIMESTAMP: "missing timestamp",
+  UNSUPPORTED_TOKEN: "unsupported token",
+};
+
 /**
  * TaxExport — "Generate Tax Report" UI component for the settings page.
  *
- * Allows users to download their complete transaction history as a
- * standardized CSV file for tax reporting purposes.
+ * The export now happens in two steps. First the user previews their tax
+ * lots (cost basis, realized yield, and any warning conditions). Only when
+ * the preview succeeds without blocking warnings does the CSV download
+ * button activate, so users no longer download silently incomplete files.
  */
 export default function TaxExport() {
   const { isConnected, walletAddress } = useWallet();
-  const [generating, setGenerating] = useState(false);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [downloading, setDownloading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<TaxLotPreview | null>(null);
   const [success, setSuccess] = useState(false);
 
-  const handleExport = async () => {
-    if (!walletAddress) return;
-    setGenerating(true);
+  const resetState = () => {
     setError(null);
     setSuccess(false);
+  };
 
+  const handlePreview = async () => {
+    if (!walletAddress) return;
+    resetState();
+    setPreview(null);
+    setPreviewLoading(true);
     try {
       const res = await fetch(
-        `${API_BASE}/api/users/${encodeURIComponent(walletAddress)}/export`,
+        `${API_BASE}/api/users/${encodeURIComponent(walletAddress)}/export/preview`,
       );
-
       if (res.status === 404) {
         setError("No transactions found for your address.");
         return;
       }
-
       if (res.status === 429) {
         setError("Too many requests. Please try again in a few minutes.");
         return;
       }
+      if (!res.ok) {
+        throw new Error("Failed to generate preview");
+      }
+      const data: TaxLotPreview = await res.json();
+      setPreview(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to generate preview",
+      );
+    } finally {
+      setPreviewLoading(false);
+    }
+  };
 
+  const handleDownload = async () => {
+    if (!walletAddress || !preview?.canDownload) return;
+    resetState();
+    setDownloading(true);
+    try {
+      const res = await fetch(
+        `${API_BASE}/api/users/${encodeURIComponent(walletAddress)}/export`,
+      );
+      if (res.status === 404) {
+        setError("No transactions found for your address.");
+        return;
+      }
+      if (res.status === 409) {
+        setError(
+          "The preview surfaced warnings that block the download. Refresh the preview and resolve them upstream.",
+        );
+        return;
+      }
+      if (res.status === 429) {
+        setError("Too many requests. Please try again in a few minutes.");
+        return;
+      }
       if (!res.ok) {
         throw new Error("Failed to generate export");
       }
 
-      // Download the CSV file
       const blob = await res.blob();
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement("a");
@@ -62,7 +170,7 @@ export default function TaxExport() {
         err instanceof Error ? err.message : "Failed to generate export",
       );
     } finally {
-      setGenerating(false);
+      setDownloading(false);
     }
   };
 
@@ -88,20 +196,26 @@ export default function TaxExport() {
       </div>
 
       <p className="text-gray-400 text-sm mb-6">
-        Download your complete transaction history as a CSV file. Includes all
-        deposits, withdrawals, and yield events with USD values at the time of
-        each transaction.
+        Preview your tax lots — cost basis, realized yield, and any warning
+        conditions — before downloading the CSV. The download only unlocks
+        when the preview is clean.
       </p>
 
       {error && (
-        <div className="flex items-center gap-2 bg-red-500/10 border border-red-500/20 rounded-xl p-3 mb-4">
+        <div
+          role="alert"
+          className="flex items-center gap-2 bg-red-500/10 border border-red-500/20 rounded-xl p-3 mb-4"
+        >
           <AlertCircle className="text-red-400 shrink-0" size={18} />
           <p className="text-red-400 text-sm">{error}</p>
         </div>
       )}
 
       {success && (
-        <div className="flex items-center gap-2 bg-green-500/10 border border-green-500/20 rounded-xl p-3 mb-4">
+        <div
+          role="status"
+          className="flex items-center gap-2 bg-green-500/10 border border-green-500/20 rounded-xl p-3 mb-4"
+        >
           <Download className="text-green-400 shrink-0" size={18} />
           <p className="text-green-400 text-sm">
             Tax report downloaded successfully!
@@ -117,11 +231,112 @@ export default function TaxExport() {
       </div>
 
       <button
-        onClick={() => void handleExport()}
-        disabled={generating}
+        onClick={() => void handlePreview()}
+        disabled={previewLoading}
+        className="w-full py-3 mb-4 bg-white/5 hover:bg-white/10 text-white font-bold rounded-xl transition-all border border-white/10 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+      >
+        {previewLoading ? (
+          <>
+            <Loader2 className="animate-spin" size={18} />
+            Generating Preview...
+          </>
+        ) : (
+          <>
+            <Eye size={18} />
+            {preview ? "Refresh Preview" : "Preview Tax Lots"}
+          </>
+        )}
+      </button>
+
+      {preview && (
+        <div className="mb-6" data-testid="tax-preview">
+          <div className="flex flex-wrap gap-3 mb-3 text-xs text-gray-300">
+            <span>Rows: {preview.totals.rows}</span>
+            <span>Cost basis: {formatUsd(preview.totals.costBasisUsd)}</span>
+            <span>
+              Realized yield: {formatUsd(preview.totals.realizedYieldUsd)}
+            </span>
+          </div>
+
+          {preview.warnings.length > 0 && (
+            <div className="mb-3 rounded-xl border border-yellow-500/30 bg-yellow-500/10 p-3 text-yellow-200 text-xs">
+              <div className="flex items-center gap-2 mb-2 font-semibold">
+                <AlertTriangle size={14} />
+                <span>{preview.warnings.length} warning(s) found</span>
+              </div>
+              <ul className="list-disc pl-5 space-y-1">
+                {preview.warnings.slice(0, 8).map((w, i) => (
+                  <li key={`${w.code}-${i}`}>
+                    <span className="uppercase tracking-wide mr-1">
+                      [{WARNING_LABEL[w.code]}]
+                    </span>
+                    {w.message}
+                  </li>
+                ))}
+                {preview.warnings.length > 8 && (
+                  <li>…and {preview.warnings.length - 8} more.</li>
+                )}
+              </ul>
+            </div>
+          )}
+
+          <div className="overflow-x-auto rounded-xl border border-white/10">
+            <table className="w-full text-xs text-left">
+              <thead className="bg-white/5 text-gray-400 uppercase tracking-wider">
+                <tr>
+                  <th className="px-3 py-2">Date</th>
+                  <th className="px-3 py-2">Action</th>
+                  <th className="px-3 py-2">Asset</th>
+                  <th className="px-3 py-2 text-right">Amount</th>
+                  <th className="px-3 py-2 text-right">Cost basis</th>
+                  <th className="px-3 py-2 text-right">Realized yield</th>
+                  <th className="px-3 py-2">Warnings</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.rows.slice(0, 50).map((row, i) => (
+                  <tr key={`${row.txHash}-${i}`} className="border-t border-white/5">
+                    <td className="px-3 py-2 text-gray-300">
+                      {formatDate(row.date)}
+                    </td>
+                    <td className="px-3 py-2 text-white">{row.action}</td>
+                    <td className="px-3 py-2 text-gray-300">{row.asset}</td>
+                    <td className="px-3 py-2 text-right text-white font-mono">
+                      {formatAmount(row.amount)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-300 font-mono">
+                      {formatUsd(row.costBasisUsd)}
+                    </td>
+                    <td className="px-3 py-2 text-right text-gray-300 font-mono">
+                      {formatUsd(row.realizedYieldUsd)}
+                    </td>
+                    <td className="px-3 py-2 text-yellow-300">
+                      {row.warnings.length === 0
+                        ? "—"
+                        : row.warnings
+                            .map((c) => WARNING_LABEL[c])
+                            .join(", ")}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            {preview.rows.length > 50 && (
+              <p className="px-3 py-2 text-xs text-gray-400">
+                Showing first 50 of {preview.rows.length} rows. The full set
+                is included in the CSV.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+
+      <button
+        onClick={() => void handleDownload()}
+        disabled={!preview?.canDownload || downloading}
         className="w-full py-3 bg-gradient-to-r from-indigo-500 to-purple-600 hover:from-indigo-400 hover:to-purple-500 text-white font-bold rounded-xl transition-all shadow-lg shadow-indigo-500/20 active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
       >
-        {generating ? (
+        {downloading ? (
           <>
             <Loader2 className="animate-spin" size={18} />
             Generating Report...
@@ -129,7 +344,11 @@ export default function TaxExport() {
         ) : (
           <>
             <Download size={18} />
-            Generate Tax Report
+            {preview?.canDownload
+              ? "Download Tax Report"
+              : preview
+                ? "Resolve warnings to download"
+                : "Preview required before download"}
           </>
         )}
       </button>

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -18,6 +18,7 @@ Protected branch merges should be approved by repository maintainers who have th
 ## Deployment Checks
 
 - Confirm the Vercel deployment for `main` finishes successfully.
+- Confirm the Vercel project still points its **Root Directory** at `client`, with Install `npm ci --no-audit`, Build `npm run build`, and Output `dist`. See the "Vercel Deployment Settings" section in [`README.md`](../README.md) for the full table.
 - Confirm any backend deployment job or hosting platform reports a healthy release.
 - Confirm Soroban contract deployment steps, addresses, and network targets match the intended release.
 - Record any updated contract addresses or environment values in the relevant docs or deployment notes.
@@ -38,7 +39,7 @@ Protected branch merges should be approved by repository maintainers who have th
 
 ## Rollback Notes
 
-- If the frontend deployment is unhealthy, redeploy the last known good Vercel build.
+- If the frontend deployment is unhealthy, redeploy the last known good Vercel build via **Deployments → … → Promote to Production** in the Vercel dashboard.
 - If the backend release is unhealthy, roll back to the previous stable deployment in the hosting platform.
 - If a contract deployment is incorrect, stop frontend promotion of the new addresses and follow the contract-specific remediation plan before resuming traffic.
 

--- a/server/scripts/strategyRotationDryRun.ts
+++ b/server/scripts/strategyRotationDryRun.ts
@@ -1,0 +1,130 @@
+#!/usr/bin/env ts-node
+/**
+ * Strategy rotation dry-run CLI (#426).
+ *
+ * Loads candidate data from a JSON file or stdin, evaluates a rotation
+ * decision using the production rotation logic, and prints the decision in
+ * either JSON or human-readable form. The CLI never mutates rotation state
+ * and never enqueues jobs — it only invokes the pure `evaluateRotation`
+ * helper, so it is safe to run locally or in CI.
+ *
+ * Usage:
+ *   npx ts-node server/scripts/strategyRotationDryRun.ts --input fixture.json
+ *   cat fixture.json | npx ts-node server/scripts/strategyRotationDryRun.ts
+ *   npx ts-node server/scripts/strategyRotationDryRun.ts --input fixture.json --format text
+ *
+ * Input JSON schema (see src/services/strategyRotationDryRun.ts):
+ *   {
+ *     "context": { currentId, currentScore, lastRotatedAt, candidates: [...] },
+ *     "policy": { minScoreDifference, cooldownMs, maxDataAgeMs, minConfidence },
+ *     "now": "2026-04-28T12:00:00Z"
+ *   }
+ */
+
+import { readFileSync } from "fs";
+import {
+  formatDryRunResult,
+  parseDryRunInput,
+  runDryRun,
+  type DryRunOutputFormat,
+} from "../src/services/strategyRotationDryRun";
+
+interface CliOptions {
+  inputPath: string | null;
+  format: DryRunOutputFormat;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const opts: CliOptions = { inputPath: null, format: "json" };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--input" || arg === "-i") {
+      const next = argv[i + 1];
+      if (!next || next.startsWith("-")) {
+        throw new Error(`Missing value for ${arg}`);
+      }
+      opts.inputPath = next;
+      i++;
+    } else if (arg.startsWith("--input=")) {
+      opts.inputPath = arg.slice("--input=".length);
+    } else if (arg === "--format" || arg === "-f") {
+      const next = argv[i + 1];
+      if (next !== "json" && next !== "text") {
+        throw new Error(
+          `--format must be either "json" or "text" (got ${JSON.stringify(next)}).`,
+        );
+      }
+      opts.format = next;
+      i++;
+    } else if (arg.startsWith("--format=")) {
+      const value = arg.slice("--format=".length);
+      if (value !== "json" && value !== "text") {
+        throw new Error(
+          `--format must be either "json" or "text" (got ${JSON.stringify(value)}).`,
+        );
+      }
+      opts.format = value;
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  return opts;
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      "Usage: strategyRotationDryRun [--input <path>] [--format json|text]",
+      "",
+      "Options:",
+      "  -i, --input <path>   JSON fixture to evaluate. Reads stdin when omitted.",
+      "  -f, --format <mode>  Output mode: 'json' (default) or 'text'.",
+      "  -h, --help           Show this help text.",
+      "",
+      "This command is read-only: no rotation state is written and no jobs are enqueued.",
+      "",
+    ].join("\n"),
+  );
+}
+
+function readAllStdin(): string {
+  // 0 = stdin; readFileSync handles non-TTY pipes fine.
+  return readFileSync(0, "utf8");
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+
+  const rawText = opts.inputPath
+    ? readFileSync(opts.inputPath, "utf8")
+    : readAllStdin();
+
+  if (!rawText.trim()) {
+    throw new Error(
+      "No input received. Pass --input <path> or pipe JSON via stdin.",
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse input as JSON: ${(err as Error).message}`,
+    );
+  }
+
+  const dryRunInput = parseDryRunInput(parsed);
+  const result = runDryRun(dryRunInput);
+  process.stdout.write(formatDryRunResult(result, opts.format));
+  process.stdout.write("\n");
+}
+
+main().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`strategy-rotation-dry-run: ${message}\n`);
+  process.exit(1);
+});

--- a/server/src/__tests__/strategyRotationDryRun.test.ts
+++ b/server/src/__tests__/strategyRotationDryRun.test.ts
@@ -1,0 +1,146 @@
+import {
+  formatDryRunResult,
+  parseDryRunInput,
+  runDryRun,
+} from "../services/strategyRotationDryRun";
+import { rotationRegistry } from "../services/strategyRotationService";
+
+const FIXED_NOW_ISO = "2026-04-28T12:00:00Z";
+const FIXED_NOW_MS = Date.parse(FIXED_NOW_ISO);
+
+const candidateAt = (offsetMs: number, overrides: Record<string, unknown> = {}) => ({
+  id: "soroswap",
+  name: "Soroswap",
+  score: 5,
+  volatility: 2,
+  confidence: 0.9,
+  fetchedAt: new Date(FIXED_NOW_MS - offsetMs).toISOString(),
+  ...overrides,
+});
+
+describe("parseDryRunInput", () => {
+  it("rejects a top-level non-object payload", () => {
+    expect(() => parseDryRunInput(null)).toThrow(TypeError);
+    expect(() => parseDryRunInput([])).toThrow(TypeError);
+    expect(() => parseDryRunInput("nope")).toThrow(TypeError);
+  });
+
+  it("rejects payloads missing a candidates array", () => {
+    expect(() =>
+      parseDryRunInput({ context: { currentId: null } }),
+    ).toThrow(/candidates/);
+  });
+
+  it("rejects candidates with non-finite scores", () => {
+    expect(() =>
+      parseDryRunInput({
+        context: {
+          candidates: [
+            { id: "blend", score: Number.NaN, fetchedAt: FIXED_NOW_ISO },
+          ],
+        },
+      }),
+    ).toThrow(/score/);
+  });
+
+  it("accepts a minimal valid input", () => {
+    const parsed = parseDryRunInput({
+      context: {
+        candidates: [
+          { id: "blend", score: 1, fetchedAt: FIXED_NOW_ISO, name: "Blend" },
+        ],
+      },
+    });
+    expect(parsed.context.candidates).toHaveLength(1);
+    expect(parsed.context.currentId).toBeNull();
+    expect(parsed.policy).toBeUndefined();
+  });
+});
+
+describe("runDryRun", () => {
+  it("returns hold/no_candidates when context has none", () => {
+    const result = runDryRun({
+      context: {
+        currentId: null,
+        currentScore: null,
+        lastRotatedAt: null,
+        candidates: [],
+      },
+      now: FIXED_NOW_ISO,
+    });
+    expect(result.decision.action).toBe("hold");
+    expect(result.decision.reason).toBe("no_candidates");
+  });
+
+  it("rotates into the best candidate when no incumbent exists", () => {
+    const result = runDryRun({
+      context: {
+        currentId: null,
+        currentScore: null,
+        lastRotatedAt: null,
+        candidates: [candidateAt(60_000, { score: 5 })],
+      },
+      now: FIXED_NOW_ISO,
+    });
+    expect(result.decision.action).toBe("rotate");
+    expect(result.decision.toId).toBe("soroswap");
+  });
+
+  it("honours an overridden policy threshold (skip case)", () => {
+    const result = runDryRun({
+      context: {
+        currentId: "blend",
+        currentScore: 5,
+        lastRotatedAt: new Date(FIXED_NOW_MS - 48 * 60 * 60 * 1000).toISOString(),
+        candidates: [candidateAt(60_000, { id: "soroswap", score: 5.4 })],
+      },
+      policy: { minScoreDifference: 1.0 },
+      now: FIXED_NOW_ISO,
+    });
+    expect(result.decision.action).toBe("hold");
+    expect(result.decision.reason).toBe("candidate_below_threshold");
+    expect(result.policy.minScoreDifference).toBe(1.0);
+  });
+
+  it("does not mutate the shared rotation registry", () => {
+    const before = rotationRegistry.current();
+    runDryRun({
+      context: {
+        currentId: null,
+        currentScore: null,
+        lastRotatedAt: null,
+        candidates: [candidateAt(60_000, { score: 9 })],
+      },
+      now: FIXED_NOW_ISO,
+    });
+    const after = rotationRegistry.current();
+    expect(after).toEqual(before);
+  });
+});
+
+describe("formatDryRunResult", () => {
+  const sample = () =>
+    runDryRun({
+      context: {
+        currentId: null,
+        currentScore: null,
+        lastRotatedAt: null,
+        candidates: [candidateAt(60_000, { score: 9 })],
+      },
+      now: FIXED_NOW_ISO,
+    });
+
+  it("renders a JSON document by default", () => {
+    const json = formatDryRunResult(sample(), "json");
+    const parsed = JSON.parse(json);
+    expect(parsed.decision.action).toBe("rotate");
+    expect(parsed.policy.minScoreDifference).toBeGreaterThan(0);
+    expect(typeof parsed.evaluatedAt).toBe("string");
+  });
+
+  it("renders human-readable text with a no-state-written footer", () => {
+    const text = formatDryRunResult(sample(), "text");
+    expect(text).toMatch(/Action:\s+ROTATE/);
+    expect(text).toMatch(/No state was written/);
+  });
+});

--- a/server/src/__tests__/taxLotPreview.test.ts
+++ b/server/src/__tests__/taxLotPreview.test.ts
@@ -1,0 +1,124 @@
+import {
+  buildTaxLotPreview,
+  previewToCsvRecords,
+  type RawTaxTransaction,
+} from "../services/export/taxLotPreview";
+import { generateCSV } from "../services/export/csvGenerator";
+
+const makeTx = (
+  overrides: Partial<RawTaxTransaction> = {},
+): RawTaxTransaction => ({
+  action: "DEPOSIT",
+  amount: 100,
+  shares: 100,
+  sharePriceAtTx: 1.0,
+  txHash: "tx-1",
+  timestamp: new Date("2026-01-01T00:00:00Z"),
+  asset: "USDC",
+  ...overrides,
+});
+
+describe("buildTaxLotPreview", () => {
+  it("returns an empty preview for no transactions and allows download", () => {
+    const preview = buildTaxLotPreview([]);
+    expect(preview.rows).toEqual([]);
+    expect(preview.warnings).toEqual([]);
+    expect(preview.totals.rows).toBe(0);
+    expect(preview.canDownload).toBe(true);
+  });
+
+  it("computes cost basis for deposits and realized yield for harvests", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({ action: "DEPOSIT", amount: 100, sharePriceAtTx: 1.0, txHash: "d1" }),
+      makeTx({
+        action: "HARVEST",
+        amount: 5,
+        sharePriceAtTx: 1.02,
+        txHash: "h1",
+        timestamp: new Date("2026-01-15T00:00:00Z"),
+      }),
+    ]);
+
+    expect(preview.rows).toHaveLength(2);
+    expect(preview.rows[0].costBasisUsd).toBe(100);
+    expect(preview.rows[0].realizedYieldUsd).toBeNull();
+    expect(preview.rows[1].costBasisUsd).toBeNull();
+    expect(preview.rows[1].realizedYieldUsd).toBeCloseTo(5.1, 5);
+    expect(preview.totals.costBasisUsd).toBe(100);
+    expect(preview.totals.realizedYieldUsd).toBeCloseTo(5.1, 2);
+    expect(preview.canDownload).toBe(true);
+  });
+
+  it("flags missing basis on deposits with non-positive share price", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({ action: "DEPOSIT", sharePriceAtTx: 0, txHash: "d-broken" }),
+    ]);
+    expect(preview.rows[0].warnings).toEqual(["MISSING_BASIS"]);
+    expect(preview.warnings[0].code).toBe("MISSING_BASIS");
+    expect(preview.canDownload).toBe(false);
+  });
+
+  it("flags missing timestamps and refuses download", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({ timestamp: "not-a-date", txHash: "bad-time" }),
+    ]);
+    expect(preview.rows[0].date).toBeNull();
+    expect(preview.rows[0].warnings).toContain("MISSING_TIMESTAMP");
+    expect(preview.canDownload).toBe(false);
+  });
+
+  it("flags unsupported tokens but still records the row", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({ asset: "AQUA", txHash: "aqua-1" }),
+    ]);
+    expect(preview.rows[0].warnings).toContain("UNSUPPORTED_TOKEN");
+    expect(preview.canDownload).toBe(false);
+  });
+
+  it("honours an explicit supported-token list", () => {
+    const preview = buildTaxLotPreview(
+      [makeTx({ asset: "XLM", txHash: "xlm-1" })],
+      { supportedTokens: ["XLM"] },
+    );
+    expect(preview.rows[0].warnings).not.toContain("UNSUPPORTED_TOKEN");
+    expect(preview.canDownload).toBe(true);
+  });
+
+  it("treats harvests without a share price as missing basis", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({
+        action: "HARVEST",
+        sharePriceAtTx: 0,
+        txHash: "h-broken",
+      }),
+    ]);
+    expect(preview.rows[0].warnings).toContain("MISSING_BASIS");
+    expect(preview.canDownload).toBe(false);
+  });
+});
+
+describe("previewToCsvRecords", () => {
+  it("drops rows with missing timestamps so the CSV never has empty dates", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({ txHash: "ok" }),
+      makeTx({ timestamp: undefined, txHash: "missing" }),
+    ]);
+    const records = previewToCsvRecords(preview);
+    expect(records).toHaveLength(1);
+    expect(records[0].txHash).toBe("ok");
+  });
+
+  it("falls back from cost basis to realized yield in the CSV usdValue column", () => {
+    const preview = buildTaxLotPreview([
+      makeTx({
+        action: "WITHDRAWAL",
+        amount: 10,
+        sharePriceAtTx: 2.0,
+        txHash: "w1",
+      }),
+    ]);
+    const records = previewToCsvRecords(preview);
+    expect(records[0].usdValue).toBe(20);
+    expect(generateCSV(records).split("\n")[0]).toMatch(/Date,Action,Asset/);
+  });
+});

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -127,7 +127,8 @@ exportRouter.get(
       res.json(preview);
     } catch (error) {
       console.error(
-        `[export] Failed to build tax preview for ${address}`,
+        "[export] Failed to build tax preview for address: %s",
+        encodeURIComponent(address),
         error,
       );
       sendError(
@@ -188,7 +189,7 @@ exportRouter.get(
       const csvStream = createCSVStream(records);
       csvStream.pipe(res);
     } catch (error) {
-      console.error(`[export] Failed to export data for ${address}`, error);
+      console.error("[export] Failed to export data for address: %s", encodeURIComponent(address), error);
       sendError(res, 500, "EXPORT_FAILED", "Failed to generate export.");
     }
   },

--- a/server/src/routes/export.ts
+++ b/server/src/routes/export.ts
@@ -1,9 +1,11 @@
 import { Router, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
 import {
+  buildTaxLotPreview,
   createCSVStream,
   createExportFilename,
-  type TransactionRecord,
+  previewToCsvRecords,
+  type RawTaxTransaction,
 } from "../services/export";
 import { sendError } from "../utils/errorResponse";
 import { validateWalletAddress } from "../middleware/validation";
@@ -53,11 +55,99 @@ const exportLimiter = rateLimit({
   message: "Too many export requests. Please try again later.",
 });
 
+async function fetchRawTransactions(
+  address: string,
+): Promise<{
+  status: "ok";
+  rawTxs: RawTaxTransaction[];
+} | {
+  status: "error";
+  httpCode: number;
+  errorCode: string;
+  message: string;
+}> {
+  const prisma = await loadPrismaClient();
+  if (!prisma) {
+    return {
+      status: "error",
+      httpCode: 503,
+      errorCode: "DB_UNAVAILABLE",
+      message: "Export database is unavailable.",
+    };
+  }
+
+  try {
+    const count = await prisma.userTransaction.count({
+      where: { walletAddress: address },
+    });
+    if (count === 0) {
+      await prisma.$disconnect?.();
+      return {
+        status: "error",
+        httpCode: 404,
+        errorCode: "NO_TRANSACTIONS",
+        message: "No transactions found for this address.",
+      };
+    }
+
+    const rawTxs = await prisma.userTransaction.findMany({
+      where: { walletAddress: address },
+      orderBy: { timestamp: "asc" },
+    });
+    await prisma.$disconnect?.();
+    return { status: "ok", rawTxs };
+  } catch (error) {
+    await prisma.$disconnect?.();
+    throw error;
+  }
+}
+
+/**
+ * GET /api/users/:address/export/preview
+ *
+ * Returns a JSON preview of the user's tax lots: cost basis, realized
+ * yield, per-row and global warnings, and a `canDownload` flag. The
+ * client renders this as a table before allowing the CSV download so
+ * users can verify the export and so missing-basis / missing-timestamp /
+ * unsupported-token cases surface up-front.
+ */
+exportRouter.get(
+  "/:address/export/preview",
+  exportLimiter,
+  validateWalletAddress,
+  async (req: Request, res: Response) => {
+    const { address } = req.params;
+    try {
+      const fetched = await fetchRawTransactions(address);
+      if (fetched.status === "error") {
+        sendError(res, fetched.httpCode, fetched.errorCode, fetched.message);
+        return;
+      }
+      const preview = buildTaxLotPreview(fetched.rawTxs);
+      res.json(preview);
+    } catch (error) {
+      console.error(
+        `[export] Failed to build tax preview for ${address}`,
+        error,
+      );
+      sendError(
+        res,
+        500,
+        "EXPORT_PREVIEW_FAILED",
+        "Failed to build tax export preview.",
+      );
+    }
+  },
+);
+
 /**
  * GET /api/users/:address/export
  *
  * Fetches all historical vault events for a user, transforms them
- * into a standardized CSV, and streams it back as a download.
+ * into a standardized CSV, and streams it back as a download. The
+ * route refuses to stream when the tax-lot preview would surface
+ * blocking warnings (missing basis / missing timestamp / unsupported
+ * token) so users do not receive a silently incomplete CSV.
  *
  * Uses streaming to handle users with thousands of transactions.
  */
@@ -68,44 +158,26 @@ exportRouter.get(
   async (req: Request, res: Response) => {
     const { address } = req.params;
 
-    const prisma = await loadPrismaClient();
-
-    if (!prisma) {
-      sendError(res, 503, "DB_UNAVAILABLE", "Export database is unavailable.");
-      return;
-    }
-
     try {
-      // Check transaction count first
-      const count = await prisma.userTransaction.count({
-        where: { walletAddress: address },
-      });
-
-      if (count === 0) {
-        await prisma.$disconnect?.();
-        sendError(res, 404, "NO_TRANSACTIONS", "No transactions found for this address.");
+      const fetched = await fetchRawTransactions(address);
+      if (fetched.status === "error") {
+        sendError(res, fetched.httpCode, fetched.errorCode, fetched.message);
         return;
       }
 
-      // Fetch all transactions for the user
-      const rawTxs = await prisma.userTransaction.findMany({
-        where: { walletAddress: address },
-        orderBy: { timestamp: "asc" },
-      });
+      const preview = buildTaxLotPreview(fetched.rawTxs);
+      if (!preview.canDownload) {
+        sendError(
+          res,
+          409,
+          "PREVIEW_WARNINGS_PRESENT",
+          "Tax export has blocking warnings; resolve them via the preview endpoint before downloading.",
+        );
+        return;
+      }
 
-      await prisma.$disconnect?.();
+      const records = previewToCsvRecords(preview);
 
-      // Transform to standardized CSV records
-      const records: TransactionRecord[] = rawTxs.map((tx) => ({
-        date: new Date(tx.timestamp).toISOString(),
-        action: tx.action,
-        asset: "USDC",
-        amount: tx.amount,
-        usdValue: tx.amount * tx.sharePriceAtTx,
-        txHash: tx.txHash,
-      }));
-
-      // Set response headers for CSV download
       const filename = createExportFilename(address);
       res.setHeader("Content-Type", "text/csv; charset=utf-8");
       res.setHeader(
@@ -113,7 +185,6 @@ exportRouter.get(
         `attachment; filename="${filename}"`,
       );
 
-      // Stream the CSV to avoid memory issues with large datasets
       const csvStream = createCSVStream(records);
       csvStream.pipe(res);
     } catch (error) {

--- a/server/src/services/export/index.ts
+++ b/server/src/services/export/index.ts
@@ -5,3 +5,16 @@ export {
 } from "./csvGenerator";
 
 export type { TransactionRecord } from "./csvGenerator";
+
+export {
+  buildTaxLotPreview,
+  previewToCsvRecords,
+} from "./taxLotPreview";
+
+export type {
+  RawTaxTransaction,
+  TaxLotPreview,
+  TaxLotPreviewRow,
+  PreviewWarning,
+  PreviewWarningCode,
+} from "./taxLotPreview";

--- a/server/src/services/export/taxLotPreview.ts
+++ b/server/src/services/export/taxLotPreview.ts
@@ -1,0 +1,217 @@
+/**
+ * Tax Lot Export Preview Builder (#424)
+ *
+ * Converts raw vault transactions into a contributor-friendly preview that
+ * surfaces cost basis, realized yield, and warning conditions *before* a
+ * user downloads the CSV. The preview is meant to be rendered as a table
+ * in the client so users can verify their export, while warnings explain
+ * the cases where the underlying CSV would still be technically valid but
+ * tax-incomplete.
+ */
+
+import type { TransactionRecord } from "./csvGenerator";
+
+export type RawTaxAction = "DEPOSIT" | "WITHDRAWAL" | "HARVEST" | string;
+
+export interface RawTaxTransaction {
+  action: RawTaxAction;
+  amount: number;
+  shares: number;
+  sharePriceAtTx: number;
+  txHash: string;
+  /** Timestamp is intentionally `unknown` so we can detect malformed rows. */
+  timestamp: unknown;
+  /** Symbol of the asset; defaults to USDC when missing for backwards compat. */
+  asset?: string;
+}
+
+export type PreviewWarningCode =
+  | "MISSING_BASIS"
+  | "MISSING_TIMESTAMP"
+  | "UNSUPPORTED_TOKEN";
+
+export interface PreviewWarning {
+  code: PreviewWarningCode;
+  message: string;
+  /** Index into `rows` that triggered the warning (or `null` if global). */
+  rowIndex: number | null;
+}
+
+export interface TaxLotPreviewRow {
+  /** ISO-8601 timestamp string, or `null` when the source row was missing one. */
+  date: string | null;
+  action: string;
+  asset: string;
+  amount: number;
+  /** USD cost basis (acquisition value). `null` when we cannot derive it. */
+  costBasisUsd: number | null;
+  /** Realized yield (USD) for the row. `null` when not applicable. */
+  realizedYieldUsd: number | null;
+  txHash: string;
+  /** Warning codes that apply to this row, in the order they were detected. */
+  warnings: PreviewWarningCode[];
+}
+
+export interface TaxLotPreview {
+  rows: TaxLotPreviewRow[];
+  warnings: PreviewWarning[];
+  totals: {
+    costBasisUsd: number;
+    realizedYieldUsd: number;
+    rows: number;
+  };
+  /**
+   * Whether the underlying CSV can be downloaded without losing data. The
+   * client should only enable the download button when this is `true`.
+   */
+  canDownload: boolean;
+}
+
+const DEFAULT_SUPPORTED_TOKENS = new Set(["USDC"]);
+
+const ZERO_BASIS_PRICE = 0;
+
+const isFiniteNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const toIsoDate = (value: unknown): string | null => {
+  if (value instanceof Date) {
+    const t = value.getTime();
+    return Number.isFinite(t) ? value.toISOString() : null;
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    const t = date.getTime();
+    return Number.isFinite(t) ? date.toISOString() : null;
+  }
+  return null;
+};
+
+/**
+ * Build a tax-lot preview from raw transactions.
+ *
+ * The function never throws on a malformed row — instead it emits the row
+ * with the relevant warning code and toggles `canDownload` off so the
+ * client can guide the user to fix the export upstream.
+ */
+export function buildTaxLotPreview(
+  rawTxs: RawTaxTransaction[],
+  options: { supportedTokens?: Iterable<string> } = {},
+): TaxLotPreview {
+  const supported = options.supportedTokens
+    ? new Set(Array.from(options.supportedTokens, (t) => t.toUpperCase()))
+    : DEFAULT_SUPPORTED_TOKENS;
+
+  const rows: TaxLotPreviewRow[] = [];
+  const warnings: PreviewWarning[] = [];
+  let totalCostBasis = 0;
+  let totalRealizedYield = 0;
+  let canDownload = true;
+
+  rawTxs.forEach((tx, rowIndex) => {
+    const rowWarnings: PreviewWarningCode[] = [];
+
+    const date = toIsoDate(tx.timestamp);
+    if (date === null) {
+      rowWarnings.push("MISSING_TIMESTAMP");
+      warnings.push({
+        code: "MISSING_TIMESTAMP",
+        message: `Row ${rowIndex + 1} (tx ${tx.txHash}) is missing a usable timestamp.`,
+        rowIndex,
+      });
+      canDownload = false;
+    }
+
+    const asset = (tx.asset ?? "USDC").toUpperCase();
+    if (!supported.has(asset)) {
+      rowWarnings.push("UNSUPPORTED_TOKEN");
+      warnings.push({
+        code: "UNSUPPORTED_TOKEN",
+        message: `Row ${rowIndex + 1} uses unsupported asset "${asset}"; values are passed through but may need manual classification.`,
+        rowIndex,
+      });
+      canDownload = false;
+    }
+
+    const action = String(tx.action).toUpperCase();
+    const hasSharePrice =
+      isFiniteNumber(tx.sharePriceAtTx) && tx.sharePriceAtTx > ZERO_BASIS_PRICE;
+
+    let costBasisUsd: number | null = null;
+    let realizedYieldUsd: number | null = null;
+
+    if (action === "DEPOSIT") {
+      if (!hasSharePrice) {
+        rowWarnings.push("MISSING_BASIS");
+        warnings.push({
+          code: "MISSING_BASIS",
+          message: `Deposit ${tx.txHash} is missing a share price at acquisition; cost basis cannot be derived.`,
+          rowIndex,
+        });
+        canDownload = false;
+      } else if (isFiniteNumber(tx.amount)) {
+        costBasisUsd = tx.amount * tx.sharePriceAtTx;
+        totalCostBasis += costBasisUsd;
+      }
+    } else if (action === "HARVEST" || action === "WITHDRAWAL") {
+      if (hasSharePrice && isFiniteNumber(tx.amount)) {
+        realizedYieldUsd = tx.amount * tx.sharePriceAtTx;
+        totalRealizedYield += realizedYieldUsd;
+      } else if (action === "HARVEST") {
+        // A harvest with no price is treated as a missing basis for tax
+        // purposes: we cannot value the gain.
+        rowWarnings.push("MISSING_BASIS");
+        warnings.push({
+          code: "MISSING_BASIS",
+          message: `Harvest ${tx.txHash} is missing a share price; realized yield cannot be valued.`,
+          rowIndex,
+        });
+        canDownload = false;
+      }
+    }
+
+    rows.push({
+      date,
+      action,
+      asset,
+      amount: isFiniteNumber(tx.amount) ? tx.amount : 0,
+      costBasisUsd,
+      realizedYieldUsd,
+      txHash: tx.txHash,
+      warnings: rowWarnings,
+    });
+  });
+
+  return {
+    rows,
+    warnings,
+    totals: {
+      costBasisUsd: Number(totalCostBasis.toFixed(2)),
+      realizedYieldUsd: Number(totalRealizedYield.toFixed(2)),
+      rows: rows.length,
+    },
+    canDownload,
+  };
+}
+
+/**
+ * Convert preview rows into the legacy `TransactionRecord` shape consumed
+ * by `generateCSV` / `createCSVStream`. Rows with a missing timestamp are
+ * skipped (callers should refuse to download in that case) so the CSV
+ * never contains an empty `Date` column.
+ */
+export function previewToCsvRecords(
+  preview: TaxLotPreview,
+): TransactionRecord[] {
+  return preview.rows
+    .filter((row) => row.date !== null)
+    .map((row) => ({
+      date: row.date as string,
+      action: row.action,
+      asset: row.asset,
+      amount: row.amount,
+      usdValue:
+        row.costBasisUsd ?? row.realizedYieldUsd ?? row.amount,
+      txHash: row.txHash,
+    }));
+}

--- a/server/src/services/strategyRotationDryRun.ts
+++ b/server/src/services/strategyRotationDryRun.ts
@@ -1,0 +1,216 @@
+import {
+  DEFAULT_ROTATION_POLICY,
+  evaluateRotation,
+  type RotationCandidate,
+  type RotationContext,
+  type RotationDecision,
+  type RotationPolicy,
+} from "./strategyRotationService";
+
+/**
+ * Pure helpers backing the `strategy-rotation-dry-run` CLI.
+ *
+ * The CLI never writes to the rotation registry, never enqueues background
+ * jobs, and never mutates any service state — it only invokes
+ * `evaluateRotation` and formats the result. Anything that *would* require
+ * mutation belongs in the regular rotation job, not here.
+ */
+
+export type DryRunOutputFormat = "json" | "text";
+
+export interface DryRunInput {
+  context: RotationContext;
+  policy?: Partial<RotationPolicy>;
+  /** ISO-8601 evaluation timestamp. Defaults to "now" when omitted. */
+  now?: string;
+}
+
+export interface DryRunResult {
+  decision: RotationDecision;
+  policy: RotationPolicy;
+  evaluatedAtMs: number;
+}
+
+/**
+ * Parse and validate the JSON payload accepted by the dry-run CLI.
+ *
+ * Throws a `TypeError` describing the first problem encountered so the CLI
+ * can surface a clean error message to the operator.
+ */
+export function parseDryRunInput(raw: unknown): DryRunInput {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new TypeError(
+      "Dry-run input must be a JSON object with a `context` field.",
+    );
+  }
+  const input = raw as Record<string, unknown>;
+  const context = input.context;
+  if (
+    context === null ||
+    typeof context !== "object" ||
+    Array.isArray(context)
+  ) {
+    throw new TypeError("`context` must be an object.");
+  }
+  const ctx = context as Record<string, unknown>;
+  if (!Array.isArray(ctx.candidates)) {
+    throw new TypeError("`context.candidates` must be an array.");
+  }
+  for (const [index, candidate] of ctx.candidates.entries()) {
+    if (
+      candidate === null ||
+      typeof candidate !== "object" ||
+      Array.isArray(candidate)
+    ) {
+      throw new TypeError(`context.candidates[${index}] must be an object.`);
+    }
+    const c = candidate as Record<string, unknown>;
+    if (typeof c.id !== "string" || c.id.length === 0) {
+      throw new TypeError(
+        `context.candidates[${index}].id must be a non-empty string.`,
+      );
+    }
+    if (typeof c.score !== "number" || !Number.isFinite(c.score)) {
+      throw new TypeError(
+        `context.candidates[${index}].score must be a finite number.`,
+      );
+    }
+    if (typeof c.fetchedAt !== "string") {
+      throw new TypeError(
+        `context.candidates[${index}].fetchedAt must be an ISO-8601 string.`,
+      );
+    }
+  }
+
+  if (
+    ctx.currentId !== null &&
+    ctx.currentId !== undefined &&
+    typeof ctx.currentId !== "string"
+  ) {
+    throw new TypeError("`context.currentId` must be a string or null.");
+  }
+  if (
+    ctx.currentScore !== null &&
+    ctx.currentScore !== undefined &&
+    (typeof ctx.currentScore !== "number" || !Number.isFinite(ctx.currentScore))
+  ) {
+    throw new TypeError(
+      "`context.currentScore` must be a finite number or null.",
+    );
+  }
+  if (
+    ctx.lastRotatedAt !== null &&
+    ctx.lastRotatedAt !== undefined &&
+    typeof ctx.lastRotatedAt !== "string"
+  ) {
+    throw new TypeError("`context.lastRotatedAt` must be a string or null.");
+  }
+
+  const policy = input.policy;
+  if (
+    policy !== undefined &&
+    (policy === null || typeof policy !== "object" || Array.isArray(policy))
+  ) {
+    throw new TypeError("`policy` must be an object when provided.");
+  }
+  const now = input.now;
+  if (now !== undefined && typeof now !== "string") {
+    throw new TypeError("`now` must be an ISO-8601 string when provided.");
+  }
+
+  return {
+    context: {
+      currentId: (ctx.currentId as string | null | undefined) ?? null,
+      currentScore: (ctx.currentScore as number | null | undefined) ?? null,
+      lastRotatedAt: (ctx.lastRotatedAt as string | null | undefined) ?? null,
+      candidates: ctx.candidates as RotationCandidate[],
+    },
+    policy: policy as Partial<RotationPolicy> | undefined,
+    now: now as string | undefined,
+  };
+}
+
+/**
+ * Run the rotation dry-run for an already-parsed input.
+ *
+ * This function never touches the singleton `rotationRegistry` and never
+ * mutates the supplied context; it returns a fresh `RotationDecision` plus
+ * the effective policy so the CLI can echo what it actually ran with.
+ */
+export function runDryRun(input: DryRunInput): DryRunResult {
+  const policy: RotationPolicy = {
+    ...DEFAULT_ROTATION_POLICY,
+    ...(input.policy ?? {}),
+  };
+
+  const nowMs =
+    input.now !== undefined && Number.isFinite(Date.parse(input.now))
+      ? Date.parse(input.now)
+      : Date.now();
+
+  const decision = evaluateRotation(input.context, policy, nowMs);
+  return { decision, policy, evaluatedAtMs: nowMs };
+}
+
+/**
+ * Render a dry-run result as either JSON or a human-readable text block.
+ */
+export function formatDryRunResult(
+  result: DryRunResult,
+  format: DryRunOutputFormat,
+): string {
+  if (format === "json") {
+    return JSON.stringify(
+      {
+        decision: result.decision,
+        policy: result.policy,
+        evaluatedAt: new Date(result.evaluatedAtMs).toISOString(),
+      },
+      null,
+      2,
+    );
+  }
+
+  const { decision, policy } = result;
+  const lines: string[] = [];
+  lines.push("Strategy Rotation Dry-Run");
+  lines.push("=========================");
+  lines.push(`Action:           ${decision.action.toUpperCase()}`);
+  lines.push(`Reason:           ${decision.reason}`);
+  lines.push(`From:             ${decision.fromId ?? "(none)"}`);
+  lines.push(`To:               ${decision.toId ?? "(none)"}`);
+  lines.push(
+    `Score delta:      ${
+      decision.scoreDelta === null
+        ? "n/a"
+        : decision.scoreDelta.toFixed(3)
+    }`,
+  );
+  lines.push(`Evaluated at:     ${decision.evaluatedAt}`);
+  lines.push(`Detail:           ${decision.detail}`);
+  if (decision.confidenceBreakdown) {
+    lines.push(
+      `Confidence:       ${decision.confidenceBreakdown.label} (score=${decision.confidenceBreakdown.score.toFixed(
+        3,
+      )})`,
+    );
+  }
+  if (decision.confidenceStrength) {
+    lines.push(`Confidence band:  ${decision.confidenceStrength}`);
+  }
+  if (decision.confidenceWhy && decision.confidenceWhy.length > 0) {
+    lines.push("Why:");
+    for (const why of decision.confidenceWhy) {
+      lines.push(`  - ${why}`);
+    }
+  }
+  lines.push("");
+  lines.push("Policy used:");
+  lines.push(`  minScoreDifference: ${policy.minScoreDifference}`);
+  lines.push(`  cooldownMs:         ${policy.cooldownMs}`);
+  lines.push(`  maxDataAgeMs:       ${policy.maxDataAgeMs}`);
+  lines.push(`  minConfidence:      ${policy.minConfidence}`);
+  lines.push("");
+  lines.push("No state was written and no jobs were enqueued.");
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- **#424 — Tax-lot export preview.** New `GET /api/users/:address/export/preview` endpoint returns cost basis, realized yield, per-row warnings, and a `canDownload` flag. The CSV download endpoint refuses to stream when the preview has blocking warnings. The settings page `TaxExport` component renders the preview as a table and only enables the download button when the preview is clean.
- **#426 — Strategy rotation dry-run CLI.** New `server/scripts/strategyRotationDryRun.ts` reads candidate JSON from a file or stdin and prints the rotation decision in either JSON or human-readable form. The script never mutates the rotation registry and never enqueues jobs; it only invokes the pure `evaluateRotation` helper.
- **#429 — Vercel deploy docs.** README and release checklist now document the required Vercel project root (`client`), install / build / output settings, and troubleshooting notes for the recurring `client/client/...` preview-path failures.

#283 (Multi-Asset Deposit Routing Recommendation API) was assigned to me but is scoped at 3–4 weeks of work and is intentionally **not** included in this PR — happy to take it on as a follow-up.

## Closes
- closes #424
- closes #426
- closes #429

## Test plan
- [x] `server`: `npx jest --testPathPatterns=\"taxLotPreview|strategyRotation\"` — 37/37 passing.
- [x] `client`: `npx vitest run src/features/taxes/TaxExport.test.tsx` — 4/4 passing (covers no-preview gating, clean preview, warning preview, 404 handling).
- [x] CLI smoke-test: piping a sample fixture via stdin returns the expected `rotate` decision in both `--format json` and `--format text`.
- [x] Docs: README and release checklist edits keep examples consistent with the existing `vercel.json`.
- [ ] Reviewers: please verify the preview table styling matches the rest of the settings page.

Pre-existing TypeScript errors in `src/config/protocols.ts` and `src/__tests__/fragmentation.test.ts` (etc.) exist on `main` and are not introduced here.
