### PR TITLE
feat(routes): route-level loading & error boundaries for analytics pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,11 +6,13 @@ import {
   useLocation,
 } from "react-router-dom";
 import Dashboard from "./components/Dashboard";
-import ApyDashboard from "./components/dashboard/ApyDashboard";
+const ApyDashboard = lazy(() => import("./components/dashboard/ApyDashboard"));
 import AIAdvisor from "./components/AIAdvisor";
 import Vault from "./components/Vault";
-import PortfolioPage from "./components/portfolio/PortfolioPage";
-import GovernanceDashboard from "./pages/governance/GovernanceDashboard";
+const PortfolioPage = lazy(() => import("./components/portfolio/PortfolioPage"));
+const GovernanceDashboard = lazy(
+  () => import("./pages/governance/GovernanceDashboard"),
+);
 import QuestsDashboard from "./pages/quests/QuestsDashboard";
 import ConnectWalletButton from "./components/wallet/ConnectWalletButton";
 import NotificationBell from "./components/Navigation/NotificationBell";
@@ -21,17 +23,20 @@ import PnLChart from "./features/pnl/PnLChart";
 import TaxExport from "./features/taxes/TaxExport";
 import ReferralDashboard from "./features/referrals/ReferralDashboard";
 import VestingDashboard from "./pages/vesting/VestingDashboard";
-import TransparencyDashboard from "./pages/transparency/TransparencyDashboard";
+const TransparencyDashboard = lazy(
+  () => import("./pages/transparency/TransparencyDashboard"),
+);
 import RiskChronology from "./pages/transparency/RiskChronology";
 import RelayerStatusPage from "./pages/transparency/RelayerStatusPage";
-import StressTestDashboard from "./pages/StressTestDashboard";
+const StressTestDashboard = lazy(() => import("./pages/StressTestDashboard"));
 import YieldForGood from "./features/donations/YieldForGood";
 import YieldCalculator from "./components/calculator/YieldCalculator";
 import StrategyLeaderboard from "./pages/leaderboard/StrategyLeaderboard";
 import TreasurySimulation from "./pages/treasury/TreasurySimulation";
 import WalletSessionReview from "./auth/WalletSessionReview";
 import { useWallet } from "./context/useWallet";
-import { useState, useEffect } from "react";
+import { lazy, useState, useEffect } from "react";
+import RouteBoundary from "./components/common/RouteBoundary";
 import {
   LayoutDashboard,
   BarChart3,
@@ -458,7 +463,11 @@ const router = createBrowserRouter([
       },
       {
         path: "/apy",
-        element: <ApyDashboard />,
+        element: (
+          <RouteBoundary>
+            <ApyDashboard />
+          </RouteBoundary>
+        ),
       },
       {
         path: "/ai-advisor",
@@ -466,7 +475,11 @@ const router = createBrowserRouter([
       },
       {
         path: "/stress",
-        element: <StressTestDashboard />,
+        element: (
+          <RouteBoundary>
+            <StressTestDashboard />
+          </RouteBoundary>
+        ),
       },
       {
         path: "/vault",
@@ -482,7 +495,11 @@ const router = createBrowserRouter([
       },
       {
         path: "/portfolio",
-        element: <PortfolioPage />,
+        element: (
+          <RouteBoundary>
+            <PortfolioPage />
+          </RouteBoundary>
+        ),
       },
       {
         path: "/calculator",
@@ -498,7 +515,11 @@ const router = createBrowserRouter([
       },
       {
         path: "/governance",
-        element: <GovernanceDashboard />,
+        element: (
+          <RouteBoundary>
+            <GovernanceDashboard />
+          </RouteBoundary>
+        ),
       },
       {
         path: "/quests",
@@ -530,7 +551,11 @@ const router = createBrowserRouter([
       },
       {
         path: "/transparency",
-        element: <TransparencyDashboard />,
+        element: (
+          <RouteBoundary>
+            <TransparencyDashboard />
+          </RouteBoundary>
+        ),
       },
       {
         path: "/transparency/incidents",

--- a/client/src/components/common/RouteBoundary.test.tsx
+++ b/client/src/components/common/RouteBoundary.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RouteBoundary, RouteLoadingPanel } from "./RouteBoundary";
+
+function Boom() {
+  throw new Error("kaboom from child");
+}
+
+describe("RouteBoundary", () => {
+  it("renders children when there is no error", () => {
+    render(
+      <RouteBoundary>
+        <div>safe content</div>
+      </RouteBoundary>,
+    );
+    expect(screen.queryByText("safe content")).not.toBeNull();
+  });
+
+  it("shows the error panel with the real message and does not swallow it", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(
+      <RouteBoundary>
+        <Boom />
+      </RouteBoundary>,
+    );
+    expect(screen.queryByRole("alert")).not.toBeNull();
+    expect(screen.queryByText(/kaboom from child/)).not.toBeNull();
+    // The real error was logged, not silently discarded.
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("renders an accessible loading panel for the suspense fallback", () => {
+    render(<RouteLoadingPanel />);
+    expect(screen.queryByRole("status")).not.toBeNull();
+  });
+});

--- a/client/src/components/common/RouteBoundary.tsx
+++ b/client/src/components/common/RouteBoundary.tsx
@@ -1,0 +1,85 @@
+import { Component, Suspense } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Catches render/load errors from a route subtree and shows a fallback panel
+ * that surfaces the real error — it never swallows errors silently.
+ */
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    // Log the real error so monitoring/console still sees it.
+    console.error("[RouteBoundary] render error:", error, info.componentStack);
+  }
+
+  private handleRetry = () => this.setState({ error: null });
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      return (
+        <div
+          role="alert"
+          className="m-6 rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-sm text-red-300"
+        >
+          <p className="font-semibold text-red-200">
+            Something went wrong loading this page.
+          </p>
+          <p className="mt-1 break-words font-mono text-xs text-red-300/90">
+            {error.message}
+          </p>
+          <button
+            type="button"
+            onClick={this.handleRetry}
+            className="mt-4 rounded-lg bg-red-500/20 px-3 py-1.5 text-red-100 transition-colors hover:bg-red-500/30"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/** Loading fallback shown while a lazily-loaded route is resolving. */
+export function RouteLoadingPanel() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center gap-3 p-12 text-slate-400"
+    >
+      <span className="h-5 w-5 animate-spin rounded-full border-2 border-slate-500 border-t-transparent" />
+      <span className="text-sm">Loading…</span>
+    </div>
+  );
+}
+
+/**
+ * Route-level boundary: renders a loading panel while a lazy page loads, and an
+ * error panel (surfacing the real error) if the page throws while loading or
+ * rendering. Wrap analytics-heavy route elements with this.
+ */
+export function RouteBoundary({ children }: { children: ReactNode }) {
+  return (
+    <ErrorBoundary>
+      <Suspense fallback={<RouteLoadingPanel />}>{children}</Suspense>
+    </ErrorBoundary>
+  );
+}
+
+export default RouteBoundary;


### PR DESCRIPTION
## Summary
closes #436

Adds a reusable `RouteBoundary` (`ErrorBoundary` + `Suspense`) and applies it to the analytics-heavy routes — `/apy`, `/stress`, `/portfolio`, `/governance`, `/transparency` — which are now `React.lazy`-loaded.

- **Consistent loading states:** a loading panel renders while each route's chunk resolves.
- **Error boundaries:** a fallback panel surfaces the **real error message** + a retry button, and logs the error (`console.error`) rather than swallowing it.
- **Test:** `RouteBoundary.test.tsx` covers normal render, the error panel (asserts the message is shown and the error is logged), and the accessible loading panel.
