### PR TITLE
feat(stellaryield): export filename standardization + referral share-link UX

### DIFF
--- a/client/src/features/analytics/ExportBundle.tsx
+++ b/client/src/features/analytics/ExportBundle.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Download, FileJson, Loader2, CheckCircle2, AlertCircle } from 'lucide-react';
+import { buildExportFilename } from './exportFilename';
 
 export const ExportBundle: React.FC = () => {
   const [isExporting, setIsExporting] = useState(false);
@@ -17,7 +18,7 @@ export const ExportBundle: React.FC = () => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `stellar-yield-snapshot-${new Date().toISOString().split('T')[0]}.json`;
+      a.download = buildExportFilename('snapshot', 'json');
       document.body.appendChild(a);
       a.click();
       window.URL.revokeObjectURL(url);

--- a/client/src/features/analytics/exportFilename.test.ts
+++ b/client/src/features/analytics/exportFilename.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { buildExportFilename, sanitizeFilenameSegment } from "./exportFilename";
+
+describe("buildExportFilename", () => {
+  it("uses the standardized stellaryield prefix and report type", () => {
+    expect(buildExportFilename("snapshot")).toMatch(/^stellaryield-snapshot-/);
+  });
+
+  it("includes the current date and the requested extension", () => {
+    const today = new Date().toISOString().split("T")[0];
+    const name = buildExportFilename("snapshot", "json");
+    expect(name).toContain(today);
+    expect(name).toMatch(/\.json$/);
+  });
+
+  it("produces no unsafe characters even with messy input", () => {
+    const name = buildExportFilename("weird report!!", "c sv");
+    expect(name).not.toMatch(/[^a-zA-Z0-9._-]/);
+  });
+});
+
+describe("sanitizeFilenameSegment", () => {
+  it("replaces unsafe characters and collapses dots (no traversal)", () => {
+    const out = sanitizeFilenameSegment("a/../ b");
+    expect(out).not.toContain("..");
+    expect(out).not.toMatch(/[^a-zA-Z0-9._-]/);
+  });
+});

--- a/client/src/features/analytics/exportFilename.ts
+++ b/client/src/features/analytics/exportFilename.ts
@@ -1,0 +1,41 @@
+/**
+ * Client-side standardized export filenames, mirroring the server's
+ * `createExportFilename` convention:
+ *
+ *   stellaryield-<reportType>-<environment>-<YYYY-MM-DD>.<ext>
+ *
+ * Keeps downloaded files predictable and filesystem-safe across the app.
+ */
+
+/** Replace unsafe characters with a hyphen and collapse runs of dots. */
+export function sanitizeFilenameSegment(value: string): string {
+  return String(value)
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/\.{2,}/g, ".")
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/** Resolve the current frontend environment for filename tagging. */
+function currentEnvironment(): string {
+  const env =
+    (import.meta.env.VITE_STELLAR_NETWORK as string | undefined) ??
+    (import.meta.env.MODE as string | undefined) ??
+    "production";
+  return sanitizeFilenameSegment(env.toLowerCase()) || "production";
+}
+
+/**
+ * Build a standardized, filesystem-safe export filename.
+ *
+ * @param reportType - Logical report name, e.g. "snapshot" or "tax-report".
+ * @param extension - File extension without the dot (default "json").
+ */
+export function buildExportFilename(
+  reportType: string,
+  extension = "json",
+): string {
+  const type = sanitizeFilenameSegment(reportType) || "export";
+  const ext = sanitizeFilenameSegment(extension) || "json";
+  const date = new Date().toISOString().split("T")[0];
+  return `stellaryield-${type}-${currentEnvironment()}-${date}.${ext}`;
+}

--- a/client/src/features/referrals/ReferralDashboard.tsx
+++ b/client/src/features/referrals/ReferralDashboard.tsx
@@ -11,6 +11,7 @@ import {
   UserPlus,
 } from "lucide-react";
 import { getApiBaseUrl } from "../../lib/api";
+import { resolveAppBaseUrl, buildReferralLink } from "./referralLink";
 
 interface ReferralData {
   referredTvl: number;
@@ -20,7 +21,16 @@ interface ReferralData {
 }
 
 const API_BASE = getApiBaseUrl();
-const APP_URL = import.meta.env.VITE_APP_URL || "https://stellaryield.vercel.app";
+const { url: APP_URL, isFallback: APP_URL_IS_FALLBACK } = resolveAppBaseUrl(
+  import.meta.env.VITE_APP_URL as string | undefined,
+);
+if (APP_URL_IS_FALLBACK) {
+  // Don't crash when VITE_APP_URL is unset — fall back to the default domain
+  // and warn so misconfigured deployments are noticed.
+  console.warn(
+    "[referrals] VITE_APP_URL is not configured; referral links use the default domain.",
+  );
+}
 
 /**
  * ReferralDashboard — User dashboard for the referral & affiliate system.
@@ -34,6 +44,7 @@ export default function ReferralDashboard() {
   const [loading, setLoading] = useState(false);
   const [claiming, setClaiming] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [claimSuccess, setClaimSuccess] = useState(false);
 
@@ -42,9 +53,7 @@ export default function ReferralDashboard() {
   const [submitSuccess, setSubmitSuccess] = useState(false);
   const [referralCodeInput, setReferralCodeInput] = useState("");
 
-  const referralLink = walletAddress
-    ? `${APP_URL}/?ref=${encodeURIComponent(walletAddress)}`
-    : "";
+  const referralLink = buildReferralLink(APP_URL, walletAddress ?? "");
 
   const fetchReferralData = useCallback(async () => {
     if (!walletAddress) return;
@@ -74,20 +83,29 @@ export default function ReferralDashboard() {
   }, [isConnected, walletAddress, fetchReferralData]);
 
   const handleCopy = async () => {
+    if (!referralLink) return;
+    setCopyError(false);
     try {
       await navigator.clipboard.writeText(referralLink);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch {
-      // Fallback for older browsers
-      const textArea = document.createElement("textarea");
-      textArea.value = referralLink;
-      document.body.appendChild(textArea);
-      textArea.select();
-      document.execCommand("copy");
-      document.body.removeChild(textArea);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      // Fallback for browsers without the async clipboard API.
+      try {
+        const textArea = document.createElement("textarea");
+        textArea.value = referralLink;
+        document.body.appendChild(textArea);
+        textArea.select();
+        const ok = document.execCommand("copy");
+        document.body.removeChild(textArea);
+        if (!ok) throw new Error("Clipboard copy was rejected");
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // Surface a clear failure instead of pretending the copy succeeded.
+        setCopyError(true);
+        setTimeout(() => setCopyError(false), 4000);
+      }
     }
   };
 
@@ -231,6 +249,13 @@ export default function ReferralDashboard() {
             )}
           </button>
         </div>
+        {copyError && (
+          <p className="text-red-400 text-xs mt-2 flex items-center gap-1">
+            <AlertCircle size={12} />
+            Couldn&apos;t copy automatically — select the link above and copy it
+            manually.
+          </p>
+        )}
         <p className="text-gray-500 text-xs mt-2">
           Share this link. When someone deposits via your link, you earn a
           percentage of the protocol fees they generate.

--- a/client/src/features/referrals/referralLink.test.ts
+++ b/client/src/features/referrals/referralLink.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveAppBaseUrl,
+  buildReferralLink,
+  DEFAULT_APP_URL,
+} from "./referralLink";
+
+describe("resolveAppBaseUrl", () => {
+  it("uses the configured URL when present", () => {
+    expect(resolveAppBaseUrl("https://app.example.com")).toEqual({
+      url: "https://app.example.com",
+      isFallback: false,
+    });
+  });
+
+  it("trims trailing slashes", () => {
+    expect(resolveAppBaseUrl("https://app.example.com/").url).toBe(
+      "https://app.example.com",
+    );
+  });
+
+  it("falls back gracefully when missing or blank", () => {
+    expect(resolveAppBaseUrl(undefined)).toEqual({
+      url: DEFAULT_APP_URL,
+      isFallback: true,
+    });
+    expect(resolveAppBaseUrl("   ").isFallback).toBe(true);
+  });
+});
+
+describe("buildReferralLink", () => {
+  it("builds an encoded ?ref link", () => {
+    expect(buildReferralLink("https://app.example.com", "GABC/DEF")).toBe(
+      "https://app.example.com/?ref=GABC%2FDEF",
+    );
+  });
+
+  it("returns an empty string without a wallet address", () => {
+    expect(buildReferralLink("https://app.example.com", "")).toBe("");
+  });
+});

--- a/client/src/features/referrals/referralLink.ts
+++ b/client/src/features/referrals/referralLink.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure helpers for building referral links, isolated from the dashboard
+ * component so the URL/fallback logic is unit-testable.
+ */
+
+export const DEFAULT_APP_URL = "https://stellaryield.vercel.app";
+
+/**
+ * Resolve the app base URL from configuration, falling back gracefully when
+ * `VITE_APP_URL` is missing or blank. `isFallback` lets the UI surface that the
+ * link uses a default rather than a configured domain.
+ */
+export function resolveAppBaseUrl(envUrl: string | undefined): {
+  url: string;
+  isFallback: boolean;
+} {
+  const trimmed = (envUrl ?? "").trim();
+  if (trimmed) {
+    return { url: trimmed.replace(/\/+$/, ""), isFallback: false };
+  }
+  return { url: DEFAULT_APP_URL, isFallback: true };
+}
+
+/** Build the shareable referral link, URL-encoding the wallet address. */
+export function buildReferralLink(baseUrl: string, walletAddress: string): string {
+  if (!walletAddress) return "";
+  const base = baseUrl.replace(/\/+$/, "");
+  return `${base}/?ref=${encodeURIComponent(walletAddress)}`;
+}

--- a/server/src/__tests__/csvExport.test.ts
+++ b/server/src/__tests__/csvExport.test.ts
@@ -225,4 +225,34 @@ describe("createExportFilename", () => {
     const filename = createExportFilename("GABCDEF");
     expect(filename).toMatch(/^stellaryield-tax-report-/);
   });
+
+  it("includes the current environment", () => {
+    const prev = process.env.STELLAR_NETWORK;
+    process.env.STELLAR_NETWORK = "testnet";
+    try {
+      expect(createExportFilename("GABCDEF")).toContain("-testnet-");
+    } finally {
+      if (prev === undefined) delete process.env.STELLAR_NETWORK;
+      else process.env.STELLAR_NETWORK = prev;
+    }
+  });
+
+  it("honours a custom report type and extension", () => {
+    const filename = createExportFilename("GABCDEF", {
+      reportType: "audit-log",
+      extension: "json",
+    });
+    expect(filename).toMatch(/^stellaryield-audit-log-/);
+    expect(filename).toMatch(/\.json$/);
+  });
+
+  it("strips unsafe characters from all segments", () => {
+    const filename = createExportFilename("G/../  AB", {
+      reportType: "tax report",
+    });
+    // No path separators, spaces, or other unsafe characters.
+    expect(filename).not.toMatch(/[^a-zA-Z0-9._-]/);
+    expect(filename).not.toContain("..");
+    expect(filename).toMatch(/^stellaryield-tax-report-/);
+  });
 });

