### PR TITLE
feat: implement allocation policy DSL, reason codes, zap quote UX, and fragmentation trend chart

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.2.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -2269,7 +2270,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2364,8 +2364,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2729,6 +2728,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4411,8 +4411,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6121,7 +6120,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6553,7 +6551,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6569,7 +6566,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6580,7 +6576,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6593,8 +6588,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/promise-worker-transferable": {
       "version": "1.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/client/src/components/AIAdvisor.tsx
+++ b/client/src/components/AIAdvisor.tsx
@@ -1,6 +1,15 @@
 import { useEffect, useState } from "react";
-import { Bot, Info, History } from "lucide-react";
+import { Bot, Info, History, AlertTriangle, TrendingUp, DollarSign, Activity, Shield } from "lucide-react";
 import { apiUrl } from "../lib/api";
+
+interface ReasonCodeDetail {
+  code: string;
+  label: string;
+  description: string;
+  severity: "info" | "warning" | "critical";
+  previousValue?: string | number;
+  currentValue?: string | number;
+}
 
 interface RecommendationTimelineEntry {
   id: string;
@@ -8,7 +17,39 @@ interface RecommendationTimelineEntry {
   rationale: string;
   targetVault: string;
   changedInputs: string[];
+  reasonCodes: ReasonCodeDetail[];
   timestamp: string;
+}
+
+const SEVERITY_CONFIG = {
+  info: {
+    border: "border-blue-500/30",
+    bg: "bg-blue-500/10",
+    text: "text-blue-400",
+    icon: TrendingUp,
+  },
+  warning: {
+    border: "border-amber-500/30",
+    bg: "bg-amber-500/10",
+    text: "text-amber-400",
+    icon: AlertTriangle,
+  },
+  critical: {
+    border: "border-red-500/30",
+    bg: "bg-red-500/10",
+    text: "text-red-400",
+    icon: Shield,
+  },
+};
+
+function formatTimestamp(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 export default function AIAdvisor() {
@@ -34,14 +75,14 @@ export default function AIAdvisor() {
       <p className="text-xl text-gray-400 max-w-2xl mx-auto leading-relaxed">
         Our integrated AI agent automatically analyzes Stellar's DeFi landscape to locate the optimal risk-to-reward vaults for your portfolio.
       </p>
-      
+
       <div className="glass-panel p-8 mt-12 max-w-3xl w-full text-left">
         <div className="h-40 border-2 border-dashed border-[#6C5DD3]/30 rounded-xl flex items-center justify-center text-gray-500 mb-6">
            Coming Soon: Interactive AI Chatbot Widget
         </div>
-        
+
         {/* Risk Badge Integration Demo */}
-        <div className="p-4 bg-white/5 border border-white/10 rounded-xl">
+        <div className="p-4 bg-white/5 border border-white/10 rounded-xl mb-5">
           <h3 className="text-sm font-semibold text-white mb-3">AI Advisor Risk Assessment Example</h3>
           <p className="text-xs text-gray-400 mb-4">When recommending vaults, the AI will evaluate risk across multiple factors:</p>
           <div className="flex gap-4">
@@ -61,7 +102,7 @@ export default function AIAdvisor() {
                 Low TVL, highly volatile assets, or experimental protocol.
               </div>
             </div>
-            
+
             <div
               className="group relative flex cursor-help outline-none"
               tabIndex={0}
@@ -80,7 +121,8 @@ export default function AIAdvisor() {
             </div>
           </div>
         </div>
-        <div className="p-4 mt-5 bg-white/5 border border-white/10 rounded-xl">
+
+        <div className="p-4 bg-white/5 border border-white/10 rounded-xl">
           <div className="flex items-center gap-2 mb-3">
             <History size={16} className="text-[#6C5DD3]" />
             <h3 className="text-sm font-semibold text-white">Recommendation Timeline</h3>
@@ -93,12 +135,45 @@ export default function AIAdvisor() {
             <div className="space-y-3">
               {timeline.map((entry) => (
                 <div key={entry.id} className="rounded-lg border border-white/10 bg-black/20 p-3">
-                  <p className="text-sm text-white font-medium">{entry.targetVault}</p>
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="text-sm text-white font-medium">{entry.targetVault}</p>
+                    <span className="text-[10px] text-gray-500">{formatTimestamp(entry.timestamp)}</span>
+                  </div>
                   <p className="text-xs text-gray-400 mt-1">{entry.recommendation}</p>
                   <p className="text-xs text-gray-500 mt-1">{entry.rationale}</p>
-                  <p className="text-[11px] text-[#6C5DD3] mt-2">
-                    Changed inputs: {entry.changedInputs.join(", ")}
-                  </p>
+
+                  {entry.reasonCodes && entry.reasonCodes.length > 0 && (
+                    <div className="mt-2 space-y-1.5">
+                      <p className="text-[10px] text-gray-500 uppercase tracking-wider font-semibold">Reason Codes</p>
+                      {entry.reasonCodes.map((rc, idx) => {
+                        const cfg = SEVERITY_CONFIG[rc.severity] ?? SEVERITY_CONFIG.info;
+                        const Icon = cfg.icon;
+                        return (
+                          <div
+                            key={idx}
+                            className={`flex items-start gap-2 rounded ${cfg.bg} border ${cfg.border} p-2`}
+                          >
+                            <Icon size={14} className={`${cfg.text} mt-0.5 shrink-0`} />
+                            <div className="text-left">
+                              <p className={`text-xs font-medium ${cfg.text}`}>{rc.label}</p>
+                              <p className="text-[10px] text-gray-400">{rc.description}</p>
+                              {rc.previousValue !== undefined && rc.currentValue !== undefined && (
+                                <p className="text-[10px] text-gray-500 mt-0.5">
+                                  {rc.previousValue} → {rc.currentValue}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )}
+
+                  {entry.changedInputs.length > 0 && (
+                    <p className="text-[11px] text-[#6C5DD3] mt-2">
+                      Changed inputs: {entry.changedInputs.join(", ")}
+                    </p>
+                  )}
                 </div>
               ))}
             </div>

--- a/client/src/features/fragmentation/FragmentationDashboard.tsx
+++ b/client/src/features/fragmentation/FragmentationDashboard.tsx
@@ -9,6 +9,7 @@ import MaterialImpactWarning from './MaterialImpactWarning';
 import ProtocolDistributionChart from './ProtocolDistributionChart';
 import RoutingRecommendations from './RoutingRecommendations';
 import DataFreshnessIndicator from './DataFreshnessIndicator';
+import FragmentationTrendChart from './FragmentationTrendChart';
 
 interface FragmentationDashboardProps {
   refreshInterval?: number;  // Default: 60000ms (1 minute)
@@ -177,6 +178,9 @@ export default function FragmentationDashboard({
             dataCompleteness={metrics.dataCompleteness}
             lastUpdate={lastUpdate}
           />
+
+          {/* Historical Trend Chart */}
+          <FragmentationTrendChart days={30} />
         </>
       )}
     </div>

--- a/client/src/features/fragmentation/FragmentationTrendChart.test.tsx
+++ b/client/src/features/fragmentation/FragmentationTrendChart.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import FragmentationTrendChart from "./FragmentationTrendChart";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function createMockHistory(overrides: Record<string, unknown> = {}) {
+  const now = Date.now();
+  const snapshots = [];
+  for (let i = 29; i >= 0; i--) {
+    snapshots.push({
+      timestamp: new Date(now - i * 24 * 60 * 60 * 1000).toISOString(),
+      fragmentationScore: 45 + (i % 5) * 1.5,
+      effectiveProtocolCount: 1.82 + (i % 7) * 0.1,
+      hhi: 5480,
+      multiProtocolRoutingPct: 35.7,
+      executionQualityScore: 72.3,
+    });
+  }
+
+  return {
+    success: true,
+    data: {
+      snapshots,
+      source: "mock",
+      dataFreshness: {
+        earliestSnapshot: snapshots[0].timestamp,
+        latestSnapshot: snapshots[snapshots.length - 1].timestamp,
+        snapshotCount: snapshots.length,
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("FragmentationTrendChart", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+    render(<FragmentationTrendChart />);
+    expect(screen.getByText("Loading historical data...")).toBeInTheDocument();
+  });
+
+  it("renders chart with data when fetch succeeds", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => createMockHistory(),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Historical Trends")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/30 snapshots over 30 days/)).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /trend chart/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows summary statistics", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => createMockHistory(),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Latest")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Average")).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Change")).toBeInTheDocument();
+    });
+  });
+
+  it("switches metrics when button is clicked", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => createMockHistory(),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Fragmentation")).toBeInTheDocument();
+    });
+
+    const protocolsBtn = screen.getByText("Effective");
+    await userEvent.click(protocolsBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole("img", { name: /Effective Protocols/ })).toBeInTheDocument();
+    });
+  });
+
+  it("displays error state on fetch failure", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({
+        success: false,
+        error: { code: "HISTORY_UNAVAILABLE", message: "No historical data" },
+      }),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Error Loading History")).toBeInTheDocument();
+    });
+  });
+
+  it("shows mock data warnings when present", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        createMockHistory({
+          warnings: ["Historical data based on simulated projections"],
+        }),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Historical data based on simulated projections/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no snapshots", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        success: true,
+        data: {
+          snapshots: [],
+          source: "mock",
+          dataFreshness: {
+            earliestSnapshot: new Date().toISOString(),
+            latestSnapshot: new Date().toISOString(),
+            snapshotCount: 0,
+          },
+        },
+      }),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No historical data available")).toBeInTheDocument();
+    });
+  });
+
+  it("includes data source in footer", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => createMockHistory(),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Source:/)).toBeInTheDocument();
+    });
+  });
+
+  it("renders data freshness date range", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => createMockHistory(),
+    });
+
+    render(<FragmentationTrendChart />);
+
+    await waitFor(() => {
+      const freshnessElements = screen.getAllByText(/2025|2026/);
+      expect(freshnessElements.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/client/src/features/fragmentation/FragmentationTrendChart.tsx
+++ b/client/src/features/fragmentation/FragmentationTrendChart.tsx
@@ -1,0 +1,331 @@
+import { useState, useEffect, useCallback } from "react";
+import { TrendingUp, AlertCircle, Clock, BarChart3 } from "lucide-react";
+import { apiUrl } from "../../lib/api";
+
+export interface FragmentationHistorySnapshot {
+  timestamp: string;
+  fragmentationScore: number;
+  effectiveProtocolCount: number;
+  hhi: number;
+  multiProtocolRoutingPct: number;
+  executionQualityScore: number;
+}
+
+interface DataFreshness {
+  earliestSnapshot: string;
+  latestSnapshot: string;
+  snapshotCount: number;
+}
+
+interface HistoryData {
+  snapshots: FragmentationHistorySnapshot[];
+  source: "live" | "mock" | "historical";
+  dataFreshness: DataFreshness;
+  warnings?: string[];
+}
+
+interface FragmentationTrendChartProps {
+  days?: number;
+}
+
+function formatDate(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatDateFull(ts: string): string {
+  const d = new Date(ts);
+  return d.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function FragmentationTrendChart({
+  days = 30,
+}: FragmentationTrendChartProps) {
+  const [history, setHistory] = useState<HistoryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedMetric, setSelectedMetric] = useState<
+    "fragmentationScore" | "effectiveProtocolCount" | "executionQualityScore"
+  >("fragmentationScore");
+
+  const fetchHistory = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(apiUrl(`/api/liquidity/fragmentation/history?days=${days}`));
+      const data = await res.json();
+
+      if (!res.ok) {
+        throw new Error(data.error?.message || "Failed to fetch history");
+      }
+
+      if (data.success && data.data) {
+        setHistory(data.data);
+      } else {
+        throw new Error("Invalid response format");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setLoading(false);
+    }
+  }, [days]);
+
+  useEffect(() => {
+    fetchHistory();
+  }, [fetchHistory]);
+
+  const snapshots = history?.snapshots ?? [];
+
+  const metricConfig = {
+    fragmentationScore: { label: "Fragmentation Score", unit: "%", color: "#6C5DD3", range: [0, 100] },
+    effectiveProtocolCount: { label: "Effective Protocols", unit: "", color: "#10B981", range: [0, 5] },
+    executionQualityScore: { label: "Execution Quality", unit: "%", color: "#F59E0B", range: [0, 100] },
+  };
+
+  const config = metricConfig[selectedMetric];
+  const maxVal = config.range[1];
+  const minVal = config.range[0];
+  const range = maxVal - minVal;
+
+  const yLabels = [];
+  for (let i = 0; i <= 4; i++) {
+    yLabels.push(minVal + (range * i) / 4);
+  }
+
+  const svgHeight = 200;
+  const svgWidth = 600;
+  const padding = { top: 20, right: 20, bottom: 30, left: 50 };
+  const chartWidth = svgWidth - padding.left - padding.right;
+  const chartHeight = svgHeight - padding.top - padding.bottom;
+
+  const points = snapshots.map((s, i) => {
+    const x = padding.left + (i / Math.max(snapshots.length - 1, 1)) * chartWidth;
+    const val = s[selectedMetric];
+    const y = padding.top + chartHeight - ((val - minVal) / range) * chartHeight;
+    return { x, y, ...s };
+  });
+
+  const pathD = points
+    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(1)},${p.y.toFixed(1)}`)
+    .join(" ");
+
+  return (
+    <div className="glass-panel overflow-hidden">
+      <div className="flex items-center justify-between border-b border-[rgba(255,255,255,0.05)] p-6">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl bg-indigo-500/20 p-2 text-indigo-400">
+            <TrendingUp size={20} />
+          </div>
+          <div>
+            <h3 className="text-xl font-bold">Historical Trends</h3>
+            <p className="text-xs text-gray-400">
+              {history
+                ? `${history.dataFreshness.snapshotCount} snapshots over ${days} days`
+                : "Loading..."}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-1">
+          {(
+            Object.entries(metricConfig) as [
+              keyof typeof metricConfig,
+              typeof config,
+            ][]
+          ).map(([key, cfg]) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setSelectedMetric(key)}
+              className={`text-xs px-2.5 py-1.5 rounded-lg font-medium transition-colors ${
+                selectedMetric === key
+                  ? "bg-indigo-500/30 text-indigo-300"
+                  : "bg-white/5 text-gray-400 hover:bg-white/10"
+              }`}
+            >
+              {cfg.label.split(" ")[0]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="m-6 flex items-start gap-3 bg-red-950/30 border border-red-500/40 rounded-lg p-4">
+          <AlertCircle size={18} className="text-red-500 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm font-semibold text-red-400 mb-1">Error Loading History</p>
+            <p className="text-xs text-red-200/80">{error}</p>
+          </div>
+        </div>
+      )}
+
+      {loading && !history && (
+        <div className="p-12 text-center">
+          <div className="inline-flex items-center gap-2 text-gray-400">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-[#6C5DD3] border-t-transparent" />
+            Loading historical data...
+          </div>
+        </div>
+      )}
+
+      {history?.warnings && history.warnings.length > 0 && (
+        <div className="mx-6 mb-2 flex items-start gap-2 bg-amber-950/30 border border-amber-500/40 rounded-lg p-3">
+          <AlertCircle size={16} className="text-amber-500 flex-shrink-0 mt-0.5" />
+          <div>
+            {history.warnings.map((w, i) => (
+              <p key={i} className="text-xs text-amber-200/80">{w}</p>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {snapshots.length > 0 && !error && (
+        <div className="p-6">
+          {/* Trend Chart */}
+          <div className="relative overflow-x-auto">
+            <svg
+              viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+              className="w-full h-auto"
+              style={{ minWidth: `${svgWidth}px` }}
+              role="img"
+              aria-label={`${config.label} trend chart`}
+            >
+              {/* Y-axis gridlines and labels */}
+              {yLabels.map((val, i) => {
+                const y = padding.top + (chartHeight * (4 - i)) / 4;
+                return (
+                  <g key={i}>
+                    <line
+                      x1={padding.left}
+                      y1={y}
+                      x2={svgWidth - padding.right}
+                      y2={y}
+                      stroke="rgba(255,255,255,0.05)"
+                    />
+                    <text
+                      x={padding.left - 8}
+                      y={y + 4}
+                      textAnchor="end"
+                      className="text-[10px] fill-gray-500"
+                    >
+                      {selectedMetric === "effectiveProtocolCount"
+                        ? val.toFixed(1)
+                        : Math.round(val)}
+                    </text>
+                  </g>
+                );
+              })}
+
+              {/* Area fill */}
+              <defs>
+                <linearGradient id="trendGradient" x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="0%" stopColor={config.color} stopOpacity="0.2" />
+                  <stop offset="100%" stopColor={config.color} stopOpacity="0.02" />
+                </linearGradient>
+              </defs>
+              <path
+                d={`${pathD} L${points[points.length - 1]?.x || padding.left},${padding.top + chartHeight} L${points[0]?.x || padding.left},${padding.top + chartHeight} Z`}
+                fill="url(#trendGradient)"
+              />
+
+              {/* Line */}
+              <path
+                d={pathD}
+                fill="none"
+                stroke={config.color}
+                strokeWidth="2"
+                vectorEffect="non-scaling-stroke"
+              />
+
+              {/* Dots */}
+              {points.map((p, i) => (
+                <circle
+                  key={i}
+                  cx={p.x}
+                  cy={p.y}
+                  r="3"
+                  fill={config.color}
+                  stroke="#1A1A24"
+                  strokeWidth="1"
+                />
+              ))}
+            </svg>
+          </div>
+
+          {/* X-axis labels */}
+          <div className="flex justify-between text-[10px] text-gray-500 mt-1 px-[50px]">
+            {snapshots.length > 0 && (
+              <>
+                <span>{formatDate(snapshots[0].timestamp)}</span>
+                <span>{formatDate(snapshots[Math.floor(snapshots.length / 2)].timestamp)}</span>
+                <span>{formatDate(snapshots[snapshots.length - 1].timestamp)}</span>
+              </>
+            )}
+          </div>
+
+          {/* Summary stats */}
+          <div className="grid grid-cols-3 gap-4 mt-6">
+            <div className="bg-white/5 rounded-lg p-3">
+              <p className="text-[10px] text-gray-400 uppercase tracking-wider">Latest</p>
+              <p className="text-lg font-bold text-white mt-1">
+                {selectedMetric === "effectiveProtocolCount"
+                  ? snapshots[snapshots.length - 1][selectedMetric].toFixed(2)
+                  : Math.round(snapshots[snapshots.length - 1][selectedMetric])}
+                {config.unit}
+              </p>
+            </div>
+            <div className="bg-white/5 rounded-lg p-3">
+              <p className="text-[10px] text-gray-400 uppercase tracking-wider">Average</p>
+              <p className="text-lg font-bold text-white mt-1">
+                {selectedMetric === "effectiveProtocolCount"
+                  ? (snapshots.reduce((s, v) => s + v[selectedMetric], 0) / snapshots.length).toFixed(2)
+                  : Math.round(snapshots.reduce((s, v) => s + v[selectedMetric], 0) / snapshots.length)}
+                {config.unit}
+              </p>
+            </div>
+            <div className="bg-white/5 rounded-lg p-3">
+              <p className="text-[10px] text-gray-400 uppercase tracking-wider">Change</p>
+              <p className={`text-lg font-bold mt-1 ${
+                snapshots.length > 1
+                  ? snapshots[snapshots.length - 1][selectedMetric] >= snapshots[0][selectedMetric]
+                    ? "text-green-400"
+                    : "text-red-400"
+                  : "text-white"
+              }`}>
+                {snapshots.length > 1
+                  ? `${(snapshots[snapshots.length - 1][selectedMetric] - snapshots[0][selectedMetric]).toFixed(1)}`
+                  : "—"}
+                {snapshots.length > 1 && config.unit}
+              </p>
+            </div>
+          </div>
+
+          {/* Data freshness info */}
+          <div className="mt-4 flex items-center gap-4 text-[10px] text-gray-500">
+            <span className="flex items-center gap-1">
+              <Clock size={10} />
+              {formatDateFull(history!.dataFreshness.earliestSnapshot)} –{" "}
+              {formatDateFull(history!.dataFreshness.latestSnapshot)}
+            </span>
+            <span className="flex items-center gap-1">
+              <BarChart3 size={10} />
+              Source: {history!.source}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {!loading && !error && snapshots.length === 0 && (
+        <div className="p-12 text-center text-gray-500">
+          <TrendingUp size={32} className="mx-auto mb-2 opacity-30" />
+          <p className="text-sm">No historical data available</p>
+          <p className="text-xs mt-1">Historical snapshots will appear once fragmentation tracking begins.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/fragmentation/index.ts
+++ b/client/src/features/fragmentation/index.ts
@@ -6,6 +6,7 @@ export { default as MaterialImpactWarning } from './MaterialImpactWarning';
 export { default as ProtocolDistributionChart } from './ProtocolDistributionChart';
 export { default as RoutingRecommendations } from './RoutingRecommendations';
 export { default as DataFreshnessIndicator } from './DataFreshnessIndicator';
+export { default as FragmentationTrendChart } from './FragmentationTrendChart';
 
 export type {
   FragmentationCategory,

--- a/client/src/features/zap/ZapDepositPanel.test.tsx
+++ b/client/src/features/zap/ZapDepositPanel.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import ZapDepositPanel from "./ZapDepositPanel";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock("./assets", () => ({
+  shouldLoadZapMetadataFromApi: () => false,
+  getVaultTokenFromEnv: () => ({
+    symbol: "yVault",
+    name: "Yield Vault",
+    contractId: "CVAULT",
+    decimals: 7,
+  }),
+  getVaultContractIdFromEnv: () => "CVAULT",
+  loadZapAssetOptions: () => [
+    { symbol: "XLM", name: "Stellar", contractId: "CXLM", decimals: 7 },
+    { symbol: "USDC", name: "USD Coin", contractId: "CUSDC", decimals: 7 },
+  ],
+  mergeVaultIntoZapSelectableAssets: (_assets: unknown[], vault: unknown) => [
+    { symbol: "XLM", name: "Stellar", contractId: "CXLM", decimals: 7 },
+    { symbol: "USDC", name: "USD Coin", contractId: "CUSDC", decimals: 7 },
+    vault,
+  ],
+  buildSelectableZapAssetsFromMetadata: () => [],
+  fetchZapSupportedAssetsMetadata: () => Promise.resolve(null),
+}));
+
+vi.mock("../../services/soroban", () => ({
+  zapDeposit: vi.fn().mockResolvedValue({ success: true, hash: "0xhash" }),
+}));
+
+vi.mock("../settings/SettingsContext", () => ({
+  useSettings: () => ({
+    settings: {},
+  }),
+}));
+
+vi.mock("../settings/types", () => ({
+  resolveSlippage: () => 0.5,
+}));
+
+function createMockQuote(overrides: Record<string, unknown> = {}) {
+  return {
+    path: [
+      { contractId: "CXLM", label: "XLM" },
+      { contractId: "CVAULT", label: "yVault" },
+    ],
+    expectedAmountOutStroops: "9500000",
+    source: "router_simulation",
+    slippageApplied: 0.005,
+    amountOutAfterSlippage: "9452500",
+    quotedAt: new Date().toISOString(),
+    minAmountOutStroops: "9452500",
+    quoteAgeMs: 100,
+    isFallback: false,
+    ...overrides,
+  };
+}
+
+function openSlippageEditor() {
+  const infoButton = screen.getByRole("button", { name: "" });
+  fireEvent.click(infoButton);
+}
+
+describe("ZapDepositPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("fresh quote state", () => {
+    it("renders quote preview with simulated source badge", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote(),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText("Simulated")).toBeInTheDocument();
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Min\. after/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows vault token symbol in expected output", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote(),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText(/yVault/)).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("fallback quote state", () => {
+    it("shows fallback warning badge", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote({ source: "fallback_rate", isFallback: true }),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText("Fallback quote active")).toBeInTheDocument();
+      });
+    });
+
+    it("shows Fallback badge for fallback source", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote({ source: "fallback_rate", isFallback: true }),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        const fallbackBadge = screen.getByText("Fallback");
+        expect(fallbackBadge).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("stale quote state", () => {
+    it("shows stale quote warning when quote is old", async () => {
+      const staleQuotedAt = new Date(Date.now() - 120_000).toISOString();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote({ quotedAt: staleQuotedAt }),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText("Stale quote")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("no wallet state", () => {
+    it("shows connect wallet prompt when no wallet", () => {
+      render(<ZapDepositPanel walletAddress={null} />);
+      expect(screen.getByText(/Connect your wallet/)).toBeInTheDocument();
+    });
+  });
+
+  describe("slippage adjustment", () => {
+    it("shows slippage tolerance display", async () => {
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+      expect(screen.getByText(/Slippage tolerance/)).toBeInTheDocument();
+    });
+
+    it("allows opening slippage editor", async () => {
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      openSlippageEditor();
+
+      await waitFor(() => {
+        expect(screen.getByText(/Safe range/)).toBeInTheDocument();
+      });
+    });
+
+    it("shows warning for high slippage", async () => {
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      openSlippageEditor();
+
+      const presetBtn = screen.getByText("5%");
+      fireEvent.click(presetBtn);
+
+      await waitFor(() => {
+        expect(screen.getByText(/High slippage/)).toBeInTheDocument();
+      });
+    });
+
+    it("clamps slippage within safe bounds", async () => {
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      openSlippageEditor();
+
+      const presetBtns = screen.getAllByRole("button");
+      const hasPresetBtn = presetBtns.some((btn) => btn.textContent === "0.1%");
+      expect(hasPresetBtn).toBe(true);
+    });
+  });
+
+  describe("invalid quote state", () => {
+    it("shows error on fetch failure", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw } from "lucide-react";
+import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw, Clock, Info } from "lucide-react";
 import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
 import { zapDeposit } from "../../services/soroban";
 import type { TxPhase } from "../../services/transactionPhase";
@@ -16,7 +16,7 @@ import {
   mergeVaultIntoZapSelectableAssets,
   shouldLoadZapMetadataFromApi,
 } from "./assets";
-import type { ZapAssetOption } from "./types";
+import type { ZapAssetOption, ZapQuoteResponse } from "./types";
 import { useSettings } from "../settings/SettingsContext";
 import { resolveSlippage } from "../settings/types";
 
@@ -24,10 +24,19 @@ export interface ZapDepositPanelProps {
   walletAddress: string | null;
 }
 
+const MIN_SLIPPAGE = 0.1;
+const MAX_SLIPPAGE = 15;
+const STALE_QUOTE_AGE_MS = 60_000;
+const FALLBACK_SOURCE = "fallback_rate";
+
+function quoteAgeSeconds(quotedAt: string): number {
+  return Math.floor((Date.now() - new Date(quotedAt).getTime()) / 1000);
+}
+
 export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps) {
   const useApiAssets = shouldLoadZapMetadataFromApi();
   const { settings } = useSettings();
-  const slippage = resolveSlippage(settings);
+  const settingsSlippage = resolveSlippage(settings);
 
   const initialVault = useMemo(() => getVaultTokenFromEnv(), []);
   const initialVaultContractId = useMemo(() => getVaultContractIdFromEnv(), []);
@@ -62,7 +71,6 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
       !inputAsset ||
       !selectableAssets.some((a) => a.contractId === inputAsset.contractId)
     ) {
-      // Schedule the state update outside the synchronous effect body
       const next = selectableAssets[0] ?? null;
       Promise.resolve().then(() => setInputAsset(next));
     }
@@ -79,6 +87,9 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
   const [expectedOut, setExpectedOut] = useState<bigint | null>(null);
   const [quotePath, setQuotePath] = useState<string>("");
   const [quoteSource, setQuoteSource] = useState<string>("");
+  const [quoteData, setQuoteData] = useState<ZapQuoteResponse | null>(null);
+  const [slippageTolerance, setSlippageTolerance] = useState(settingsSlippage);
+  const [showSlippageEdit, setShowSlippageEdit] = useState(false);
 
   const needsSwap = inputAsset?.contractId !== vaultToken.contractId;
 
@@ -86,6 +97,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     if (!inputAsset || !amount || !vaultToken.contractId) {
       setExpectedOut(null);
       setQuotePath("");
+      setQuoteData(null);
       return;
     }
     let stroops: bigint;
@@ -107,6 +119,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
         setExpectedOut(stroops);
         setQuotePath(`${inputAsset.symbol} (no swap)`);
         setQuoteSource("direct");
+        setQuoteData(null);
       } else {
         const q = await fetchSwapQuote({
           inputTokenContract: inputAsset.contractId,
@@ -114,18 +127,21 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
           amountInStroops: stroops.toString(),
           inputDecimals: inputAsset.decimals,
           vaultDecimals: vaultToken.decimals,
+          slippageTolerance: slippageTolerance / 100,
         });
         setExpectedOut(BigInt(q.expectedAmountOutStroops));
         setQuotePath(q.path.map((h) => h.label ?? h.contractId.slice(0, 6)).join(" → "));
         setQuoteSource(q.source);
+        setQuoteData(q);
       }
     } catch (e) {
       setExpectedOut(null);
       setError(e instanceof Error ? e.message : "Could not load quote");
+      setQuoteData(null);
     } finally {
       setQuoteLoading(false);
     }
-  }, [amount, inputAsset, needsSwap, vaultToken]);
+  }, [amount, inputAsset, needsSwap, slippageTolerance, vaultToken]);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -136,8 +152,18 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
 
   const minOut = useMemo(() => {
     if (expectedOut === null || expectedOut <= 0n) return null;
-    return minAmountAfterSlippage(expectedOut, slippage);
-  }, [expectedOut, slippage]);
+    return minAmountAfterSlippage(expectedOut, slippageTolerance);
+  }, [expectedOut, slippageTolerance]);
+
+  const isStale = useMemo(() => {
+    if (!quoteData) return false;
+    return quoteAgeSeconds(quoteData.quotedAt) > STALE_QUOTE_AGE_MS / 1000;
+  }, [quoteData]);
+
+  const isFallback = useMemo(() => {
+    if (!quoteData) return false;
+    return quoteData.isFallback || quoteData.source === FALLBACK_SOURCE;
+  }, [quoteData]);
 
   const emitPhase = useCallback((p: TxPhase) => {
     setTxPhase(p);
@@ -145,6 +171,11 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
       lastProgressPhaseRef.current = p;
       setLastProgressPhase(p);
     }
+  }, []);
+
+  const handleSlippageChange = useCallback((value: number) => {
+    const clamped = Math.min(MAX_SLIPPAGE, Math.max(MIN_SLIPPAGE, value));
+    setSlippageTolerance(clamped);
   }, []);
 
   const handleZap = useCallback(async () => {
@@ -252,6 +283,32 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
         </div>
       )}
 
+      {/* Fallback quote warning */}
+      {isFallback && needsSwap && (
+        <div className="mb-4 flex items-start gap-2 text-amber-200/90 text-sm bg-amber-500/10 border border-amber-500/30 rounded-lg p-3">
+          <Info className="w-4 h-4 shrink-0 mt-0.5 text-amber-400" />
+          <div>
+            <p className="font-medium text-amber-300">Fallback quote active</p>
+            <p className="text-xs text-amber-200/70">
+              Router simulation unavailable. Using estimated rate. Actual output may differ.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Stale quote warning */}
+      {isStale && !quoteLoading && (
+        <div className="mb-4 flex items-start gap-2 text-orange-200/90 text-sm bg-orange-500/10 border border-orange-500/30 rounded-lg p-3">
+          <Clock className="w-4 h-4 shrink-0 mt-0.5 text-orange-400" />
+          <div>
+            <p className="font-medium text-orange-300">Stale quote</p>
+            <p className="text-xs text-orange-200/70">
+              Quote is over 60 seconds old. Refresh for current rates.
+            </p>
+          </div>
+        </div>
+      )}
+
       <div className="bg-white/5 rounded-xl p-4 mb-2">
         <label className="text-sm text-gray-400 mb-2 block">You pay</label>
         <div className="flex gap-3">
@@ -301,26 +358,109 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
             {needsSwap ? "Vault token after swap" : "Vault token"}
           </span>
         </div>
+
+        {/* Min output after slippage */}
         {minOut !== null && minOut > 0n && (
           <p className="text-xs text-gray-400">
-            Min. after {slippage}% slippage:{" "}
+            Min. after {slippageTolerance}% slippage:{" "}
             <span className="text-gray-200 font-mono">
               {formatStroopsToDecimal(minOut, vaultToken.decimals)} {vaultToken.symbol}
             </span>
           </p>
         )}
+
+        {/* Quote source badge */}
+        {quoteSource && needsSwap && (
+          <div className="flex items-center gap-2">
+            <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+              quoteSource === "router_simulation"
+                ? "bg-green-500/20 text-green-400"
+                : quoteSource === "fallback_rate"
+                  ? "bg-amber-500/20 text-amber-400"
+                  : "bg-blue-500/20 text-blue-400"
+            }`}>
+              {quoteSource === "router_simulation" ? "Simulated" : quoteSource === "fallback_rate" ? "Fallback" : quoteSource}
+            </span>
+
+            {/* Quote age */}
+            {quoteData && (
+              <span className="text-[10px] text-gray-500 flex items-center gap-1">
+                <Clock size={10} />
+                {quoteAgeSeconds(quoteData.quotedAt)}s ago
+              </span>
+            )}
+          </div>
+        )}
+
         {quotePath && (
           <p className="text-xs text-gray-500">
             Path: {quotePath}
-            {quoteSource && ` · ${quoteSource}`}
           </p>
         )}
       </div>
 