--- a/server/src/services/export/csvGenerator.ts
+++ b/server/src/services/export/csvGenerator.ts
@@ -115,13 +115,45 @@ export function createCSVStream(records: TransactionRecord[]): Readable {
 }
 
 /**
- * Create a filename for the tax export CSV.
- *
- * @param address - The user's wallet address.
- * @returns A safe filename string.
+ * Replace any character that is not alphanumeric, dot, underscore or hyphen
+ * with a single hyphen, and trim leading/trailing hyphens. Keeps export
+ * filenames safe across operating systems and Content-Disposition headers.
  */
-export function createExportFilename(address: string): string {
+export function sanitizeFilenameSegment(value: string): string {
+  return String(value)
+    .replace(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/\.{2,}/g, ".") // collapse runs of dots so no segment contains ".."
+    .replace(/^[-.]+|[-.]+$/g, "");
+}
+
+/** Resolve the current deployment environment for filename tagging. */
+function currentEnvironment(): string {
+  const raw =
+    process.env.STELLAR_NETWORK ??
+    process.env.NETWORK ??
+    process.env.NODE_ENV ??
+    "production";
+  return sanitizeFilenameSegment(raw.toLowerCase()) || "production";
+}
+
+/**
+ * Create a standardized, filesystem-safe filename for an export download.
+ *
+ * Format: `stellaryield-<reportType>-<environment>-<shortAddr>-<YYYY-MM-DD>.<ext>`
+ * e.g. `stellaryield-tax-report-testnet-GABCDEFG-2026-05-26.csv`.
+ *
+ * @param address - The user's wallet address (first 8 chars are used).
+ * @param options - Optional report type (default `tax-report`) and extension
+ *   (default `csv`). All segments are sanitized of unsafe characters.
+ */
+export function createExportFilename(
+  address: string,
+  options: { reportType?: string; extension?: string } = {},
+): string {
+  const reportType = sanitizeFilenameSegment(options.reportType ?? "tax-report");
+  const extension = sanitizeFilenameSegment(options.extension ?? "csv") || "csv";
+  const env = currentEnvironment();
   const date = new Date().toISOString().split("T")[0];
-  const shortAddr = address.slice(0, 8);
-  return `stellaryield-tax-report-${shortAddr}-${date}.csv`;
+  const shortAddr = sanitizeFilenameSegment(address.slice(0, 8));
+  return `stellaryield-${reportType}-${env}-${shortAddr}-${date}.${extension}`;
 }


### PR DESCRIPTION
## Summary
mawuli's StellarYield issues, batched into one PR.

### closes #473 — export filename standardization
Standard convention `stellaryield-<reportType>-<environment>-[<addr>-]<YYYY-MM-DD>.<ext>`. Server `createExportFilename` tags environment + accepts reportType/extension; new `sanitizeFilenameSegment` strips unsafe chars and collapses dots (no `..`). Client `buildExportFilename` mirrors it; `ExportBundle` uses it. Tests added both sides.

### closes #471 — referral dashboard share-link UX
Pure `resolveAppBaseUrl`/`buildReferralLink` helpers (unit-tested); graceful fallback when `VITE_APP_URL` is unset; clear copy-failure feedback instead of a false "Copied!"; monospace (scannable) link.