+      {/* Slippage tolerance editor */}
       {needsSwap && (
-        <div className="bg-white/5 rounded-xl p-3 mb-4 flex items-center justify-between text-sm">
-          <span className="text-gray-400">Slippage tolerance</span>
-          <span className="text-white font-medium">{slippage}%</span>
+        <div className="bg-white/5 rounded-xl p-3 mb-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-1">
+              <span className="text-sm text-gray-400">Slippage tolerance</span>
+              <button
+                type="button"
+                onClick={() => setShowSlippageEdit(!showSlippageEdit)}
+                className="text-gray-500 hover:text-gray-300"
+              >
+                <Info size={12} />
+              </button>
+            </div>
+            <span className={`text-sm font-medium ${
+              slippageTolerance > 5 ? "text-red-400" : slippageTolerance > 2 ? "text-amber-400" : "text-white"
+            }`}>
+              {slippageTolerance}%
+            </span>
+          </div>
+
+          {showSlippageEdit && (
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                {[0.1, 0.5, 1, 2, 3, 5].map((val) => (
+                  <button
+                    key={val}
+                    type="button"
+                    onClick={() => handleSlippageChange(val)}
+                    className={`text-xs px-2 py-1 rounded ${
+                      slippageTolerance === val
+                        ? "bg-[#6C5DD3] text-white"
+                        : "bg-white/10 text-gray-400 hover:bg-white/20"
+                    }`}
+                  >
+                    {val}%
+                  </button>
+                ))}
+              </div>
+              <div className="flex items-center gap-2">
+                <input
+                  type="range"
+                  min={MIN_SLIPPAGE}
+                  max={MAX_SLIPPAGE}
+                  step={0.1}
+                  value={slippageTolerance}
+                  onChange={(e) => handleSlippageChange(parseFloat(e.target.value))}
+                  className="flex-1 accent-[#6C5DD3]"
+                />
+                <span className="text-xs text-gray-500 w-10 text-right">{slippageTolerance}%</span>
+              </div>
+              {slippageTolerance >= 5 && (
+                <p className="text-xs text-red-400 flex items-center gap-1">
+                  <AlertTriangle size={10} />
+                  High slippage may result in significant price impact
+                </p>
+              )}
+              <p className="text-[10px] text-gray-500">
+                Safe range: {MIN_SLIPPAGE}% – {MAX_SLIPPAGE}%. Higher tolerance means more risk of unfavorable rate.
+              </p>
+            </div>
+          )}
         </div>
       )}
 

--- a/client/src/features/zap/fetchSwapQuote.ts
+++ b/client/src/features/zap/fetchSwapQuote.ts
@@ -4,8 +4,11 @@ import { apiUrl } from "../../lib/api";
 /**
  * Ask the backend for the best known swap path and expected vault-token output.
  * Falls back to a deterministic ratio when the DEX router is not configured.
+ * Includes slippage tolerance and returns quote metadata (age, source, min output).
  */
-export async function fetchSwapQuote(req: ZapQuoteRequest): Promise<ZapQuoteResponse> {
+export async function fetchSwapQuote(
+  req: ZapQuoteRequest,
+): Promise<ZapQuoteResponse> {
   const res = await fetch(apiUrl("/api/zap/quote"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/client/src/features/zap/types.ts
+++ b/client/src/features/zap/types.ts
@@ -12,6 +12,7 @@ export interface ZapQuoteRequest {
   amountInStroops: string;
   inputDecimals: number;
   vaultDecimals: number;
+  slippageTolerance?: number;
 }
 
 /** Quote used to show expected vault-token output and to derive `min_amount_out`. */
@@ -19,6 +20,12 @@ export interface ZapQuoteResponse {
   path: SwapPathHop[];
   expectedAmountOutStroops: string;
   source: "router_simulation" | "fallback_rate";
+  slippageApplied: number;
+  amountOutAfterSlippage: string;
+  quotedAt: string;
+  minAmountOutStroops: string;
+  quoteAgeMs: number;
+  isFallback: boolean;
 }
 
 /** Asset the user can select as zap input (Soroban SAC contract id). */

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.57.0",
+        "fast-check": "^4.8.0",
         "jest": "^30.3.0",
         "supertest": "^7.2.2",
         "ts-jest": "^29.4.9",
@@ -4537,6 +4538,46 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-check": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.8.0.tgz",
+      "integrity": "sha512-GOJ158CUMnN6cSahsv4+ExARvIDuzzinFjkp0E9WtiBa5zcVeLozVkWaE4IzFcc+Y48Wp1EDlUZsXRyAztQcSg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-check/node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {

--- a/server/package.json
+++ b/server/package.json
@@ -38,6 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",
+    "fast-check": "^4.8.0",
     "jest": "^30.3.0",
     "supertest": "^7.2.2",
     "ts-jest": "^29.4.9",

--- a/server/src/__tests__/allocationPolicyDsl.test.ts
+++ b/server/src/__tests__/allocationPolicyDsl.test.ts
@@ -1,0 +1,599 @@
+import {
+  validatePolicy,
+  storePolicy,
+  getPolicy,
+  listPolicies,
+  deletePolicy,
+  updatePolicy,
+  resetPolicyStore,
+  evaluatePolicy,
+  markRuleExecuted,
+  type AllocationPolicy,
+  type PolicyEvaluationContext,
+} from "../services/allocationPolicyDsl";
+
+const VALID_POLICY = {
+  name: "Balanced Allocation",
+  version: "1.0.0",
+  description: "A balanced allocation policy for stable returns",
+  rules: [
+    {
+      id: "high-yield-stable",
+      description: "High yield with low volatility",
+      weight: 0.6,
+      conditions: {
+        minTvl: 1_000_000,
+        maxVolatility: 15,
+        minApy: 5,
+      },
+      cooldown: {
+        durationMs: 3600000,
+      },
+      threshold: {
+        max: 70,
+      },
+    },
+    {
+      id: "growth-focused",
+      description: "Growth with higher volatility tolerance",
+      weight: 0.4,
+      conditions: {
+        minTvl: 500_000,
+        maxVolatility: 30,
+        minApy: 8,
+      },
+      threshold: {
+        min: 10,
+        max: 50,
+      },
+    },
+  ],
+  defaultRule: {
+    conditions: {
+      maxVolatility: 50,
+    },
+  },
+};
+
+describe("validatePolicy", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("accepts a valid policy definition", () => {
+    const result = validatePolicy(VALID_POLICY);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.policy.name).toBe("Balanced Allocation");
+      expect(result.policy.rules).toHaveLength(2);
+    }
+  });
+
+  it("rejects null input", () => {
+    const result = validatePolicy(null);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects empty name", () => {
+    const result = validatePolicy({ ...VALID_POLICY, name: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.path === "name")).toBe(true);
+    }
+  });
+
+  it("rejects missing version", () => {
+    const result = validatePolicy({ ...VALID_POLICY, version: "" });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.path === "version")).toBe(true);
+    }
+  });
+
+  it("rejects empty rules array", () => {
+    const result = validatePolicy({ ...VALID_POLICY, rules: [] });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.path === "rules")).toBe(true);
+    }
+  });
+
+  it("rejects rules with invalid weight", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "bad-weight",
+          weight: 1.5,
+          conditions: {},
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.path.includes("weight"))).toBe(true);
+    }
+  });
+
+  it("rejects rules with negative weight", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "neg-weight",
+          weight: -0.1,
+          conditions: {},
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects weights not summing to 1.0", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        { id: "r1", weight: 0.3, conditions: {} },
+        { id: "r2", weight: 0.3, conditions: {} },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.code === "WEIGHT_SUM")).toBe(true);
+    }
+  });
+
+  it("rejects duplicate rule ids", () => {
+    const result = validatePolicy({
+      name: "Duplicate",
+      version: "1.0",
+      rules: [
+        { id: "same-id", weight: 0.5, conditions: {} },
+        { id: "same-id", weight: 0.5, conditions: {} },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.code === "DUPLICATE_ID")).toBe(true);
+    }
+  });
+
+  it("rejects reserved rule ids", () => {
+    const result = validatePolicy({
+      name: "Reserved",
+      version: "1.0",
+      rules: [
+        { id: "__default__", weight: 1.0, conditions: {} },
+      ],
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.some((e) => e.code === "RESERVED_ID")).toBe(true);
+    }
+  });
+
+  it("rejects allowlist that is not an array of strings", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "bad-allowlist",
+          weight: 1.0,
+          conditions: { allowlist: [123] },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects deny-list that is not an array of strings", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "bad-denylist",
+          weight: 1.0,
+          conditions: { denylist: [true] },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects invalid maxVolatility", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "bad-vol",
+          weight: 1.0,
+          conditions: { maxVolatility: 150 },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects invalid cooldown duration", () => {
+    const result = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "bad-cd",
+          weight: 1.0,
+          conditions: {},
+          cooldown: { durationMs: -1 },
+        },
+      ],
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("accepts policy with only allowlist conditions", () => {
+    const result = validatePolicy({
+      name: "Allowlist Only",
+      version: "1.0",
+      rules: [
+        {
+          id: "blend-only",
+          weight: 1.0,
+          conditions: { allowlist: ["Blend"] },
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts policy with denylist conditions", () => {
+    const result = validatePolicy({
+      name: "Denylist",
+      version: "1.0",
+      rules: [
+        {
+          id: "no-defindex",
+          weight: 1.0,
+          conditions: { denylist: ["DeFindex"] },
+        },
+      ],
+    });
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("storePolicy and getPolicy", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("stores and retrieves a policy", () => {
+    const validation = validatePolicy(VALID_POLICY);
+    expect(validation.ok).toBe(true);
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+    const retrieved = getPolicy(validation.policy.id);
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.name).toBe("Balanced Allocation");
+  });
+
+  it("returns undefined for non-existent policy", () => {
+    expect(getPolicy("non-existent")).toBeUndefined();
+  });
+});
+
+describe("listPolicies", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("returns all stored policies", () => {
+    const p1 = validatePolicy({ ...VALID_POLICY, name: "Policy 1" });
+    const p2 = validatePolicy({ ...VALID_POLICY, name: "Policy 2" });
+    if (!p1.ok || !p2.ok) return;
+
+    storePolicy(p1.policy);
+    storePolicy(p2.policy);
+
+    const all = listPolicies();
+    expect(all).toHaveLength(2);
+    expect(all.map((p) => p.name)).toEqual(expect.arrayContaining(["Policy 1", "Policy 2"]));
+  });
+
+  it("returns empty array when no policies stored", () => {
+    expect(listPolicies()).toEqual([]);
+  });
+});
+
+describe("deletePolicy", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("deletes an existing policy", () => {
+    const validation = validatePolicy(VALID_POLICY);
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+    expect(deletePolicy(validation.policy.id)).toBe(true);
+    expect(getPolicy(validation.policy.id)).toBeUndefined();
+  });
+
+  it("returns false for non-existent policy", () => {
+    expect(deletePolicy("ghost")).toBe(false);
+  });
+});
+
+describe("updatePolicy", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("updates an existing policy", () => {
+    const validation = validatePolicy(VALID_POLICY);
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+
+    const updateResult = updatePolicy(validation.policy.id, {
+      ...VALID_POLICY,
+      name: "Updated Policy",
+      version: "2.0.0",
+    });
+
+    expect(updateResult.ok).toBe(true);
+    if (!updateResult.ok) return;
+
+    const updated = getPolicy(validation.policy.id);
+    expect(updated!.name).toBe("Updated Policy");
+    expect(updated!.version).toBe("2.0.0");
+    expect(updated!.id).toBe(validation.policy.id);
+    expect(updated!.createdAt).toBe(validation.policy.createdAt);
+  });
+
+  it("returns error for non-existent policy", () => {
+    const result = updatePolicy("ghost", VALID_POLICY);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("evaluatePolicy", () => {
+  let policy: AllocationPolicy;
+
+  beforeEach(() => {
+    resetPolicyStore();
+    const validation = validatePolicy(VALID_POLICY);
+    if (!validation.ok) throw new Error("Invalid test policy");
+    policy = validation.policy;
+    storePolicy(policy);
+  });
+
+  it("matches the first rule when conditions are satisfied", () => {
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Blend",
+      tvlUsd: 5_000_000,
+      apyPct: 10,
+      volatilityPct: 8,
+      currentAllocationPct: 30,
+    };
+
+    const result = evaluatePolicy(policy, ctx);
+    expect(result.matched).toBe(true);
+    expect(result.ruleId).toBe("high-yield-stable");
+    expect(result.effectiveWeight).toBe(0.6);
+  });
+
+  it("matches second rule when first rule conditions fail", () => {
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Soroswap",
+      tvlUsd: 600_000,
+      apyPct: 12,
+      volatilityPct: 25,
+      currentAllocationPct: 20,
+    };
+
+    const result = evaluatePolicy(policy, ctx);
+    expect(result.matched).toBe(true);
+    expect(result.ruleId).toBe("growth-focused");
+    expect(result.effectiveWeight).toBe(0.4);
+  });
+
+  it("uses default rule when no rules match", () => {
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Unknown",
+      tvlUsd: 100_000,
+      apyPct: 3,
+      volatilityPct: 60,
+      currentAllocationPct: 5,
+    };
+
+    const result = evaluatePolicy(policy, ctx);
+    expect(result.matched).toBe(true);
+    expect(result.ruleId).toBeNull();
+    expect(result.effectiveWeight).toBe(0.5);
+  });
+
+  it("blocks vaults in denylist", () => {
+    const denylistPolicy = validatePolicy({
+      name: "Denylist Test",
+      version: "1.0",
+      rules: [
+        {
+          id: "no-defindex",
+          weight: 1.0,
+          conditions: { denylist: ["DeFindex"] },
+        },
+      ],
+    });
+    if (!denylistPolicy.ok) return;
+
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "DeFindex",
+      tvlUsd: 1_000_000,
+      apyPct: 10,
+      volatilityPct: 10,
+      currentAllocationPct: 10,
+    };
+
+    const result = evaluatePolicy(denylistPolicy.policy, ctx);
+    expect(result.matched).toBe(false);
+    expect(result.blocked.length).toBeGreaterThan(0);
+    expect(result.blocked[0]).toContain("denylist");
+  });
+
+  it("respects allowlist filtering", () => {
+    const allowlistPolicy = validatePolicy({
+      name: "Allowlist Test",
+      version: "1.0",
+      rules: [
+        {
+          id: "blend-only",
+          weight: 1.0,
+          conditions: { allowlist: ["Blend"] },
+        },
+      ],
+    });
+    if (!allowlistPolicy.ok) return;
+
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Soroswap",
+      tvlUsd: 1_000_000,
+      apyPct: 10,
+      volatilityPct: 10,
+      currentAllocationPct: 10,
+    };
+
+    const result = evaluatePolicy(allowlistPolicy.policy, ctx);
+    expect(result.matched).toBe(false);
+    expect(result.blocked[0]).toContain("allowlist");
+  });
+
+  it("enforces cooldown periods", () => {
+    const validation = validatePolicy(VALID_POLICY);
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+    markRuleExecuted(validation.policy.id, "high-yield-stable");
+
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Blend",
+      tvlUsd: 5_000_000,
+      apyPct: 10,
+      volatilityPct: 8,
+      currentAllocationPct: 30,
+    };
+
+    const result = evaluatePolicy(validation.policy, ctx);
+    expect(result.cooldownActive).toBe(true);
+    expect(result.ruleId).not.toBe("high-yield-stable");
+  });
+
+  it("enforces threshold constraints", () => {
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Blend",
+      tvlUsd: 5_000_000,
+      apyPct: 10,
+      volatilityPct: 8,
+      currentAllocationPct: 80,
+    };
+
+    const result = evaluatePolicy(policy, ctx);
+    expect(result.ruleId).not.toBe("high-yield-stable");
+    expect(result.reasons.some((r) => r.includes("threshold"))).toBe(true);
+  });
+
+  it("skips rule when TVL is below minTvl", () => {
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Blend",
+      tvlUsd: 100_000,
+      apyPct: 10,
+      volatilityPct: 8,
+      currentAllocationPct: 30,
+    };
+
+    const result = evaluatePolicy(policy, ctx);
+    expect(result.ruleId).not.toBe("high-yield-stable");
+    expect(result.reasons.some((r) => r.includes("minTvl"))).toBe(true);
+  });
+});
+
+describe("markRuleExecuted", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("sets cooldown timestamp on a rule", () => {
+    const validation = validatePolicy(VALID_POLICY);
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+    const success = markRuleExecuted(validation.policy.id, "high-yield-stable");
+    expect(success).toBe(true);
+
+    const policy = getPolicy(validation.policy.id);
+    const rule = policy!.rules.find((r) => r.id === "high-yield-stable");
+    expect(rule!.cooldown!.lastExecuted).toBeDefined();
+  });
+
+  it("returns false for non-existent policy", () => {
+    expect(markRuleExecuted("ghost", "rule-id")).toBe(false);
+  });
+
+  it("returns false for rule without cooldown config", () => {
+    const validation = validatePolicy({
+      ...VALID_POLICY,
+      rules: [
+        {
+          id: "no-cooldown",
+          weight: 1.0,
+          conditions: {},
+        },
+      ],
+    });
+    if (!validation.ok) return;
+
+    storePolicy(validation.policy);
+    expect(markRuleExecuted(validation.policy.id, "no-cooldown")).toBe(false);
+  });
+});
+
+describe("Policy lifecycle integration", () => {
+  beforeEach(() => {
+    resetPolicyStore();
+  });
+
+  it("full create → store → evaluate → update lifecycle", () => {
+    const v1 = validatePolicy(VALID_POLICY);
+    expect(v1.ok).toBe(true);
+    if (!v1.ok) return;
+
+    storePolicy(v1.policy);
+    expect(listPolicies()).toHaveLength(1);
+
+    const ctx: PolicyEvaluationContext = {
+      vaultId: "Blend",
+      tvlUsd: 5_000_000,
+      apyPct: 10,
+      volatilityPct: 8,
+      currentAllocationPct: 30,
+    };
+    const evalResult = evaluatePolicy(v1.policy, ctx);
+    expect(evalResult.matched).toBe(true);
+    expect(evalResult.ruleId).toBe("high-yield-stable");
+
+    const updated = updatePolicy(v1.policy.id, {
+      ...VALID_POLICY,
+      name: "Updated Strategy",
+      version: "2.0.0",
+    });
+    expect(updated.ok).toBe(true);
+    if (!updated.ok) return;
+
+    expect(updated.policy.name).toBe("Updated Strategy");
+
+    expect(deletePolicy(v1.policy.id)).toBe(true);
+    expect(listPolicies()).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/fragmentationHistory.test.ts
+++ b/server/src/__tests__/fragmentationHistory.test.ts
@@ -1,0 +1,186 @@
+import request from 'supertest';
+import { createApp } from '../app';
+import { getHistoricalServiceForTesting } from '../routes/fragmentation';
+import fc from 'fast-check';
+
+describe('GET /api/liquidity/fragmentation/history', () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    getHistoricalServiceForTesting().resetHistory();
+  });
+
+  describe('Basic functionality', () => {
+    it('returns 200 with snapshots array', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.data).toBeDefined();
+      expect(Array.isArray(res.body.data.snapshots)).toBe(true);
+      expect(res.body.data.snapshots.length).toBeGreaterThan(0);
+    });
+
+    it('includes data freshness metadata', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      expect(res.body.data.dataFreshness).toBeDefined();
+      expect(res.body.data.dataFreshness).toHaveProperty('earliestSnapshot');
+      expect(res.body.data.dataFreshness).toHaveProperty('latestSnapshot');
+      expect(res.body.data.dataFreshness).toHaveProperty('snapshotCount');
+      expect(res.body.data.dataFreshness.snapshotCount).toBe(res.body.data.snapshots.length);
+    });
+
+    it('includes source field', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      expect(['live', 'mock', 'historical']).toContain(res.body.data.source);
+    });
+  });
+
+  describe('Snapshot validation', () => {
+    it('each snapshot has required fields', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      res.body.data.snapshots.forEach((snapshot: Record<string, unknown>) => {
+        expect(snapshot).toHaveProperty('timestamp');
+        expect(snapshot).toHaveProperty('fragmentationScore');
+        expect(snapshot).toHaveProperty('effectiveProtocolCount');
+        expect(snapshot).toHaveProperty('hhi');
+        expect(snapshot).toHaveProperty('multiProtocolRoutingPct');
+        expect(snapshot).toHaveProperty('executionQualityScore');
+      });
+    });
+
+    it('fragmentationScore is in valid range [0, 100]', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      res.body.data.snapshots.forEach((snapshot: { fragmentationScore: number }) => {
+        expect(snapshot.fragmentationScore).toBeGreaterThanOrEqual(0);
+        expect(snapshot.fragmentationScore).toBeLessThanOrEqual(100);
+      });
+    });
+
+    it('executionQualityScore is in valid range [0, 100]', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      res.body.data.snapshots.forEach((snapshot: { executionQualityScore: number }) => {
+        expect(snapshot.executionQualityScore).toBeGreaterThanOrEqual(0);
+        expect(snapshot.executionQualityScore).toBeLessThanOrEqual(100);
+      });
+    });
+
+    it('effectiveProtocolCount is at least 1', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      res.body.data.snapshots.forEach((snapshot: { effectiveProtocolCount: number }) => {
+        expect(snapshot.effectiveProtocolCount).toBeGreaterThanOrEqual(1);
+      });
+    });
+
+    it('timestamps are valid ISO 8601', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      res.body.data.snapshots.forEach((snapshot: { timestamp: string }) => {
+        const ts = new Date(snapshot.timestamp);
+        expect(ts.getTime()).not.toBeNaN();
+      });
+    });
+  });
+
+  describe('Days parameter', () => {
+    it('respects days query parameter', async () => {
+      const res7 = await request(app).get('/api/liquidity/fragmentation/history?days=7');
+      expect(res7.body.data.snapshots.length).toBeLessThanOrEqual(7);
+
+      const res30 = await request(app).get('/api/liquidity/fragmentation/history?days=30');
+      expect(res30.body.data.snapshots.length).toBeGreaterThanOrEqual(res7.body.data.snapshots.length);
+    });
+
+    it('clamps days to min 1', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history?days=0');
+      expect(res.status).toBe(200);
+      expect(res.body.data.snapshots.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('clamps days to max 365', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history?days=500');
+      expect(res.status).toBe(200);
+    });
+
+    it('defaults to 30 days when not provided', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+      expect(res.status).toBe(200);
+      const resDefault = await request(app).get('/api/liquidity/fragmentation/history?days=30');
+      expect(res.body.data.snapshots.length).toBe(resDefault.body.data.snapshots.length);
+    });
+  });
+
+  describe('Cache headers', () => {
+    it('includes Cache-Control header', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      expect(res.headers['cache-control']).toBeDefined();
+      expect(res.headers['cache-control']).toContain('public');
+    });
+  });
+
+  describe('Property-based tests', () => {
+    it('all timestamps are chronological', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constant(null),
+          async () => {
+            const res = await request(app).get('/api/liquidity/fragmentation/history');
+            if (res.status !== 200) return true;
+
+            const snapshots = res.body.data.snapshots as { timestamp: string }[];
+            for (let i = 1; i < snapshots.length; i++) {
+              const prev = new Date(snapshots[i - 1].timestamp).getTime();
+              const curr = new Date(snapshots[i].timestamp).getTime();
+              expect(curr).toBeGreaterThan(prev);
+            }
+            return true;
+          },
+        ),
+        { numRuns: 50 },
+      );
+    }, 30000);
+
+    it('fragmentationScore and executionQualityScore are always in [0, 100]', async () => {
+      await fc.assert(
+        fc.asyncProperty(
+          fc.constant(null),
+          async () => {
+            const res = await request(app).get('/api/liquidity/fragmentation/history');
+            if (res.status !== 200) return true;
+
+            const snapshots = res.body.data.snapshots as {
+              fragmentationScore: number;
+              executionQualityScore: number;
+            }[];
+            snapshots.forEach((s) => {
+              expect(s.fragmentationScore).toBeGreaterThanOrEqual(0);
+              expect(s.fragmentationScore).toBeLessThanOrEqual(100);
+              expect(s.executionQualityScore).toBeGreaterThanOrEqual(0);
+              expect(s.executionQualityScore).toBeLessThanOrEqual(100);
+            });
+            return true;
+          },
+        ),
+        { numRuns: 50 },
+      );
+    }, 30000);
+  });
+
+  describe('Warning scenarios', () => {
+    it('includes mock data warning when source is mock', async () => {
+      const res = await request(app).get('/api/liquidity/fragmentation/history');
+
+      if (res.body.data.source === 'mock') {
+        expect(res.body.data.warnings).toBeDefined();
+        expect(res.body.data.warnings.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/server/src/__tests__/recommendationTimelineService.test.ts
+++ b/server/src/__tests__/recommendationTimelineService.test.ts
@@ -2,6 +2,7 @@ import {
   getRecommendationTimeline,
   recordRecommendation,
   resetRecommendationTimelineStore,
+  REASON_CODE_LABELS,
 } from "../services/recommendationTimelineService";
 
 describe("recommendationTimelineService", () => {
@@ -9,8 +10,8 @@ describe("recommendationTimelineService", () => {
     resetRecommendationTimelineStore();
   });
 
-  it("stores recommendation history with timestamps", () => {
-    const entry = recordRecommendation("user-1", {
+  it("stores recommendation history with timestamps", async () => {
+    const entry = await recordRecommendation("user-1", {
       recommendation: "Allocate to Blend vault.",
       targetVault: "Blend Stable",
       rationale: "Stable fees and deep liquidity.",
@@ -28,8 +29,8 @@ describe("recommendationTimelineService", () => {
     expect(timeline[0].changedInputs).toContain("initial-baseline");
   });
 
-  it("tracks changed inputs against prior recommendation", () => {
-    recordRecommendation("user-2", {
+  it("tracks changed inputs against prior recommendation", async () => {
+    await recordRecommendation("user-2", {
       recommendation: "Use DeFindex index vault.",
       targetVault: "DeFindex Index",
       rationale: "Diversified routing.",
@@ -41,7 +42,7 @@ describe("recommendationTimelineService", () => {
       },
     });
 
-    const updated = recordRecommendation("user-2", {
+    const updated = await recordRecommendation("user-2", {
       recommendation: "Switch to Soroswap LP.",
       targetVault: "Soroswap LP",
       rationale: "Yield increased after volatility shift.",
@@ -56,5 +57,201 @@ describe("recommendationTimelineService", () => {
     expect(updated.changedInputs).toEqual(
       expect.arrayContaining(["riskTolerance", "expectedApy", "volatilityPct"]),
     );
+  });
+
+  describe("reasonCodes", () => {
+    it("generates initial-baseline reason code for first entry", async () => {
+      const entry = await recordRecommendation("user-3", {
+        recommendation: "Start with Blend.",
+        targetVault: "Blend",
+        rationale: "Getting started.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      expect(entry.reasonCodes).toHaveLength(1);
+      expect(entry.reasonCodes[0].code).toBe("initial-baseline");
+    });
+
+    it("generates apy-shift reason code when APY changes ≥ 0.5", async () => {
+      await recordRecommendation("user-4", {
+        recommendation: "First.",
+        targetVault: "Vault A",
+        rationale: "Initial.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      const second = await recordRecommendation("user-4", {
+        recommendation: "Second.",
+        targetVault: "Vault B",
+        rationale: "Changed.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 7.5,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      expect(second.reasonCodes.some((rc) => rc.code === "apy-shift")).toBe(true);
+      expect(second.reasonCodes.some((rc) => rc.code === "initial-baseline")).toBe(false);
+    });
+
+    it("generates volatility-change reason code when volatility changes ≥ 1", async () => {
+      await recordRecommendation("user-5", {
+        recommendation: "First.",
+        targetVault: "Vault A",
+        rationale: "Initial.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 3,
+        },
+      });
+
+      const second = await recordRecommendation("user-5", {
+        recommendation: "Second.",
+        targetVault: "Vault B",
+        rationale: "Changed.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 7,
+        },
+      });
+
+      expect(second.reasonCodes.some((rc) => rc.code === "volatility-change")).toBe(true);
+      const volRc = second.reasonCodes.find((rc) => rc.code === "volatility-change");
+      expect(volRc?.previousValue).toBe(3);
+      expect(volRc?.currentValue).toBe(7);
+    });
+
+    it("generates risk-tolerance-change reason code", async () => {
+      await recordRecommendation("user-6", {
+        recommendation: "First.",
+        targetVault: "Vault A",
+        rationale: "Initial.",
+        inputSnapshot: {
+          riskTolerance: "low",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      const second = await recordRecommendation("user-6", {
+        recommendation: "Second.",
+        targetVault: "Vault B",
+        rationale: "Changed.",
+        inputSnapshot: {
+          riskTolerance: "high",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      expect(second.reasonCodes.some((rc) => rc.code === "risk-tolerance-change")).toBe(true);
+      const rtRc = second.reasonCodes.find((rc) => rc.code === "risk-tolerance-change");
+      expect(rtRc?.previousValue).toBe("low");
+      expect(rtRc?.currentValue).toBe("high");
+    });
+
+    it("generates liquidity-change reason code when liquidity changes ≥ 50k", async () => {
+      await recordRecommendation("user-7", {
+        recommendation: "First.",
+        targetVault: "Vault A",
+        rationale: "Initial.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 500_000,
+          volatilityPct: 5,
+        },
+      });
+
+      const second = await recordRecommendation("user-7", {
+        recommendation: "Second.",
+        targetVault: "Vault B",
+        rationale: "Changed.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      expect(second.reasonCodes.some((rc) => rc.code === "liquidity-change")).toBe(true);
+    });
+
+    it("includes severity levels in reason codes", async () => {
+      const entry = await recordRecommendation("user-8", {
+        recommendation: "Test.",
+        targetVault: "Vault",
+        rationale: "Testing severity.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      const rc = entry.reasonCodes[0];
+      expect(["info", "warning", "critical"]).toContain(rc.severity);
+    });
+
+    it("includes reason code labels from REASON_CODE_LABELS", async () => {
+      const entry = await recordRecommendation("user-9", {
+        recommendation: "Test.",
+        targetVault: "Vault",
+        rationale: "Testing labels.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 6,
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+
+      const rc = entry.reasonCodes[0];
+      expect(rc.label).toBe(REASON_CODE_LABELS[rc.code].label);
+      expect(rc.description).toBe(REASON_CODE_LABELS[rc.code].description);
+    });
+  });
+
+  it("returns empty array for unknown user", () => {
+    expect(getRecommendationTimeline("unknown-user")).toEqual([]);
+  });
+
+  it("caps entries at MAX_ENTRIES_PER_USER", async () => {
+    const many = Array.from({ length: 25 }, (_, i) => i);
+    for (const i of many) {
+      await recordRecommendation("user-capped", {
+        recommendation: `Entry ${i}`,
+        targetVault: "Vault",
+        rationale: "Bulk add.",
+        inputSnapshot: {
+          riskTolerance: "medium",
+          expectedApy: 5 + Math.random(),
+          liquidityDepthUsd: 1_000_000,
+          volatilityPct: 5,
+        },
+      });
+    }
+    const timeline = getRecommendationTimeline("user-capped");
+    expect(timeline.length).toBeLessThanOrEqual(20);
   });
 });

--- a/server/src/__tests__/zapQuote.test.ts
+++ b/server/src/__tests__/zapQuote.test.ts
@@ -25,6 +25,9 @@ describe("quoteFallback", () => {
     });
     expect(q.expectedAmountOutStroops).toBe("10000000");
     expect(q.source).toBe("fallback_rate");
+    expect(q.isFallback).toBe(true);
+    expect(q.quotedAt).toBeDefined();
+    expect(q.minAmountOutStroops).toBeDefined();
   });
 
   it("scales by fallback ratio when tokens differ", () => {
@@ -43,6 +46,7 @@ describe("quoteFallback", () => {
 
     expect(q.expectedAmountOutStroops).toBe("15000000");
     expect(q.path).toHaveLength(2);
+    expect(q.isFallback).toBe(true);
 
     if (prevNum === undefined) {
       delete process.env.ZAP_FALLBACK_NUMERATOR;
@@ -54,6 +58,32 @@ describe("quoteFallback", () => {
     } else {
       process.env.ZAP_FALLBACK_DENOMINATOR = prevDen;
     }
+  });
+
+  it("includes quotedAt timestamp", () => {
+    const before = Date.now();
+    const q = quoteFallback({
+      inputTokenContract: "A",
+      vaultTokenContract: "A",
+      amountInStroops: "1000",
+      inputDecimals: 7,
+      vaultDecimals: 7,
+    });
+    const after = Date.now();
+    const ts = new Date(q.quotedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("includes minAmountOutStroops", () => {
+    const q = quoteFallback({
+      inputTokenContract: "A",
+      vaultTokenContract: "A",
+      amountInStroops: "5000000",
+      inputDecimals: 7,
+      vaultDecimals: 7,
+    });
+    expect(q.minAmountOutStroops).toBe("5000000");
   });
 });
 
@@ -73,6 +103,9 @@ describe("getZapQuote", () => {
     });
 
     expect(q.expectedAmountOutStroops).toBe("42");
+    expect(q.isFallback).toBe(true);
+    expect(q.quotedAt).toBeDefined();
+    expect(typeof q.quoteAgeMs).toBe("number");
 
     if (prevSim !== undefined) {
       process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT = prevSim;
@@ -109,6 +142,7 @@ describe("getZapQuote", () => {
 
     expect(q.expectedAmountOutStroops).toBe("42");
     expect(q.source).toBe("fallback_rate");
+    expect(q.isFallback).toBe(true);
 
     jest.restoreAllMocks();
 
@@ -120,5 +154,55 @@ describe("getZapQuote", () => {
 
     if (prevTimeout !== undefined) process.env.SOROBAN_RPC_TIMEOUT_MS = prevTimeout;
     else delete process.env.SOROBAN_RPC_TIMEOUT_MS;
+  });
+
+  describe("quote metadata", () => {
+    it("includes quotedAt and minAmountOutStroops", async () => {
+      const prevRouter = process.env.DEX_ROUTER_CONTRACT_ID;
+      const prevSim = process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+      delete process.env.DEX_ROUTER_CONTRACT_ID;
+      delete process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+
+      const q = await getZapQuote({
+        inputTokenContract: "A",
+        vaultTokenContract: "B",
+        amountInStroops: "1000000",
+        inputDecimals: 7,
+        vaultDecimals: 7,
+      });
+
+      expect(q.quotedAt).toBeDefined();
+      expect(() => new Date(q.quotedAt)).not.toThrow();
+      expect(q.minAmountOutStroops).toBeDefined();
+      expect(BigInt(q.minAmountOutStroops) > 0n).toBe(true);
+      expect(typeof q.quoteAgeMs).toBe("number");
+
+      if (prevSim !== undefined) process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT = prevSim;
+      else delete process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+      if (prevRouter !== undefined) process.env.DEX_ROUTER_CONTRACT_ID = prevRouter;
+      else delete process.env.DEX_ROUTER_CONTRACT_ID;
+    });
+
+    it("marks fallback quotes correctly", async () => {
+      const prevRouter = process.env.DEX_ROUTER_CONTRACT_ID;
+      const prevSim = process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+      delete process.env.DEX_ROUTER_CONTRACT_ID;
+      delete process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+
+      const q = await getZapQuote({
+        inputTokenContract: "A",
+        vaultTokenContract: "B",
+        amountInStroops: "1000000",
+        inputDecimals: 7,
+        vaultDecimals: 7,
+      });
+
+      expect(q.isFallback).toBe(true);
+
+      if (prevSim !== undefined) process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT = prevSim;
+      else delete process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
+      if (prevRouter !== undefined) process.env.DEX_ROUTER_CONTRACT_ID = prevRouter;
+      else delete process.env.DEX_ROUTER_CONTRACT_ID;
+    });
   });
 });

--- a/server/src/__tests__/zapRoute.test.ts
+++ b/server/src/__tests__/zapRoute.test.ts
@@ -43,4 +43,64 @@ describe("POST /api/zap/quote", () => {
 
     expect(res.status).toBe(400);
   });
+
+  describe("enhanced quote metadata", () => {
+    it("includes quotedAt timestamp", async () => {
+      const res = await request(createApp())
+        .post("/api/zap/quote")
+        .send({
+          inputTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          vaultTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          amountInStroops: "1000",
+          inputDecimals: 7,
+          vaultDecimals: 7,
+        });
+
+      expect(res.body.quotedAt).toBeDefined();
+      expect(() => new Date(res.body.quotedAt)).not.toThrow();
+    });
+
+    it("includes minAmountOutStroops", async () => {
+      const res = await request(createApp())
+        .post("/api/zap/quote")
+        .send({
+          inputTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          vaultTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          amountInStroops: "1000",
+          inputDecimals: 7,
+          vaultDecimals: 7,
+        });
+
+      expect(res.body.minAmountOutStroops).toBeDefined();
+    });
+
+    it("includes isFallback flag", async () => {
+      const res = await request(createApp())
+        .post("/api/zap/quote")
+        .send({
+          inputTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          vaultTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          amountInStroops: "1000",
+          inputDecimals: 7,
+          vaultDecimals: 7,
+        });
+
+      expect(res.body.isFallback).toBe(true);
+    });
+
+    it("includes slippageApplied and amountOutAfterSlippage", async () => {
+      const res = await request(createApp())
+        .post("/api/zap/quote")
+        .send({
+          inputTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          vaultTokenContract: "CDSAMEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+          amountInStroops: "1000",
+          inputDecimals: 7,
+          vaultDecimals: 7,
+        });
+
+      expect(typeof res.body.slippageApplied).toBe("number");
+      expect(res.body.amountOutAfterSlippage).toBeDefined();
+    });
+  });
 });

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -37,6 +37,7 @@ import treasuryRouter from "./routes/treasury";
 import governanceRouter from "./routes/governance";
 import presetsRouter from "./routes/presets";
 import analyticsRouter from "./routes/analytics";
+import fragmentationRouter from "./routes/fragmentation";
 import { createAuthChallenge, verifyAuthChallenge } from "./utils/stellarAuth";
 import {
   getRecommendationTimeline,
@@ -120,6 +121,7 @@ export function createApp() {
   app.use("/api/governance", governanceRouter);
   app.use("/api/presets", presetsRouter);
   app.use("/api/analytics", analyticsRouter);
+app.use("/api/liquidity", fragmentationRouter);
 
   // Legacy JSON metrics (internal tooling)
   app.get("/api/metrics", getMetrics);

--- a/server/src/config/protocols.ts
+++ b/server/src/config/protocols.ts
@@ -7,7 +7,6 @@ export interface ProtocolConfig {
   baseTvlUsd: number;
   volatilityPct: number;
   protocolAgeDays: number;
-  protocolAgeDays: number;
   source: string;
   liquidityUsd: number;
   rebalancingBehavior: string;

--- a/server/src/routes/fragmentation.ts
+++ b/server/src/routes/fragmentation.ts
@@ -291,6 +291,85 @@ export function resetFragmentationServiceForTesting(): void {
   (fragmentationService as any).lastSuccessfulUpdate = null;
 }
 
+export interface FragmentationHistorySnapshot {
+  timestamp: string;
+  fragmentationScore: number;
+  effectiveProtocolCount: number;
+  hhi: number;
+  multiProtocolRoutingPct: number;
+  executionQualityScore: number;
+}
+
+export interface FragmentationHistoryResponse {
+  success: boolean;
+  data: {
+    snapshots: FragmentationHistorySnapshot[];
+    source: "live" | "mock" | "historical";
+    dataFreshness: {
+      earliestSnapshot: string;
+      latestSnapshot: string;
+      snapshotCount: number;
+    };
+    warnings?: string[];
+  };
+}
+
+class MockHistoricalService {
+  private historyStore: FragmentationHistorySnapshot[] | null = null;
+
+  private generateMockHistory(): FragmentationHistorySnapshot[] {
+    const snapshots: FragmentationHistorySnapshot[] = [];
+    const now = Date.now();
+    const baseScore = 45;
+    const baseProtocols = 1.82;
+
+    for (let i = 29; i >= 0; i--) {
+      const ts = new Date(now - i * 24 * 60 * 60 * 1000);
+      const noise = (Math.random() - 0.5) * 10;
+      const protocolNoise = (Math.random() - 0.5) * 0.4;
+      snapshots.push({
+        timestamp: ts.toISOString(),
+        fragmentationScore: Math.max(0, Math.min(100, baseScore + noise + (i % 5) * 1.5)),
+        effectiveProtocolCount: Math.max(1, baseProtocols + protocolNoise + (i % 7) * 0.1),
+        hhi: Math.round(5000 + (Math.random() - 0.5) * 1000),
+        multiProtocolRoutingPct: Math.max(0, Math.min(100, 35 + (Math.random() - 0.5) * 10)),
+        executionQualityScore: Math.max(0, Math.min(100, 72 + (Math.random() - 0.5) * 8)),
+      });
+    }
+
+    return snapshots;
+  }
+
+  async getHistory(
+    days: number = 30,
+  ): Promise<FragmentationHistorySnapshot[]> {
+    if (!this.historyStore) {
+      this.historyStore = this.generateMockHistory();
+    }
+
+    const snapshots = this.historyStore.slice(-days);
+    if (snapshots.length === 0) {
+      throw new DataUnavailableError("No historical fragmentation data available");
+    }
+
+    return snapshots;
+  }
+
+  resetHistory(): void {
+    this.historyStore = null;
+  }
+}
+
+const historicalService = new MockHistoricalService();
+
+/**
+ * Expose historical service for testing
+ * @internal
+ */
+export function getHistoricalServiceForTesting(): MockHistoricalService {
+  return historicalService;
+}
+
 /**
  * Create fragmentation router
  */
@@ -308,6 +387,67 @@ export function createFragmentationRouter(): Router {
    * - Calculation errors: HTTP 500
    * - Invalid requests: HTTP 400
    */
+  /**
+   * GET /api/liquidity/fragmentation/history
+   * Returns historical fragmentation snapshots for trend analysis
+   */
+  router.get('/fragmentation/history', async (req: Request, res: Response) => {
+    const startTime = Date.now();
+
+    try {
+      const days = Math.min(Math.max(parseInt(req.query.days as string) || 30, 1), 365);
+
+      const snapshots = await historicalService.getHistory(days);
+      const earliestSnapshot = snapshots[0]?.timestamp || new Date().toISOString();
+      const latestSnapshot = snapshots[snapshots.length - 1]?.timestamp || new Date().toISOString();
+
+      const warnings: string[] = [];
+      const source = process.env.FRAGMENTATION_HISTORY_SOURCE === "live" ? "live" : "mock";
+
+      if (source === "mock") {
+        warnings.push("Historical data based on simulated projections. Actual historical data may vary.");
+      }
+
+      const response: FragmentationHistoryResponse = {
+        success: true,
+        data: {
+          snapshots,
+          source,
+          dataFreshness: {
+            earliestSnapshot,
+            latestSnapshot,
+            snapshotCount: snapshots.length,
+          },
+          ...(warnings.length > 0 && { warnings }),
+        },
+      };
+
+      res.setHeader('Cache-Control', 'public, max-age=3600');
+      res.status(200).json(response);
+    } catch (error) {
+      if (error instanceof DataUnavailableError) {
+        const errorResponse: FragmentationErrorResponse = {
+          success: false,
+          error: {
+            code: 'HISTORY_UNAVAILABLE',
+            message: error.message,
+          },
+        };
+        res.status(503).json(errorResponse);
+        return;
+      }
+
+      const errorResponse: FragmentationErrorResponse = {
+        success: false,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'An unexpected error occurred while fetching historical data',
+        },
+      };
+      res.status(500).json(errorResponse);
+    }
+  });
+
   router.get('/fragmentation', async (req: Request, res: Response) => {
     const startTime = Date.now();
 

--- a/server/src/routes/zap.ts
+++ b/server/src/routes/zap.ts
@@ -30,6 +30,7 @@ router.post("/quote", validateZapQuote, async (req: Request, res: Response) => {
       amountInStroops: String(b.amountInStroops),
       inputDecimals: Number(b.inputDecimals ?? 7),
       vaultDecimals: Number(b.vaultDecimals ?? 7),
+      slippageTolerance: b.slippageTolerance !== undefined ? Number(b.slippageTolerance) : undefined,
     };
 
     const quote = await getZapQuote(body);
@@ -37,6 +38,12 @@ router.post("/quote", validateZapQuote, async (req: Request, res: Response) => {
       path: quote.path,
       expectedAmountOutStroops: quote.expectedAmountOutStroops,
       source: quote.source,
+      slippageApplied: quote.slippageApplied,
+      amountOutAfterSlippage: quote.amountOutAfterSlippage,
+      quotedAt: quote.quotedAt,
+      minAmountOutStroops: quote.minAmountOutStroops,
+      quoteAgeMs: quote.quoteAgeMs,
+      isFallback: quote.isFallback,
     });
   } catch (e) {
     sendError(

--- a/server/src/services/allocationPolicyDsl.ts
+++ b/server/src/services/allocationPolicyDsl.ts
@@ -1,0 +1,398 @@
+export interface AllocationRuleCondition {
+  allowlist?: string[];
+  denylist?: string[];
+  minTvl?: number;
+  maxTvl?: number;
+  minApy?: number;
+  maxApy?: number;
+  maxVolatility?: number;
+}
+
+export interface AllocationRuleCooldown {
+  durationMs: number;
+  lastExecuted?: string;
+}
+
+export interface AllocationRuleThreshold {
+  min?: number;
+  max?: number;
+}
+
+export interface AllocationRule {
+  id: string;
+  description?: string;
+  weight: number;
+  conditions: AllocationRuleCondition;
+  cooldown?: AllocationRuleCooldown;
+  threshold?: AllocationRuleThreshold;
+}
+
+export interface AllocationPolicy {
+  id: string;
+  name: string;
+  description?: string;
+  version: string;
+  rules: AllocationRule[];
+  defaultRule?: AllocationRule;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PolicyEvaluationContext {
+  vaultId: string;
+  tvlUsd: number;
+  apyPct: number;
+  volatilityPct: number;
+  currentAllocationPct: number;
+}
+
+export interface PolicyEvaluationResult {
+  matched: boolean;
+  ruleId: string | null;
+  effectiveWeight: number;
+  reasons: string[];
+  blocked: string[];
+  cooldownActive: boolean;
+}
+
+export interface PolicyValidationError {
+  path: string;
+  message: string;
+  code: string;
+}
+
+export type PolicyValidationResult =
+  | { ok: true; policy: AllocationPolicy }
+  | { ok: false; errors: PolicyValidationError[] };
+
+const RESERVED_RULE_IDS = ["__default__", "__fallback__"];
+
+const policyStore = new Map<string, AllocationPolicy>();
+
+function generateId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function validatePolicy(raw: unknown): PolicyValidationResult {
+  const errors: PolicyValidationError[] = [];
+
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      errors: [{ path: "", message: "Policy must be a non-null object", code: "INVALID_TYPE" }],
+    };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (typeof obj.name !== "string" || obj.name.trim().length === 0) {
+    errors.push({ path: "name", message: "name is required and must be a non-empty string", code: "REQUIRED" });
+  }
+
+  if (typeof obj.version !== "string" || obj.version.trim().length === 0) {
+    errors.push({ path: "version", message: "version is required and must be a non-empty string", code: "REQUIRED" });
+  }
+
+  if (typeof obj.description !== "undefined" && typeof obj.description !== "string") {
+    errors.push({ path: "description", message: "description must be a string", code: "INVALID_TYPE" });
+  }
+
+  if (!Array.isArray(obj.rules)) {
+    errors.push({ path: "rules", message: "rules must be a non-empty array", code: "REQUIRED" });
+    return { ok: false, errors };
+  }
+
+  if (obj.rules.length === 0) {
+    errors.push({ path: "rules", message: "rules must contain at least one rule", code: "MIN_LENGTH" });
+  }
+
+  const seenIds = new Set<string>();
+  (obj.rules as unknown[]).forEach((rule, index) => {
+    const ruleObj = rule as Record<string, unknown>;
+    const prefix = `rules[${index}]`;
+
+    if (!ruleObj || typeof ruleObj !== "object") {
+      errors.push({ path: prefix, message: "Each rule must be a non-null object", code: "INVALID_TYPE" });
+      return;
+    }
+
+    if (typeof ruleObj.id !== "string" || ruleObj.id.trim().length === 0) {
+      errors.push({ path: `${prefix}.id`, message: "rule.id is required and must be a non-empty string", code: "REQUIRED" });
+    } else {
+      if (RESERVED_RULE_IDS.includes(ruleObj.id as string)) {
+        errors.push({ path: `${prefix}.id`, message: `rule.id "${ruleObj.id}" is reserved`, code: "RESERVED_ID" });
+      }
+      if (seenIds.has(ruleObj.id as string)) {
+        errors.push({ path: `${prefix}.id`, message: `Duplicate rule id "${ruleObj.id}"`, code: "DUPLICATE_ID" });
+      }
+      seenIds.add(ruleObj.id as string);
+    }
+
+    if (typeof ruleObj.weight !== "number" || ruleObj.weight < 0 || ruleObj.weight > 1) {
+      errors.push({ path: `${prefix}.weight`, message: "rule.weight must be a number between 0 and 1", code: "INVALID_RANGE" });
+    }
+
+    if (typeof ruleObj.conditions !== "object" || ruleObj.conditions === null) {
+      errors.push({ path: `${prefix}.conditions`, message: "rule.conditions must be an object", code: "REQUIRED" });
+    } else {
+      const cond = ruleObj.conditions as Record<string, unknown>;
+
+      if (cond.allowlist !== undefined) {
+        if (!Array.isArray(cond.allowlist) || !(cond.allowlist as unknown[]).every((v) => typeof v === "string")) {
+          errors.push({ path: `${prefix}.conditions.allowlist`, message: "allowlist must be an array of strings", code: "INVALID_TYPE" });
+        }
+      }
+
+      if (cond.denylist !== undefined) {
+        if (!Array.isArray(cond.denylist) || !(cond.denylist as unknown[]).every((v) => typeof v === "string")) {
+          errors.push({ path: `${prefix}.conditions.denylist`, message: "denylist must be an array of strings", code: "INVALID_TYPE" });
+        }
+      }
+
+      if (cond.minTvl !== undefined && (typeof cond.minTvl !== "number" || cond.minTvl < 0)) {
+        errors.push({ path: `${prefix}.conditions.minTvl`, message: "minTvl must be a non-negative number", code: "INVALID_RANGE" });
+      }
+
+      if (cond.maxTvl !== undefined && (typeof cond.maxTvl !== "number" || cond.maxTvl < 0)) {
+        errors.push({ path: `${prefix}.conditions.maxTvl`, message: "maxTvl must be a non-negative number", code: "INVALID_RANGE" });
+      }
+
+      if (cond.maxVolatility !== undefined && (typeof cond.maxVolatility !== "number" || cond.maxVolatility < 0 || cond.maxVolatility > 100)) {
+        errors.push({ path: `${prefix}.conditions.maxVolatility`, message: "maxVolatility must be a number between 0 and 100", code: "INVALID_RANGE" });
+      }
+
+      if (cond.minApy !== undefined && typeof cond.minApy !== "number") {
+        errors.push({ path: `${prefix}.conditions.minApy`, message: "minApy must be a number", code: "INVALID_TYPE" });
+      }
+
+      if (cond.maxApy !== undefined && typeof cond.maxApy !== "number") {
+        errors.push({ path: `${prefix}.conditions.maxApy`, message: "maxApy must be a number", code: "INVALID_TYPE" });
+      }
+    }
+
+    if (ruleObj.cooldown !== undefined) {
+      if (typeof ruleObj.cooldown !== "object" || ruleObj.cooldown === null) {
+        errors.push({ path: `${prefix}.cooldown`, message: "cooldown must be an object", code: "INVALID_TYPE" });
+      } else {
+        const cd = ruleObj.cooldown as Record<string, unknown>;
+        if (typeof cd.durationMs !== "number" || cd.durationMs < 0) {
+          errors.push({ path: `${prefix}.cooldown.durationMs`, message: "cooldown.durationMs must be a non-negative number", code: "INVALID_RANGE" });
+        }
+      }
+    }
+
+    if (ruleObj.threshold !== undefined) {
+      if (typeof ruleObj.threshold !== "object" || ruleObj.threshold === null) {
+        errors.push({ path: `${prefix}.threshold`, message: "threshold must be an object", code: "INVALID_TYPE" });
+      } else {
+        const th = ruleObj.threshold as Record<string, unknown>;
+        if (th.min !== undefined && typeof th.min !== "number") {
+          errors.push({ path: `${prefix}.threshold.min`, message: "threshold.min must be a number", code: "INVALID_TYPE" });
+        }
+        if (th.max !== undefined && typeof th.max !== "number") {
+          errors.push({ path: `${prefix}.threshold.max`, message: "threshold.max must be a number", code: "INVALID_TYPE" });
+        }
+      }
+    }
+  });
+
+  const totalWeight = (obj.rules as unknown[]).reduce<number>((sum, rule) => {
+    const r = rule as Record<string, unknown>;
+    return sum + (typeof r.weight === "number" ? r.weight : 0);
+  }, 0);
+
+  if (totalWeight > 0 && Math.abs(totalWeight - 1) > 0.001) {
+    errors.push({
+      path: "rules",
+      message: `Total weight of all rules must sum to 1.0 (got ${totalWeight.toFixed(3)})`,
+      code: "WEIGHT_SUM",
+    });
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  const now = new Date().toISOString();
+  const policy: AllocationPolicy = {
+    id: (obj.id as string) || generateId(),
+    name: (obj.name as string).trim(),
+    description: (obj.description as string)?.trim(),
+    version: (obj.version as string).trim(),
+    rules: (obj.rules as unknown[]).map((rule) => {
+      const r = rule as Record<string, unknown>;
+      const conditions = r.conditions as AllocationRuleCondition;
+      return {
+        id: r.id as string,
+        description: r.description as string | undefined,
+        weight: r.weight as number,
+        conditions,
+        cooldown: r.cooldown ? {
+          durationMs: (r.cooldown as Record<string, unknown>).durationMs as number,
+          lastExecuted: (r.cooldown as Record<string, unknown>).lastExecuted as string | undefined,
+        } : undefined,
+        threshold: r.threshold ? {
+          min: (r.threshold as Record<string, unknown>).min as number | undefined,
+          max: (r.threshold as Record<string, unknown>).max as number | undefined,
+        } : undefined,
+      };
+    }),
+    defaultRule: obj.defaultRule
+      ? ({
+          id: "__default__",
+          weight: 0.5,
+          conditions: (obj.defaultRule as Record<string, unknown>).conditions as AllocationRuleCondition || {},
+        } as AllocationRule)
+      : undefined,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  return { ok: true, policy };
+}
+
+export function storePolicy(policy: AllocationPolicy): void {
+  policyStore.set(policy.id, policy);
+}
+
+export function getPolicy(id: string): AllocationPolicy | undefined {
+  return policyStore.get(id);
+}
+
+export function listPolicies(): AllocationPolicy[] {
+  return Array.from(policyStore.values());
+}
+
+export function deletePolicy(id: string): boolean {
+  return policyStore.delete(id);
+}
+
+export function updatePolicy(id: string, raw: unknown): PolicyValidationResult {
+  const existing = policyStore.get(id);
+  if (!existing) {
+    return { ok: false, errors: [{ path: "id", message: `Policy "${id}" not found`, code: "NOT_FOUND" }] };
+  }
+
+  const validation = validatePolicy(raw);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  const policy: AllocationPolicy = {
+    ...validation.policy,
+    id: existing.id,
+    createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+
+  policyStore.set(id, policy);
+  return { ok: true, policy };
+}
+
+export function resetPolicyStore(): void {
+  policyStore.clear();
+}
+
+function isOnCooldown(rule: AllocationRule): boolean {
+  if (!rule.cooldown || !rule.cooldown.lastExecuted) return false;
+  const elapsed = Date.now() - new Date(rule.cooldown.lastExecuted).getTime();
+  return elapsed < rule.cooldown.durationMs;
+}
+
+export function evaluatePolicy(
+  policy: AllocationPolicy,
+  ctx: PolicyEvaluationContext,
+): PolicyEvaluationResult {
+  const reasons: string[] = [];
+  const blocked: string[] = [];
+  let matched = false;
+  let matchedRuleId: string | null = null;
+  let effectiveWeight = policy.defaultRule?.weight ?? 0.5;
+  let cooldownActive = false;
+
+  for (const rule of policy.rules) {
+    const cond = rule.conditions;
+
+    if (cond.allowlist && cond.allowlist.length > 0) {
+      if (!cond.allowlist.includes(ctx.vaultId)) {
+        blocked.push(`Vault "${ctx.vaultId}" not in allowlist for rule "${rule.id}"`);
+        continue;
+      }
+    }
+
+    if (cond.denylist && cond.denylist.length > 0) {
+      if (cond.denylist.includes(ctx.vaultId)) {
+        blocked.push(`Vault "${ctx.vaultId}" in denylist for rule "${rule.id}"`);
+        continue;
+      }
+    }
+
+    if (cond.minTvl !== undefined && ctx.tvlUsd < cond.minTvl) {
+      reasons.push(`TVL ${ctx.tvlUsd} below minTvl ${cond.minTvl} for rule "${rule.id}"`);
+      continue;
+    }
+
+    if (cond.maxTvl !== undefined && ctx.tvlUsd > cond.maxTvl) {
+      reasons.push(`TVL ${ctx.tvlUsd} above maxTvl ${cond.maxTvl} for rule "${rule.id}"`);
+      continue;
+    }
+
+    if (cond.minApy !== undefined && ctx.apyPct < cond.minApy) {
+      reasons.push(`APY ${ctx.apyPct}% below minApy ${cond.minApy}% for rule "${rule.id}"`);
+      continue;
+    }
+
+    if (cond.maxApy !== undefined && ctx.apyPct > cond.maxApy) {
+      reasons.push(`APY ${ctx.apyPct}% above maxApy ${cond.maxApy}% for rule "${rule.id}"`);
+      continue;
+    }
+
+    if (cond.maxVolatility !== undefined && ctx.volatilityPct > cond.maxVolatility) {
+      reasons.push(`Volatility ${ctx.volatilityPct}% above maxVolatility ${cond.maxVolatility}% for rule "${rule.id}"`);
+      continue;
+    }
+
+    if (rule.threshold) {
+      if (rule.threshold.min !== undefined && ctx.currentAllocationPct < rule.threshold.min) {
+        reasons.push(`Allocation ${ctx.currentAllocationPct}% below threshold min ${rule.threshold.min}% for rule "${rule.id}"`);
+        continue;
+      }
+      if (rule.threshold.max !== undefined && ctx.currentAllocationPct > rule.threshold.max) {
+        reasons.push(`Allocation ${ctx.currentAllocationPct}% above threshold max ${rule.threshold.max}% for rule "${rule.id}"`);
+        continue;
+      }
+    }
+
+    if (isOnCooldown(rule)) {
+      cooldownActive = true;
+      reasons.push(`Rule "${rule.id}" is on cooldown until ${rule.cooldown!.lastExecuted}`);
+      continue;
+    }
+
+    matched = true;
+    matchedRuleId = rule.id;
+    effectiveWeight = rule.weight;
+    reasons.push(`Matched rule "${rule.id}" with weight ${rule.weight}`);
+    break;
+  }
+
+  if (!matched && policy.defaultRule) {
+    matched = true;
+    reasons.push(`No rule matched, using default rule with weight ${policy.defaultRule.weight}`);
+  }
+
+  return { matched, ruleId: matchedRuleId, effectiveWeight, reasons, blocked, cooldownActive };
+}
+
+export function markRuleExecuted(policyId: string, ruleId: string): boolean {
+  const policy = policyStore.get(policyId);
+  if (!policy) return false;
+
+  const rule = policy.rules.find((r) => r.id === ruleId);
+  if (!rule || !rule.cooldown) return false;
+
+  rule.cooldown.lastExecuted = new Date().toISOString();
+  policy.updatedAt = new Date().toISOString();
+  policyStore.set(policyId, policy);
+  return true;
+}

--- a/server/src/services/incidentService.ts
+++ b/server/src/services/incidentService.ts
@@ -1,5 +1,5 @@
 import { PrismaClient, Incident } from "@prisma/client"; // Type verified via tsc
-import { recoveryRecommendationService, RecoveryRecommendation, ShockEvent } from "./recoveryRecommendationService";
+import { recoveryRecommendationService, RecoveryRecommendation, ShockEvent, ShockEventType } from "./recoveryRecommendationService";
 
 const prisma = new PrismaClient();
 

--- a/server/src/services/recommendationTimelineService.ts
+++ b/server/src/services/recommendationTimelineService.ts
@@ -1,6 +1,23 @@
 import { assessConversionRisk } from "./conversionRiskService";
 import { ZapQuoteBody } from "./zapQuote";
 
+export type ReasonCode =
+  | "risk-tolerance-change"
+  | "apy-shift"
+  | "liquidity-change"
+  | "volatility-change"
+  | "initial-baseline"
+  | "conversion-risk-alert";
+
+export interface ReasonCodeDetail {
+  code: ReasonCode;
+  label: string;
+  description: string;
+  severity: "info" | "warning" | "critical";
+  previousValue?: string | number;
+  currentValue?: string | number;
+}
+
 export interface RecommendationInputSnapshot {
   riskTolerance: string;
   expectedApy: number;
@@ -14,6 +31,7 @@ export interface RecommendationTimelineEntry {
   rationale: string;
   targetVault: string;
   changedInputs: string[];
+  reasonCodes: ReasonCodeDetail[];
   inputSnapshot: RecommendationInputSnapshot;
   timestamp: string;
   conversionRisk?: unknown;
@@ -22,11 +40,109 @@ export interface RecommendationTimelineEntry {
 const MAX_ENTRIES_PER_USER = 20;
 const historyStore = new Map<string, RecommendationTimelineEntry[]>();
 
+export const REASON_CODE_LABELS: Record<ReasonCode, { label: string; description: string; severity: "info" | "warning" | "critical" }> = {
+  "risk-tolerance-change": {
+    label: "Risk Tolerance Adjusted",
+    description: "Your risk tolerance input changed, affecting the recommendation.",
+    severity: "warning",
+  },
+  "apy-shift": {
+    label: "APY Shift Detected",
+    description: "Projected APY changed significantly, triggering a re-evaluation.",
+    severity: "info",
+  },
+  "liquidity-change": {
+    label: "Liquidity Depth Change",
+    description: "Available liquidity depth changed, affecting routing safety.",
+    severity: "warning",
+  },
+  "volatility-change": {
+    label: "Volatility Shift",
+    description: "Asset volatility changed, impacting risk assessment.",
+    severity: "critical",
+  },
+  "initial-baseline": {
+    label: "Initial Baseline",
+    description: "First recommendation recorded as baseline.",
+    severity: "info",
+  },
+  "conversion-risk-alert": {
+    label: "Conversion Risk Alert",
+    description: "Swap conversion risk detected for the recommended path.",
+    severity: "critical",
+  },
+};
+
 function sanitizeText(text: string): string {
   return text
     .replace(/(api[_-]?key|secret|token)\s*[:=]\s*[^\s,;]+/gi, "[redacted]")
     .replace(/[A-Za-z0-9+/_-]{24,}/g, "[redacted]")
     .slice(0, 500);
+}
+
+function generateReasonCodes(
+  previous: RecommendationInputSnapshot | null,
+  current: RecommendationInputSnapshot,
+): ReasonCodeDetail[] {
+  if (!previous) {
+    return [
+      {
+        code: "initial-baseline",
+        label: REASON_CODE_LABELS["initial-baseline"].label,
+        description: REASON_CODE_LABELS["initial-baseline"].description,
+        severity: REASON_CODE_LABELS["initial-baseline"].severity,
+        currentValue: JSON.stringify(current),
+      },
+    ];
+  }
+
+  const codes: ReasonCodeDetail[] = [];
+
+  if (previous.riskTolerance !== current.riskTolerance) {
+    codes.push({
+      code: "risk-tolerance-change",
+      label: REASON_CODE_LABELS["risk-tolerance-change"].label,
+      description: REASON_CODE_LABELS["risk-tolerance-change"].description,
+      severity: REASON_CODE_LABELS["risk-tolerance-change"].severity,
+      previousValue: previous.riskTolerance,
+      currentValue: current.riskTolerance,
+    });
+  }
+
+  if (Math.abs(previous.expectedApy - current.expectedApy) >= 0.5) {
+    codes.push({
+      code: "apy-shift",
+      label: REASON_CODE_LABELS["apy-shift"].label,
+      description: REASON_CODE_LABELS["apy-shift"].description,
+      severity: REASON_CODE_LABELS["apy-shift"].severity,
+      previousValue: previous.expectedApy,
+      currentValue: current.expectedApy,
+    });
+  }
+
+  if (Math.abs(previous.liquidityDepthUsd - current.liquidityDepthUsd) >= 50_000) {
+    codes.push({
+      code: "liquidity-change",
+      label: REASON_CODE_LABELS["liquidity-change"].label,
+      description: REASON_CODE_LABELS["liquidity-change"].description,
+      severity: REASON_CODE_LABELS["liquidity-change"].severity,
+      previousValue: previous.liquidityDepthUsd,
+      currentValue: current.liquidityDepthUsd,
+    });
+  }
+
+  if (Math.abs(previous.volatilityPct - current.volatilityPct) >= 1) {
+    codes.push({
+      code: "volatility-change",
+      label: REASON_CODE_LABELS["volatility-change"].label,
+      description: REASON_CODE_LABELS["volatility-change"].description,
+      severity: REASON_CODE_LABELS["volatility-change"].severity,
+      previousValue: previous.volatilityPct,
+      currentValue: current.volatilityPct,
+    });
+  }
+
+  return codes;
 }
 
 function diffInputs(
@@ -60,7 +176,7 @@ export async function recordRecommendation(
   userId: string,
   payload: Omit<
     RecommendationTimelineEntry,
-    "id" | "timestamp" | "changedInputs" | "conversionRisk"
+    "id" | "timestamp" | "changedInputs" | "conversionRisk" | "reasonCodes"
   > & {
     inputSnapshot: RecommendationInputSnapshot;
   },
@@ -75,12 +191,25 @@ export async function recordRecommendation(
       ? await assessConversionRisk(zapBody, strategyId)
       : undefined;
 
+  const reasonCodes = generateReasonCodes(previous, payload.inputSnapshot);
+
+  if (conversionRisk) {
+    reasonCodes.push({
+      code: "conversion-risk-alert",
+      label: REASON_CODE_LABELS["conversion-risk-alert"].label,
+      description: REASON_CODE_LABELS["conversion-risk-alert"].description,
+      severity: REASON_CODE_LABELS["conversion-risk-alert"].severity,
+      currentValue: JSON.stringify(conversionRisk),
+    });
+  }
+
   const entry: RecommendationTimelineEntry = {
     id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
     recommendation: sanitizeText(payload.recommendation),
     rationale: sanitizeText(payload.rationale),
     targetVault: sanitizeText(payload.targetVault),
     changedInputs: diffInputs(previous, payload.inputSnapshot),
+    reasonCodes,
     inputSnapshot: payload.inputSnapshot,
     timestamp: new Date().toISOString(),
     conversionRisk,

--- a/server/src/services/zapQuote.ts
+++ b/server/src/services/zapQuote.ts
@@ -9,6 +9,7 @@ export interface ZapQuoteBody {
   amountInStroops: string;
   inputDecimals: number;
   vaultDecimals: number;
+  slippageTolerance?: number;
   protocol?: string;
 }
 
@@ -18,6 +19,10 @@ export interface ZapQuoteResult {
   source: "router_simulation" | "fallback_rate";
   slippageApplied: number;
   amountOutAfterSlippage: string;
+  quotedAt: string;
+  minAmountOutStroops: string;
+  quoteAgeMs: number;
+  isFallback: boolean;
 }
 
 const rpcUrl = process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
@@ -32,11 +37,6 @@ function mulDivStroops(amountIn: string, numerator: string, denominator: string)
   return ((a * n) / d).toString();
 }
 
-/**
- * When `DEX_ROUTER_CONTRACT_ID` and `ZAP_QUOTE_SIM_SOURCE_ACCOUNT` are set,
- * simulates the router `swap` and reads the quoted `i128` output.
- * Returns `null` if simulation is unavailable or fails (caller uses fallback).
- */
 export async function quoteViaRouterSimulation(
   body: ZapQuoteBody,
 ): Promise<ZapQuoteResult | null> {
@@ -92,6 +92,8 @@ export async function quoteViaRouterSimulation(
     const expected =
       typeof out === "bigint" ? out : BigInt(String(out));
 
+    const now = Date.now();
+
     return {
       path: [
         { contractId: body.inputTokenContract, label: "in" },
@@ -101,18 +103,20 @@ export async function quoteViaRouterSimulation(
       source: "router_simulation",
       slippageApplied: 0,
       amountOutAfterSlippage: expected.toString(),
+      quotedAt: new Date(now).toISOString(),
+      minAmountOutStroops: expected.toString(),
+      quoteAgeMs: 0,
+      isFallback: false,
     };
   } catch {
     return null;
   }
 }
 
-/**
- * Deterministic quote when router simulation is not used (local dev / CI).
- * Same token → 1:1. Otherwise scales by `ZAP_FALLBACK_NUMERATOR` / `ZAP_FALLBACK_DENOMINATOR`.
- */
 export function quoteFallback(body: ZapQuoteBody): ZapQuoteResult {
   const amountIn = body.amountInStroops;
+  const now = Date.now();
+
   if (body.inputTokenContract === body.vaultTokenContract) {
     return {
       path: [{ contractId: body.inputTokenContract }],
@@ -120,6 +124,10 @@ export function quoteFallback(body: ZapQuoteBody): ZapQuoteResult {
       source: "fallback_rate",
       slippageApplied: 0,
       amountOutAfterSlippage: amountIn,
+      quotedAt: new Date(now).toISOString(),
+      minAmountOutStroops: amountIn,
+      quoteAgeMs: 0,
+      isFallback: true,
     };
   }
 
@@ -136,6 +144,10 @@ export function quoteFallback(body: ZapQuoteBody): ZapQuoteResult {
     source: "fallback_rate",
     slippageApplied: 0,
     amountOutAfterSlippage: expected,
+    quotedAt: new Date(now).toISOString(),
+    minAmountOutStroops: expected,
+    quoteAgeMs: 0,
+    isFallback: true,
   };
 }
 
@@ -144,26 +156,40 @@ export async function getZapQuote(body: ZapQuoteBody): Promise<ZapQuoteResult> {
     throw new Error(`Quoting is temporarily disabled for ${body.protocol || "all protocols"} due to safety freeze.`);
   }
 
+  const quotedAt = new Date().toISOString();
+
   const sim = (await quoteViaRouterSimulation(body)) || quoteFallback(body);
 
   const protocol = body.protocol || "default";
   const model = slippageRegistry.getModel(protocol);
 
-  // Get TVL for slippage calculation
   const yieldData = await getYieldData();
   const protocolData = yieldData.find(y => y.protocolName.toLowerCase() === protocol.toLowerCase());
-  const tvl = BigInt(Math.floor(protocolData?.tvl || 10_000_000)); // Fallback to 10M
+  const tvl = BigInt(Math.floor(protocolData?.tvl || 10_000_000));
 
   const amountIn = BigInt(body.amountInStroops);
   const slippage = model.calculateSlippage(amountIn, tvl);
 
+  const userSlippage = body.slippageTolerance !== undefined
+    ? Math.min(Math.max(body.slippageTolerance, 0.001), 0.15)
+    : slippage;
+
+  const effectiveSlippage = Math.max(slippage, userSlippage);
+
   const expectedOut = BigInt(sim.expectedAmountOutStroops);
-  const multiplier = 1 - slippage;
+  const multiplier = 1 - effectiveSlippage;
   const outAfterSlippage = (expectedOut * BigInt(Math.floor(multiplier * 10000))) / BigInt(10000);
+
+  const now = Date.now();
+  const quoteAgeMs = new Date(quotedAt).getTime();
 
   return {
     ...sim,
-    slippageApplied: slippage,
+    slippageApplied: effectiveSlippage,
     amountOutAfterSlippage: outAfterSlippage.toString(),
+    minAmountOutStroops: outAfterSlippage.toString(),
+    quotedAt,
+    quoteAgeMs: now - quoteAgeMs,
+    isFallback: sim.source === "fallback_rate",
   };
 }

--- a/server/src/utils/yieldNormalization.ts
+++ b/server/src/utils/yieldNormalization.ts
@@ -15,7 +15,7 @@ export function normalizeYield(rawYield: RawProtocolYield): NormalizedYield {
 
   const baseApy = roundTo(rawYield.apyBps / 100, 2);
   let rewardApy = 0;
-  const rewards: { symbol: string; apy: number }[] = [];
+  const rewards: { symbol: string; apy: number; confidence?: "low" | "medium" | "high" }[] = [];
 
   if (rawYield.rewards && rawYield.tvlUsd > 0) {
     for (const reward of rawYield.rewards) {


### PR DESCRIPTION
PR description:
## Summary
- Closes #284 — Allocation Policy DSL (parser/validator/evaluator + cooldown enforcement)
- Closes #410 — Reason codes (6 types with severity levels) in recommendation timeline + AIAdvisor rendering
- Closes #413 — Zap quote UX enhancements (slippage slider, fallback/stale warnings, min amount display)
- Closes #425 — Fragmentation trend chart (SVG line chart, 30-day history, metric switching)
## Changes
- New: `server/src/services/allocationPolicyDsl.ts` — DSL with JSON schema, validation, evaluation
- New: `server/src/__tests__/allocationPolicyDsl.test.ts` — 40+ tests
- New: `client/src/features/fragmentation/FragmentationTrendChart.tsx` + tests
- New: `client/src/features/zap/ZapDepositPanel.test.tsx`
- Updated: `recommendationTimelineService.ts` — generateReasonCodes() with severity
- Updated: `AIAdvisor.tsx` — renders reason codes with badge colors
- Updated: `zapQuote.ts`, `zapRoute.ts`, `fetchSwapQuote.ts` — new quote metadata fields
- Updated: `ZapDepositPanel.tsx` — slippage editor, fallback/stale warnings, quote source badge
- Updated: `fragmentation.ts` — `GET /api/liquidity/fragmentation/history` endpoint
- Updated: `app.ts` — mounted fragmentation router
- Bugfixes: `protocols.ts` (duplicate key), `yieldNormalization.ts` (missing field), `incidentService.ts` (missing import)
## Tests
- Server: 47 new tests pass (allocation DSL 40 + reason codes 7)
- Client: All new UI tests pass (trend chart 9 + zap panel 11)
- 0 regressions