### PR TITLE
feat: source health, rebalance sandbox, indexer status, and emergency runbook

### DIFF
--- a/client/src/features/analytics/SourceHealthPanel.tsx
+++ b/client/src/features/analytics/SourceHealthPanel.tsx
@@ -1,0 +1,176 @@
+/**
+ * Yield Data Source Registry & Health Dashboard
+ *
+ * Read-only analytics panel that lists every yield data source with its
+ * status, latest fetch time, uptime, latency, and failure reason.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Activity, RefreshCw, AlertTriangle } from "lucide-react";
+import StatusBadge from "../../components/StatusBadge";
+import { apiUrl } from "../../lib/api";
+import {
+  getSourceStatusDisplay,
+  formatLatency,
+  formatAge,
+  hasUnhealthySources,
+  type SourceHealthRegistry,
+} from "./sourceHealthStatus";
+
+export default function SourceHealthPanel() {
+  const [registry, setRegistry] = useState<SourceHealthRegistry | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchRegistry = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const res = await fetch(apiUrl("/api/analytics/sources/health"));
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const body = await res.json();
+      setRegistry(body.data as SourceHealthRegistry);
+    } catch (err) {
+      console.error("Failed to fetch source health registry:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to fetch source health",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchRegistry();
+  }, [fetchRegistry]);
+
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity size={20} className="text-indigo-400" />
+          <h2 className="text-xl font-semibold">Yield Data Source Health</h2>
+        </div>
+        <button
+          type="button"
+          onClick={fetchRegistry}
+          disabled={isLoading}
+          aria-label="Refresh source health"
+          className="flex items-center gap-2 text-sm text-gray-300 hover:text-white disabled:opacity-50"
+        >
+          <RefreshCw size={16} className={isLoading ? "animate-spin" : ""} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-500" />
+          <span className="text-sm text-red-400">{error}</span>
+        </div>
+      )}
+
+      {!error && isLoading && !registry && (
+        <p className="text-sm text-gray-400">Loading source health…</p>
+      )}
+
+      {registry && (
+        <>
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <span className="text-gray-400">
+              {registry.totalSources} sources ·
+            </span>
+            <StatusBadge
+              variant="success"
+              compact
+              label={`${registry.counts.healthy} healthy`}
+            />
+            <StatusBadge
+              variant="warning"
+              compact
+              label={`${registry.counts.degraded} degraded`}
+            />
+            <StatusBadge
+              variant="warning"
+              compact
+              label={`${registry.counts.stale} stale`}
+            />
+            <StatusBadge
+              variant="danger"
+              compact
+              label={`${registry.counts.unavailable} unavailable`}
+            />
+          </div>
+
+          {hasUnhealthySources(registry) && (
+            <div className="flex items-center gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+              <AlertTriangle className="w-4 h-4 text-yellow-500" />
+              <span className="text-sm text-yellow-400">
+                One or more data sources need attention.
+              </span>
+            </div>
+          )}
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-400 border-b border-white/10">
+                  <th className="py-2 pr-4 font-medium">Source</th>
+                  <th className="py-2 pr-4 font-medium">Status</th>
+                  <th className="py-2 pr-4 font-medium">Uptime</th>
+                  <th className="py-2 pr-4 font-medium">Latency</th>
+                  <th className="py-2 pr-4 font-medium">Last fetch</th>
+                  <th className="py-2 font-medium">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {registry.sources.map((source) => {
+                  const display = getSourceStatusDisplay(source.status);
+                  return (
+                    <tr
+                      key={source.providerId}
+                      className="border-b border-white/5"
+                    >
+                      <td className="py-2 pr-4">
+                        <div className="font-medium">{source.providerName}</div>
+                        <div className="text-xs text-gray-500">
+                          {source.dataSource}
+                        </div>
+                      </td>
+                      <td className="py-2 pr-4">
+                        <StatusBadge
+                          variant={display.variant}
+                          compact
+                          label={display.label}
+                        />
+                      </td>
+                      <td className="py-2 pr-4">
+                        {source.uptimePct.toFixed(1)}%
+                      </td>
+                      <td className="py-2 pr-4">
+                        {formatLatency(source.latencyMs)}
+                      </td>
+                      <td className="py-2 pr-4 text-gray-400">
+                        {formatAge(source.ageSeconds)}
+                      </td>
+                      <td className="py-2 text-gray-400">
+                        {source.failureReason ?? "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <p className="text-xs text-gray-500">
+            Generated {new Date(registry.generatedAt).toLocaleString()} ·
+            read-only
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/analytics/sourceHealthStatus.test.ts
+++ b/client/src/features/analytics/sourceHealthStatus.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSourceStatusDisplay,
+  formatLatency,
+  formatAge,
+  hasUnhealthySources,
+  type SourceHealthRegistry,
+} from "./sourceHealthStatus";
+
+describe("getSourceStatusDisplay", () => {
+  it("maps healthy to a non-attention success badge", () => {
+    const display = getSourceStatusDisplay("healthy");
+    expect(display.variant).toBe("success");
+    expect(display.needsAttention).toBe(false);
+    expect(display.label).toBe("Healthy");
+  });
+
+  it("maps degraded and stale to attention-worthy warning badges", () => {
+    expect(getSourceStatusDisplay("degraded").variant).toBe("warning");
+    expect(getSourceStatusDisplay("degraded").needsAttention).toBe(true);
+    expect(getSourceStatusDisplay("stale").variant).toBe("warning");
+    expect(getSourceStatusDisplay("stale").needsAttention).toBe(true);
+  });
+
+  it("maps unavailable to a danger badge", () => {
+    const display = getSourceStatusDisplay("unavailable");
+    expect(display.variant).toBe("danger");
+    expect(display.needsAttention).toBe(true);
+  });
+
+  it("falls back to a neutral 'Unknown' badge for unexpected values", () => {
+    const display = getSourceStatusDisplay("something-else");
+    expect(display.variant).toBe("neutral");
+    expect(display.label).toBe("Unknown");
+  });
+});
+
+describe("formatLatency", () => {
+  it("renders sub-second latency in ms", () => {
+    expect(formatLatency(250)).toBe("250ms");
+  });
+  it("renders >=1s latency in seconds", () => {
+    expect(formatLatency(1500)).toBe("1.50s");
+  });
+  it("renders a dash for invalid latency", () => {
+    expect(formatLatency(-1)).toBe("—");
+  });
+});
+
+describe("formatAge", () => {
+  it("renders seconds, minutes, and hours", () => {
+    expect(formatAge(30)).toBe("30s ago");
+    expect(formatAge(120)).toBe("2m ago");
+    expect(formatAge(7200)).toBe("2h ago");
+  });
+  it("renders 'unknown' for invalid age", () => {
+    expect(formatAge(-1)).toBe("unknown");
+  });
+});
+
+describe("hasUnhealthySources", () => {
+  const registry = (
+    counts: Partial<SourceHealthRegistry["counts"]>,
+  ): SourceHealthRegistry => ({
+    generatedAt: new Date().toISOString(),
+    totalSources: 0,
+    counts: { healthy: 0, degraded: 0, stale: 0, unavailable: 0, ...counts },
+    sources: [],
+  });
+
+  it("is false when all sources are healthy", () => {
+    expect(hasUnhealthySources(registry({ healthy: 3 }))).toBe(false);
+  });
+
+  it("is true when any source is degraded, stale, or unavailable", () => {
+    expect(hasUnhealthySources(registry({ healthy: 2, stale: 1 }))).toBe(true);
+    expect(hasUnhealthySources(registry({ unavailable: 1 }))).toBe(true);
+  });
+});

--- a/client/src/features/analytics/sourceHealthStatus.ts
+++ b/client/src/features/analytics/sourceHealthStatus.ts
@@ -1,0 +1,92 @@
+/**
+ * UI status mapping for the Yield Data Source Health dashboard.
+ *
+ * Keeps the mapping from backend status -> visual presentation pure and
+ * framework-free so it can be unit tested without rendering a component.
+ */
+
+import type { StatusVariant } from "../../components/StatusBadge";
+
+export type SourceHealthStatus =
+  | "healthy"
+  | "degraded"
+  | "stale"
+  | "unavailable";
+
+export interface SourceHealthSummary {
+  providerId: string;
+  providerName: string;
+  dataSource: string;
+  status: SourceHealthStatus;
+  reliabilityScore: number;
+  uptimePct: number;
+  freshnessPct: number;
+  errorRatePct: number;
+  latencyMs: number;
+  latestFetch: string;
+  ageSeconds: number;
+  consecutiveFailures: number;
+  failureReason: string | null;
+  trend: "improving" | "stable" | "declining";
+}
+
+export interface SourceHealthRegistry {
+  generatedAt: string;
+  totalSources: number;
+  counts: Record<SourceHealthStatus, number>;
+  sources: SourceHealthSummary[];
+}
+
+interface StatusDisplay {
+  label: string;
+  variant: StatusVariant;
+  /** Whether this status should draw operator attention. */
+  needsAttention: boolean;
+}
+
+const STATUS_DISPLAY: Record<SourceHealthStatus, StatusDisplay> = {
+  healthy: { label: "Healthy", variant: "success", needsAttention: false },
+  degraded: { label: "Degraded", variant: "warning", needsAttention: true },
+  stale: { label: "Stale", variant: "warning", needsAttention: true },
+  unavailable: { label: "Unavailable", variant: "danger", needsAttention: true },
+};
+
+const FALLBACK_DISPLAY: StatusDisplay = {
+  label: "Unknown",
+  variant: "neutral",
+  needsAttention: true,
+};
+
+/** Map a source status to its badge label/variant. */
+export function getSourceStatusDisplay(
+  status: SourceHealthStatus | string,
+): StatusDisplay {
+  return STATUS_DISPLAY[status as SourceHealthStatus] ?? FALLBACK_DISPLAY;
+}
+
+/** Human-friendly latency string. */
+export function formatLatency(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(2)}s`;
+}
+
+/** Human-friendly "time since last fetch" string. */
+export function formatAge(ageSeconds: number): string {
+  if (!Number.isFinite(ageSeconds) || ageSeconds < 0) return "unknown";
+  if (ageSeconds < 60) return `${ageSeconds}s ago`;
+  const minutes = Math.round(ageSeconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  return `${hours}h ago`;
+}
+
+/** True when any source is not healthy. */
+export function hasUnhealthySources(registry: SourceHealthRegistry): boolean {
+  return (
+    registry.counts.degraded +
+      registry.counts.stale +
+      registry.counts.unavailable >
+    0
+  );
+}

--- a/client/src/features/portfolio_builder/PortfolioBuilder.tsx
+++ b/client/src/features/portfolio_builder/PortfolioBuilder.tsx
@@ -14,10 +14,23 @@ import {
   distributeAmount,
   normalizeWeights,
 } from "./portfolioUtils";
+import RebalancePreview from "./RebalancePreview";
 
 export interface PortfolioBuilderProps {
   walletAddress: string | null;
   availableVaults: Array<{ contractId: string; name: string; apy: number }>;
+}
+
+function buildInitialAllocations(
+  availableVaults: PortfolioBuilderProps["availableVaults"],
+): VaultAllocation[] {
+  return availableVaults.slice(0, 3).map((v) => ({
+    vaultContractId: v.contractId,
+    vaultName: v.name,
+    apy: v.apy,
+    weight: 100 / Math.min(3, availableVaults.length),
+    amount: 0n,
+  }));
 }
 
 export default function PortfolioBuilder({
@@ -26,13 +39,11 @@ export default function PortfolioBuilder({
 }: PortfolioBuilderProps) {
   const [totalAmount, setTotalAmount] = useState("");
   const [allocations, setAllocations] = useState<VaultAllocation[]>(() =>
-    availableVaults.slice(0, 3).map((v) => ({
-      vaultContractId: v.contractId,
-      vaultName: v.name,
-      apy: v.apy,
-      weight: 100 / Math.min(3, availableVaults.length),
-      amount: 0n,
-    })),
+    buildInitialAllocations(availableVaults),
+  );
+  // Baseline ("current") position the rebalance sandbox previews against.
+  const [baselineAllocations] = useState<VaultAllocation[]>(() =>
+    buildInitialAllocations(availableVaults),
   );
   const [txPhase, setTxPhase] = useState<TxPhase>("idle");
   const [error, setError] = useState("");
@@ -192,6 +203,16 @@ export default function PortfolioBuilder({
             </div>
           ))}
         </div>
+      )}
+
+      {/* Rebalance Simulation Sandbox */}
+      {totalAmount && Number(totalAmount) > 0 && (
+        <RebalancePreview
+          totalValueUsd={Number(totalAmount)}
+          currentAllocations={baselineAllocations}
+          targetAllocations={allocations}
+          disabled={!isValid}
+        />
       )}
 
       {/* Error Display */}

--- a/client/src/features/portfolio_builder/RebalancePreview.tsx
+++ b/client/src/features/portfolio_builder/RebalancePreview.tsx
@@ -1,0 +1,188 @@
+/**
+ * Rebalance Simulation Sandbox
+ *
+ * Read-only preview of moving from the builder's baseline allocation to the
+ * slider-adjusted target: before/after weights, blended APY, estimated
+ * turnover fees, and warnings for high fees / stale data / liquidity risk.
+ * Calls the backend sandbox endpoint — it never commits capital.
+ */
+
+import { useCallback, useState } from "react";
+import { TrendingUp, TrendingDown, Minus, AlertTriangle, FlaskConical } from "lucide-react";
+import { apiUrl } from "../../lib/api";
+import type { VaultAllocation } from "./types";
+import {
+  buildRebalanceRequest,
+  summarizeApyDelta,
+  hasWarnings,
+  type RebalancePreview as RebalancePreviewData,
+} from "./rebalancePreview";
+
+export interface RebalancePreviewProps {
+  totalValueUsd: number;
+  currentAllocations: VaultAllocation[];
+  targetAllocations: VaultAllocation[];
+  disabled?: boolean;
+}
+
+export default function RebalancePreview({
+  totalValueUsd,
+  currentAllocations,
+  targetAllocations,
+  disabled = false,
+}: RebalancePreviewProps) {
+  const [preview, setPreview] = useState<RebalancePreviewData | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const runPreview = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const body = buildRebalanceRequest(
+        totalValueUsd,
+        currentAllocations,
+        targetAllocations,
+      );
+      const res = await fetch(apiUrl("/api/simulator/rebalance"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const details = Array.isArray(data?.details)
+          ? data.details.join(" ")
+          : "";
+        throw new Error(data?.error ? `${data.error}. ${details}`.trim() : `HTTP ${res.status}`);
+      }
+      setPreview(data as RebalancePreviewData);
+    } catch (err) {
+      console.error("Rebalance preview failed:", err);
+      setPreview(null);
+      setError(err instanceof Error ? err.message : "Failed to preview rebalance");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [totalValueUsd, currentAllocations, targetAllocations]);
+
+  const apyDelta = preview ? summarizeApyDelta(preview) : null;
+  const DeltaIcon =
+    apyDelta?.direction === "up"
+      ? TrendingUp
+      : apyDelta?.direction === "down"
+        ? TrendingDown
+        : Minus;
+  const deltaColor =
+    apyDelta?.direction === "up"
+      ? "text-green-400"
+      : apyDelta?.direction === "down"
+        ? "text-red-400"
+        : "text-gray-400";
+
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <FlaskConical size={20} className="text-indigo-400" />
+          <h3 className="text-lg font-semibold">Rebalance Preview (Sandbox)</h3>
+        </div>
+        <button
+          type="button"
+          onClick={runPreview}
+          disabled={disabled || isLoading}
+          className="text-sm bg-white/10 hover:bg-white/20 disabled:opacity-50 px-3 py-1.5 rounded-lg"
+        >
+          {isLoading ? "Previewing…" : "Preview rebalance"}
+        </button>
+      </div>
+
+      <p className="text-xs text-gray-500">
+        Simulation only — previews the effect of your target allocation before
+        any capital moves.
+      </p>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertTriangle className="w-4 h-4 text-red-500" />
+          <span className="text-sm text-red-400">{error}</span>
+        </div>
+      )}
+
+      {preview && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <Metric label="Blended APY (before)" value={`${preview.blendedApyBefore.toFixed(2)}%`} />
+            <Metric label="Blended APY (after)" value={`${preview.blendedApyAfter.toFixed(2)}%`} />
+            <div className="p-3 bg-black/30 rounded-lg">
+              <p className="text-xs text-gray-400">APY change</p>
+              <p className={`text-lg font-semibold flex items-center gap-1 ${deltaColor}`}>
+                <DeltaIcon className="w-4 h-4" />
+                {apyDelta?.label}
+              </p>
+            </div>
+            <Metric label="Est. fees" value={`$${preview.estimatedFeeUsd.toFixed(2)}`} />
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-400 border-b border-white/10">
+                  <th className="py-2 pr-4 font-medium">Vault</th>
+                  <th className="py-2 pr-4 font-medium">Before</th>
+                  <th className="py-2 pr-4 font-medium">After</th>
+                  <th className="py-2 pr-4 font-medium">Drift</th>
+                  <th className="py-2 font-medium">Δ Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                {preview.legs.map((leg) => (
+                  <tr key={leg.label} className="border-b border-white/5">
+                    <td className="py-2 pr-4 font-medium">{leg.label}</td>
+                    <td className="py-2 pr-4 text-gray-400">
+                      {leg.currentWeight.toFixed(1)}%
+                    </td>
+                    <td className="py-2 pr-4">{leg.targetWeight.toFixed(1)}%</td>
+                    <td
+                      className={`py-2 pr-4 ${leg.driftPct > 0 ? "text-green-400" : leg.driftPct < 0 ? "text-red-400" : "text-gray-400"}`}
+                    >
+                      {leg.driftPct > 0 ? "+" : ""}
+                      {leg.driftPct.toFixed(1)}%
+                    </td>
+                    <td className="py-2 text-gray-400">
+                      {leg.deltaUsd >= 0 ? "+" : "−"}$
+                      {Math.abs(leg.deltaUsd).toFixed(2)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {hasWarnings(preview) && (
+            <div className="space-y-2">
+              {preview.warnings.map((warning) => (
+                <div
+                  key={warning}
+                  className="flex items-start gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg"
+                >
+                  <AlertTriangle className="w-4 h-4 text-yellow-500 mt-0.5 shrink-0" />
+                  <span className="text-sm text-yellow-400">{warning}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-3 bg-black/30 rounded-lg">
+      <p className="text-xs text-gray-400">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/client/src/features/portfolio_builder/rebalancePreview.test.ts
+++ b/client/src/features/portfolio_builder/rebalancePreview.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildRebalanceRequest,
+  summarizeApyDelta,
+  hasWarnings,
+  type RebalancePreview,
+} from "./rebalancePreview";
+import type { VaultAllocation } from "./types";
+
+const vault = (
+  id: string,
+  name: string,
+  apy: number,
+  weight: number,
+): VaultAllocation => ({
+  vaultContractId: id,
+  vaultName: name,
+  apy,
+  weight,
+  amount: 0n,
+});
+
+describe("buildRebalanceRequest", () => {
+  it("pairs current and target weights by vault id", () => {
+    const current = [vault("c1", "Blend", 8, 50), vault("c2", "Soroswap", 4, 50)];
+    const target = [vault("c1", "Blend", 8, 70), vault("c2", "Soroswap", 4, 30)];
+
+    const req = buildRebalanceRequest(10_000, current, target);
+
+    expect(req.totalValueUsd).toBe(10_000);
+    expect(req.allocations).toEqual([
+      { label: "Blend", currentWeight: 50, targetWeight: 70, apy: 8 },
+      { label: "Soroswap", currentWeight: 50, targetWeight: 30, apy: 4 },
+    ]);
+  });
+
+  it("treats a newly added vault as 0% current weight", () => {
+    const current = [vault("c1", "Blend", 8, 100)];
+    const target = [vault("c1", "Blend", 8, 60), vault("c2", "New", 10, 40)];
+
+    const req = buildRebalanceRequest(5_000, current, target);
+    const added = req.allocations.find((a) => a.label === "New");
+    expect(added?.currentWeight).toBe(0);
+    expect(added?.targetWeight).toBe(40);
+  });
+});
+
+describe("summarizeApyDelta", () => {
+  const preview = (apyDeltaPct: number): RebalancePreview => ({
+    isSimulationOnly: true,
+    legs: [],
+    blendedApyBefore: 6,
+    blendedApyAfter: 6 + apyDeltaPct,
+    apyDeltaPct,
+    totalTurnoverUsd: 0,
+    estimatedFeeUsd: 0,
+    maxDriftPct: 0,
+    warnings: [],
+  });
+
+  it("labels a positive delta as up with a + sign", () => {
+    const summary = summarizeApyDelta(preview(0.8));
+    expect(summary.direction).toBe("up");
+    expect(summary.label).toBe("+0.80%");
+  });
+
+  it("labels a negative delta as down", () => {
+    expect(summarizeApyDelta(preview(-1.25)).direction).toBe("down");
+    expect(summarizeApyDelta(preview(-1.25)).label).toBe("-1.25%");
+  });
+
+  it("labels a zero delta as flat", () => {
+    expect(summarizeApyDelta(preview(0)).direction).toBe("flat");
+  });
+});
+
+describe("hasWarnings", () => {
+  it("is true only when the preview carries warnings", () => {
+    const base: RebalancePreview = {
+      isSimulationOnly: true,
+      legs: [],
+      blendedApyBefore: 6,
+      blendedApyAfter: 6,
+      apyDeltaPct: 0,
+      totalTurnoverUsd: 0,
+      estimatedFeeUsd: 0,
+      maxDriftPct: 0,
+      warnings: [],
+    };
+    expect(hasWarnings(base)).toBe(false);
+    expect(hasWarnings({ ...base, warnings: ["High fees: …"] })).toBe(true);
+  });
+});

--- a/client/src/features/portfolio_builder/rebalancePreview.ts
+++ b/client/src/features/portfolio_builder/rebalancePreview.ts
@@ -1,0 +1,96 @@
+/**
+ * Rebalance Simulation Sandbox — client contract & presentation helpers.
+ *
+ * Mirrors the response shape of `POST /api/simulator/rebalance` and keeps the
+ * request-building / presentation logic pure so it can be unit tested without
+ * rendering a component or hitting the network. All calculations live on the
+ * server; this module only shapes inputs and formats outputs.
+ */
+
+import type { VaultAllocation } from "./types";
+
+export interface RebalanceAllocationInput {
+  label: string;
+  currentWeight: number;
+  targetWeight: number;
+  apy: number;
+  liquidityUsd?: number;
+}
+
+export interface RebalanceRequest {
+  totalValueUsd: number;
+  allocations: RebalanceAllocationInput[];
+}
+
+export interface RebalanceLeg {
+  label: string;
+  currentWeight: number;
+  targetWeight: number;
+  driftPct: number;
+  currentValueUsd: number;
+  targetValueUsd: number;
+  deltaUsd: number;
+}
+
+export interface RebalancePreview {
+  isSimulationOnly: true;
+  legs: RebalanceLeg[];
+  blendedApyBefore: number;
+  blendedApyAfter: number;
+  apyDeltaPct: number;
+  totalTurnoverUsd: number;
+  estimatedFeeUsd: number;
+  maxDriftPct: number;
+  warnings: string[];
+}
+
+/**
+ * Build a `/api/simulator/rebalance` request from the builder's current
+ * baseline and the live (slider-adjusted) target allocations. Allocations are
+ * matched by vault contract id; the target weights drive the rebalance.
+ */
+export function buildRebalanceRequest(
+  totalValueUsd: number,
+  current: VaultAllocation[],
+  target: VaultAllocation[],
+): RebalanceRequest {
+  const currentByVault = new Map(
+    current.map((a) => [a.vaultContractId, a.weight]),
+  );
+
+  return {
+    totalValueUsd,
+    allocations: target.map((a) => ({
+      label: a.vaultName,
+      currentWeight: currentByVault.get(a.vaultContractId) ?? 0,
+      targetWeight: a.weight,
+      apy: a.apy,
+    })),
+  };
+}
+
+export type ApyDirection = "up" | "down" | "flat";
+
+export interface ApyDeltaSummary {
+  direction: ApyDirection;
+  deltaPct: number;
+  label: string;
+}
+
+/** Describe the APY change so the UI can pick a colour/arrow without re-deriving it. */
+export function summarizeApyDelta(preview: RebalancePreview): ApyDeltaSummary {
+  const deltaPct = preview.apyDeltaPct;
+  const direction: ApyDirection =
+    deltaPct > 0 ? "up" : deltaPct < 0 ? "down" : "flat";
+  const sign = deltaPct > 0 ? "+" : "";
+  return {
+    direction,
+    deltaPct,
+    label: `${sign}${deltaPct.toFixed(2)}%`,
+  };
+}
+
+/** True when the preview surfaced any warning the operator should resolve first. */
+export function hasWarnings(preview: RebalancePreview): boolean {
+  return preview.warnings.length > 0;
+}

--- a/client/src/pages/governance/EmergencyRunbookPanel.test.tsx
+++ b/client/src/pages/governance/EmergencyRunbookPanel.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import EmergencyRunbookPanel from "./EmergencyRunbookPanel";
+import {
+  deriveRunbookProgress,
+  EMERGENCY_RUNBOOK_STEPS,
+} from "./emergencyRunbook";
+
+describe("deriveRunbookProgress", () => {
+  it("is nominal with no current step when running and healthy", () => {
+    const progress = deriveRunbookProgress({ isPaused: false, healthy: true });
+    expect(progress.phase).toBe("nominal");
+    expect(progress.steps.every((s) => s.state === "upcoming")).toBe(true);
+  });
+
+  it("makes pause the current step when health degrades before pausing", () => {
+    const progress = deriveRunbookProgress({ isPaused: false, healthy: false });
+    expect(progress.phase).toBe("incident");
+    expect(progress.steps.find((s) => s.id === "pause")?.state).toBe("current");
+  });
+
+  it("completes pause and activates verify while paused and unhealthy", () => {
+    const progress = deriveRunbookProgress({ isPaused: true, healthy: false });
+    expect(progress.steps.find((s) => s.id === "pause")?.state).toBe("complete");
+    expect(progress.steps.find((s) => s.id === "verify")?.state).toBe("current");
+  });
+
+  it("advances to notify once paused and health has recovered", () => {
+    const progress = deriveRunbookProgress({ isPaused: true, healthy: true });
+    expect(progress.steps.find((s) => s.id === "pause")?.state).toBe("complete");
+    expect(progress.steps.find((s) => s.id === "verify")?.state).toBe("complete");
+    expect(progress.steps.find((s) => s.id === "notify")?.state).toBe("current");
+  });
+});
+
+describe("EmergencyRunbookPanel", () => {
+  it("renders every runbook step as a checklist", () => {
+    render(<EmergencyRunbookPanel status={{ isPaused: true, healthy: false }} />);
+    for (const step of EMERGENCY_RUNBOOK_STEPS) {
+      expect(screen.getByTestId(`runbook-step-${step.id}`)).toBeInTheDocument();
+    }
+  });
+
+  it("renders every privileged action button as disabled (read-only)", () => {
+    render(<EmergencyRunbookPanel status={{ isPaused: false, healthy: false }} />);
+    for (const step of EMERGENCY_RUNBOOK_STEPS) {
+      const button = screen.getByRole("button", { name: step.actionLabel });
+      expect(button).toBeDisabled();
+    }
+  });
+
+  it("reflects the current pause and health status", () => {
+    render(<EmergencyRunbookPanel status={{ isPaused: true, healthy: true }} />);
+    expect(screen.getByText("Protocol: Paused")).toBeInTheDocument();
+    expect(screen.getByText("Health: OK")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/governance/EmergencyRunbookPanel.tsx
+++ b/client/src/pages/governance/EmergencyRunbookPanel.tsx
@@ -1,0 +1,151 @@
+/**
+ * Emergency Mode Operator Runbook Panel
+ *
+ * Checklist-style panel that guides operators through pause → verify → notify
+ * → resume. It shows the current pause/health status where available and links
+ * each step to the runbook doc or a read-only status check.
+ *
+ * Read-only by design: the per-step action buttons are always disabled. The
+ * panel holds no privileged keys and never executes pause/resume — those are
+ * performed deliberately via the admin console.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { ShieldAlert, CheckCircle2, Circle, ExternalLink } from "lucide-react";
+import StatusBadge from "../../components/StatusBadge";
+import { apiUrl } from "../../lib/api";
+import {
+  EMERGENCY_RUNBOOK_STEPS,
+  deriveRunbookProgress,
+  type EmergencyStatus,
+  type RunbookStepState,
+} from "./emergencyRunbook";
+
+export interface EmergencyRunbookPanelProps {
+  /** When provided, the panel renders this status instead of fetching it. */
+  status?: EmergencyStatus;
+}
+
+const STATE_STYLES: Record<RunbookStepState, string> = {
+  complete: "border-green-500/30 bg-green-500/5",
+  current: "border-indigo-500/40 bg-indigo-500/5",
+  upcoming: "border-white/10 bg-black/20",
+};
+
+export default function EmergencyRunbookPanel({
+  status: statusProp,
+}: EmergencyRunbookPanelProps) {
+  const [fetchedStatus, setFetchedStatus] = useState<EmergencyStatus | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (statusProp) return;
+    let cancelled = false;
+    // Health is read from the public health route. Pause state is not exposed
+    // through a public endpoint, so it defaults to "unknown" (treated as not
+    // paused) until an operator confirms it in the admin console.
+    fetch(apiUrl("/api/health"))
+      .then((res) => {
+        if (!cancelled) setFetchedStatus({ isPaused: false, healthy: res.ok });
+      })
+      .catch(() => {
+        if (!cancelled) setFetchedStatus({ isPaused: false, healthy: false });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [statusProp]);
+
+  const status: EmergencyStatus = statusProp ??
+    fetchedStatus ?? { isPaused: false, healthy: true };
+
+  const progress = useMemo(() => deriveRunbookProgress(status), [status]);
+  const stateById = useMemo(
+    () => new Map(progress.steps.map((s) => [s.id, s.state])),
+    [progress],
+  );
+
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center gap-2">
+        <ShieldAlert size={20} className="text-amber-400" />
+        <h2 className="text-xl font-semibold">Emergency Mode Runbook</h2>
+      </div>
+
+      <p className="text-sm text-gray-400">
+        Guidance only — this panel never pauses or resumes the protocol. Perform
+        privileged actions in the admin console.
+      </p>
+
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <span className="text-gray-400">Status:</span>
+        <StatusBadge
+          variant={status.healthy ? "success" : "danger"}
+          compact
+          label={status.healthy ? "Health: OK" : "Health: Degraded"}
+        />
+        <StatusBadge
+          variant={status.isPaused ? "warning" : "neutral"}
+          compact
+          label={status.isPaused ? "Protocol: Paused" : "Protocol: Active"}
+        />
+        <StatusBadge
+          variant={progress.phase === "incident" ? "danger" : "success"}
+          compact
+          label={progress.phase === "incident" ? "Incident in progress" : "Nominal"}
+        />
+      </div>
+
+      <ol className="space-y-3">
+        {EMERGENCY_RUNBOOK_STEPS.map((step, idx) => {
+          const state = stateById.get(step.id) ?? "upcoming";
+          return (
+            <li
+              key={step.id}
+              data-testid={`runbook-step-${step.id}`}
+              data-state={state}
+              className={`rounded-lg border p-4 ${STATE_STYLES[state]}`}
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    {state === "complete" ? (
+                      <CheckCircle2 className="w-4 h-4 text-green-400" />
+                    ) : (
+                      <Circle
+                        className={`w-4 h-4 ${state === "current" ? "text-indigo-400" : "text-gray-500"}`}
+                      />
+                    )}
+                    <span className="font-medium">
+                      {idx + 1}. {step.title}
+                    </span>
+                  </div>
+                  <p className="text-sm text-gray-400">{step.description}</p>
+                  <a
+                    href={step.reference.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-indigo-300 hover:text-indigo-200"
+                  >
+                    {step.reference.label}
+                    <ExternalLink className="w-3 h-3" />
+                  </a>
+                </div>
+                <button
+                  type="button"
+                  disabled
+                  aria-disabled="true"
+                  title="Read-only — perform this action in the admin console"
+                  className="shrink-0 text-xs px-3 py-1.5 rounded-lg bg-white/5 text-gray-400 cursor-not-allowed opacity-60"
+                >
+                  {step.actionLabel}
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}

--- a/client/src/pages/governance/emergencyRunbook.ts
+++ b/client/src/pages/governance/emergencyRunbook.ts
@@ -1,0 +1,118 @@
+/**
+ * Emergency Mode Operator Runbook — data & progress logic.
+ *
+ * Defines the pause → verify → notify → resume checklist and a pure function
+ * that derives each step's state from the current pause/health status. Pure
+ * and framework-free so it can be unit tested without rendering.
+ *
+ * The runbook is guidance only: it never executes privileged actions. See
+ * docs/EMERGENCY_RUNBOOK.md.
+ */
+
+export type RunbookStepId = "pause" | "verify" | "notify" | "resume";
+
+export interface RunbookReference {
+  label: string;
+  /** Doc anchor or read-only status-check path for this step. */
+  href: string;
+}
+
+export interface RunbookStep {
+  id: RunbookStepId;
+  title: string;
+  description: string;
+  reference: RunbookReference;
+  /** Label of the privileged action this step describes (rendered disabled). */
+  actionLabel: string;
+}
+
+const RUNBOOK_DOC = "/docs/EMERGENCY_RUNBOOK.md";
+
+export const EMERGENCY_RUNBOOK_STEPS: RunbookStep[] = [
+  {
+    id: "pause",
+    title: "Pause",
+    description:
+      "Halt new deposits and strategy execution to contain the incident.",
+    reference: { label: "Runbook: Pause", href: `${RUNBOOK_DOC}#pause` },
+    actionLabel: "Pause protocol",
+  },
+  {
+    id: "verify",
+    title: "Verify",
+    description:
+      "Confirm the pause took effect and establish what is actually wrong.",
+    reference: { label: "Health check", href: "/api/health" },
+    actionLabel: "Re-run verification",
+  },
+  {
+    id: "notify",
+    title: "Notify",
+    description:
+      "Communicate status to users and stakeholders and record the timeline.",
+    reference: { label: "Runbook: Notify", href: `${RUNBOOK_DOC}#notify` },
+    actionLabel: "Mark stakeholders notified",
+  },
+  {
+    id: "resume",
+    title: "Resume",
+    description:
+      "Return to normal operation only after the root cause is fixed and verified.",
+    reference: { label: "Runbook: Resume", href: `${RUNBOOK_DOC}#resume` },
+    actionLabel: "Resume protocol",
+  },
+];
+
+export type RunbookPhase = "nominal" | "incident";
+export type RunbookStepState = "complete" | "current" | "upcoming";
+
+export interface EmergencyStatus {
+  isPaused: boolean;
+  healthy: boolean;
+}
+
+export interface RunbookStepProgress {
+  id: RunbookStepId;
+  state: RunbookStepState;
+}
+
+export interface RunbookProgress {
+  phase: RunbookPhase;
+  steps: RunbookStepProgress[];
+}
+
+/**
+ * Derive checklist progress from the current pause/health status.
+ *
+ * - `nominal` phase (running and healthy): no active incident; every step is
+ *   upcoming.
+ * - `incident` phase: steps are evaluated sequentially. A step is `complete`
+ *   when its goal is objectively met, `current` for the first incomplete step,
+ *   and `upcoming` otherwise. `notify` is a manual acknowledgement and is never
+ *   auto-completed.
+ */
+export function deriveRunbookProgress(status: EmergencyStatus): RunbookProgress {
+  const phase: RunbookPhase =
+    !status.isPaused && status.healthy ? "nominal" : "incident";
+
+  const complete: Record<RunbookStepId, boolean> = {
+    pause: status.isPaused,
+    verify: status.isPaused && status.healthy,
+    notify: false,
+    resume: false,
+  };
+
+  let currentAssigned = false;
+  const steps: RunbookStepProgress[] = EMERGENCY_RUNBOOK_STEPS.map((step) => {
+    if (complete[step.id]) {
+      return { id: step.id, state: "complete" };
+    }
+    if (phase === "incident" && !currentAssigned) {
+      currentAssigned = true;
+      return { id: step.id, state: "current" };
+    }
+    return { id: step.id, state: "upcoming" };
+  });
+
+  return { phase, steps };
+}

--- a/client/src/pages/transparency/IndexerCheckpointPanel.tsx
+++ b/client/src/pages/transparency/IndexerCheckpointPanel.tsx
@@ -1,0 +1,149 @@
+/**
+ * Contract Event Indexer — Replay Checkpoint Panel
+ *
+ * Operator-facing, read-only view of the event indexer: latest indexed ledger
+ * (replay checkpoint), latest network ledger, lag from Horizon, and recent
+ * replay errors. Surfaces a degraded/unavailable banner when the indexer
+ * falls behind.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { Database, RefreshCw, AlertTriangle } from "lucide-react";
+import StatusBadge from "../../components/StatusBadge";
+import { apiUrl } from "../../lib/api";
+import {
+  getIndexerStatusDisplay,
+  formatLag,
+  isIndexerDegraded,
+  type IndexerStatus,
+} from "./indexerStatus";
+
+export default function IndexerCheckpointPanel() {
+  const [status, setStatus] = useState<IndexerStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const res = await fetch(apiUrl("/api/indexer/status"));
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const body = await res.json();
+      setStatus(body.data as IndexerStatus);
+    } catch (err) {
+      console.error("Failed to fetch indexer status:", err);
+      setError(err instanceof Error ? err.message : "Failed to fetch indexer status");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  const display = status ? getIndexerStatusDisplay(status.status) : null;
+
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Database size={20} className="text-indigo-400" />
+          <h2 className="text-xl font-semibold">Event Indexer Checkpoint</h2>
+        </div>
+        <button
+          type="button"
+          onClick={fetchStatus}
+          disabled={isLoading}
+          aria-label="Refresh indexer status"
+          className="flex items-center gap-2 text-sm text-gray-300 hover:text-white disabled:opacity-50"
+        >
+          <RefreshCw size={16} className={isLoading ? "animate-spin" : ""} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-500" />
+          <span className="text-sm text-red-400">{error}</span>
+        </div>
+      )}
+
+      {!error && isLoading && !status && (
+        <p className="text-sm text-gray-400">Loading indexer status…</p>
+      )}
+
+      {status && display && (
+        <>
+          <div className="flex flex-wrap items-center gap-3">
+            <StatusBadge variant={display.variant} label={display.label} />
+            <span className="text-sm text-gray-400">{formatLag(status.lagLedgers)}</span>
+          </div>
+
+          {isIndexerDegraded(status) && status.reason && (
+            <div className="flex items-center gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+              <AlertTriangle className="w-4 h-4 text-yellow-500" />
+              <span className="text-sm text-yellow-400">{status.reason}</span>
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            <Metric
+              label="Replay checkpoint"
+              value={status.indexedLedger !== null ? `#${status.indexedLedger}` : "—"}
+            />
+            <Metric
+              label="Network ledger"
+              value={status.horizonLedger !== null ? `#${status.horizonLedger}` : "—"}
+            />
+            <Metric
+              label="Lag (ledgers)"
+              value={status.lagLedgers !== null ? String(status.lagLedgers) : "—"}
+            />
+          </div>
+
+          <div>
+            <h3 className="text-sm font-medium text-gray-300 mb-2">
+              Recent replay errors
+            </h3>
+            {status.recentErrors.length === 0 ? (
+              <p className="text-sm text-gray-500">No recent replay errors.</p>
+            ) : (
+              <ul className="space-y-1">
+                {status.recentErrors.map((err, idx) => (
+                  <li
+                    key={`${err.at}-${idx}`}
+                    className="text-xs text-red-300 bg-red-500/5 border border-red-500/20 rounded px-2 py-1"
+                  >
+                    <span className="text-gray-500">
+                      {new Date(err.at).toLocaleTimeString()}
+                      {err.ledger !== null ? ` · #${err.ledger}` : ""}
+                    </span>{" "}
+                    {err.message}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <p className="text-xs text-gray-500">
+            Generated {new Date(status.generatedAt).toLocaleString()} · read-only
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="p-3 bg-black/30 rounded-lg">
+      <p className="text-xs text-gray-400">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  );
+}

--- a/client/src/pages/transparency/indexerStatus.test.ts
+++ b/client/src/pages/transparency/indexerStatus.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  getIndexerStatusDisplay,
+  formatLag,
+  isIndexerDegraded,
+  type IndexerStatus,
+} from "./indexerStatus";
+
+const status = (overrides: Partial<IndexerStatus> = {}): IndexerStatus => ({
+  status: "healthy",
+  reason: null,
+  indexedLedger: 1000,
+  horizonLedger: 1002,
+  lagLedgers: 2,
+  lastIndexedAt: null,
+  heartbeatAgeSeconds: null,
+  recentErrors: [],
+  generatedAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("getIndexerStatusDisplay", () => {
+  it("maps healthy to a non-attention success badge", () => {
+    const display = getIndexerStatusDisplay("healthy");
+    expect(display.variant).toBe("success");
+    expect(display.needsAttention).toBe(false);
+  });
+
+  it("maps degraded to an attention-worthy warning badge", () => {
+    const display = getIndexerStatusDisplay("degraded");
+    expect(display.variant).toBe("warning");
+    expect(display.needsAttention).toBe(true);
+  });
+
+  it("maps unavailable to a danger badge", () => {
+    expect(getIndexerStatusDisplay("unavailable").variant).toBe("danger");
+  });
+
+  it("falls back to neutral for unexpected values", () => {
+    expect(getIndexerStatusDisplay("???").label).toBe("Unknown");
+  });
+});
+
+describe("formatLag", () => {
+  it("renders in sync, singular, and plural correctly", () => {
+    expect(formatLag(0)).toBe("in sync");
+    expect(formatLag(1)).toBe("1 ledger behind");
+    expect(formatLag(42)).toBe("42 ledgers behind");
+  });
+  it("renders unknown for null lag", () => {
+    expect(formatLag(null)).toBe("unknown");
+  });
+});
+
+describe("isIndexerDegraded", () => {
+  it("is false only for healthy", () => {
+    expect(isIndexerDegraded(status({ status: "healthy" }))).toBe(false);
+    expect(isIndexerDegraded(status({ status: "degraded" }))).toBe(true);
+    expect(isIndexerDegraded(status({ status: "unavailable" }))).toBe(true);
+  });
+});

--- a/client/src/pages/transparency/indexerStatus.ts
+++ b/client/src/pages/transparency/indexerStatus.ts
@@ -1,0 +1,65 @@
+/**
+ * UI status mapping for the Contract Event Indexer checkpoint panel.
+ *
+ * Pure and framework-free so the status mapping (including the degraded state)
+ * can be unit tested without rendering a component.
+ */
+
+import type { StatusVariant } from "../../components/StatusBadge";
+
+export type IndexerHealthStatus = "healthy" | "degraded" | "unavailable";
+
+export interface IndexerReplayError {
+  ledger: number | null;
+  message: string;
+  at: string;
+}
+
+export interface IndexerStatus {
+  status: IndexerHealthStatus;
+  reason: string | null;
+  indexedLedger: number | null;
+  horizonLedger: number | null;
+  lagLedgers: number | null;
+  lastIndexedAt: string | null;
+  heartbeatAgeSeconds: number | null;
+  recentErrors: IndexerReplayError[];
+  generatedAt: string;
+}
+
+interface StatusDisplay {
+  label: string;
+  variant: StatusVariant;
+  needsAttention: boolean;
+}
+
+const STATUS_DISPLAY: Record<IndexerHealthStatus, StatusDisplay> = {
+  healthy: { label: "Healthy", variant: "success", needsAttention: false },
+  degraded: { label: "Degraded", variant: "warning", needsAttention: true },
+  unavailable: { label: "Unavailable", variant: "danger", needsAttention: true },
+};
+
+const FALLBACK_DISPLAY: StatusDisplay = {
+  label: "Unknown",
+  variant: "neutral",
+  needsAttention: true,
+};
+
+/** Map an indexer status to its badge label/variant. */
+export function getIndexerStatusDisplay(
+  status: IndexerHealthStatus | string,
+): StatusDisplay {
+  return STATUS_DISPLAY[status as IndexerHealthStatus] ?? FALLBACK_DISPLAY;
+}
+
+/** Human-friendly ledger lag string. */
+export function formatLag(lagLedgers: number | null): string {
+  if (lagLedgers === null || !Number.isFinite(lagLedgers)) return "unknown";
+  if (lagLedgers === 0) return "in sync";
+  return `${lagLedgers} ledger${lagLedgers === 1 ? "" : "s"} behind`;
+}
+
+/** True when the indexer is degraded or unavailable and needs operator attention. */
+export function isIndexerDegraded(status: IndexerStatus): boolean {
+  return status.status !== "healthy";
+}

--- a/docs/EMERGENCY_RUNBOOK.md
+++ b/docs/EMERGENCY_RUNBOOK.md
@@ -1,0 +1,52 @@
+# Emergency Mode Operator Runbook
+
+This runbook guides operators through a protocol emergency. It is a **checklist
+and reference**, not an automation tool — every privileged action (pausing,
+resuming) is performed deliberately through the admin console, never triggered
+automatically by the UI.
+
+The in-app companion is the **Emergency Runbook Panel**
+(`client/src/pages/governance/EmergencyRunbookPanel.tsx`), which renders these
+steps, shows the current pause/health status where available, and links each
+step back to this document or to a read-only status check.
+
+## Steps
+
+### Pause
+
+Halt new deposits and strategy execution to contain the incident.
+
+- Action is performed by an authorized operator via the admin freeze controls
+  (`POST /api/admin/recommendations/freeze`). The panel never executes it.
+- Confirm the freeze took effect before moving on.
+
+### Verify
+
+Establish what is actually wrong before communicating or resuming.
+
+- Check protocol health: [`GET /api/health`](/api/health).
+- Review the [Event Indexer Checkpoint](#) for replay lag and recent errors.
+- Confirm the pause is active and no unexpected state changes are occurring.
+
+### Notify
+
+Communicate clearly with users and stakeholders.
+
+- Post status to the official channels (status page, social, governance forum).
+- Record the incident timeline for the post-mortem.
+- This step is a manual acknowledgement; the panel cannot complete it for you.
+
+### Resume
+
+Return to normal operation only after the root cause is understood and fixed.
+
+- Re-run the **Verify** checks and confirm health has recovered.
+- Lift the freeze via the admin controls (read-only status reflected in the panel).
+- Continue monitoring for regressions after resuming.
+
+## Principles
+
+- **Read-only by design.** The panel surfaces status and guidance; it does not
+  hold privileged keys and cannot pause or resume the protocol.
+- **Verify before you act.** Each transition is gated on confirming current
+  state, not assumptions.

--- a/server/src/__tests__/indexerStatus.test.ts
+++ b/server/src/__tests__/indexerStatus.test.ts
@@ -1,0 +1,90 @@
+import request from "supertest";
+import { createApp } from "../app";
+import {
+  classifyIndexerStatus,
+  INDEXER_THRESHOLDS,
+  type IndexerStatusInput,
+} from "../indexer/indexerStatus";
+
+const baseInput: IndexerStatusInput = {
+  indexedLedger: 1000,
+  horizonLedger: 1005,
+  lastIndexedAt: new Date().toISOString(),
+  recentErrors: [],
+  now: Date.now(),
+};
+
+describe("classifyIndexerStatus", () => {
+  it("reports healthy when lag is small and there are no errors", () => {
+    const status = classifyIndexerStatus(baseInput);
+    expect(status.status).toBe("healthy");
+    expect(status.lagLedgers).toBe(5);
+    expect(status.reason).toBeNull();
+  });
+
+  it("marks the indexer degraded once lag exceeds the threshold", () => {
+    const status = classifyIndexerStatus({
+      ...baseInput,
+      horizonLedger: baseInput.indexedLedger! + INDEXER_THRESHOLDS.degradedLagLedgers,
+    });
+    expect(status.status).toBe("degraded");
+    expect(status.reason).toMatch(/lag/i);
+  });
+
+  it("marks the indexer unavailable when far behind the network", () => {
+    const status = classifyIndexerStatus({
+      ...baseInput,
+      horizonLedger:
+        baseInput.indexedLedger! + INDEXER_THRESHOLDS.unavailableLagLedgers,
+    });
+    expect(status.status).toBe("unavailable");
+  });
+
+  it("is unavailable when no checkpoint exists", () => {
+    const status = classifyIndexerStatus({
+      ...baseInput,
+      indexedLedger: null,
+      horizonLedger: null,
+    });
+    expect(status.status).toBe("unavailable");
+    expect(status.lagLedgers).toBeNull();
+    expect(status.reason).toMatch(/checkpoint unavailable/i);
+  });
+
+  it("degrades on a stale heartbeat even when lag is small", () => {
+    const status = classifyIndexerStatus({
+      ...baseInput,
+      lastIndexedAt: new Date(
+        Date.now() - (INDEXER_THRESHOLDS.staleHeartbeatSeconds + 60) * 1000,
+      ).toISOString(),
+    });
+    expect(status.status).toBe("degraded");
+    expect(status.heartbeatAgeSeconds).toBeGreaterThan(
+      INDEXER_THRESHOLDS.staleHeartbeatSeconds,
+    );
+  });
+
+  it("degrades when recent replay errors are present", () => {
+    const status = classifyIndexerStatus({
+      ...baseInput,
+      recentErrors: [{ ledger: 1001, message: "boom", at: new Date().toISOString() }],
+    });
+    expect(status.status).toBe("degraded");
+    expect(status.reason).toMatch(/replay error/i);
+  });
+});
+
+describe("GET /api/indexer/status", () => {
+  it("returns 200 with a well-formed status envelope", async () => {
+    const res = await request(createApp()).get("/api/indexer/status");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    const { data } = res.body;
+    expect(["healthy", "degraded", "unavailable"]).toContain(data.status);
+    expect("indexedLedger" in data).toBe(true);
+    expect("lagLedgers" in data).toBe(true);
+    expect(Array.isArray(data.recentErrors)).toBe(true);
+    expect(typeof data.generatedAt).toBe("string");
+  });
+});

--- a/server/src/__tests__/simulationService.test.ts
+++ b/server/src/__tests__/simulationService.test.ts
@@ -1,4 +1,10 @@
-import { simulateDeposit } from "../services/simulationService";
+import {
+  simulateDeposit,
+  simulateRebalance,
+  validateRebalanceParams,
+  REBALANCE_THRESHOLDS,
+  type RebalanceParams,
+} from "../services/simulationService";
 
 describe("Simulation Service", () => {
   it("should estimate allocations, expected shares, fees, and explicitly mark as preview-only", () => {
@@ -47,5 +53,90 @@ describe("Simulation Service", () => {
     });
 
     expect(result0.warnings).toContain("Amount must be greater than zero.");
+  });
+});
+
+describe("Rebalance Simulation Sandbox", () => {
+  const evenToConcentrated: RebalanceParams = {
+    totalValueUsd: 10_000,
+    allocations: [
+      { label: "Blend", currentWeight: 50, targetWeight: 70, apy: 8 },
+      { label: "Soroswap", currentWeight: 50, targetWeight: 30, apy: 4 },
+    ],
+  };
+
+  it("previews before/after blended APY and is flagged simulation-only", () => {
+    const preview = simulateRebalance(evenToConcentrated);
+
+    expect(preview.isSimulationOnly).toBe(true);
+    // before: 0.5*8 + 0.5*4 = 6 ; after: 0.7*8 + 0.3*4 = 6.8
+    expect(preview.blendedApyBefore).toBeCloseTo(6, 5);
+    expect(preview.blendedApyAfter).toBeCloseTo(6.8, 5);
+    expect(preview.apyDeltaPct).toBeCloseTo(0.8, 5);
+  });
+
+  it("computes per-leg drift, turnover, and fees", () => {
+    const preview = simulateRebalance({ ...evenToConcentrated, feeBps: 20 });
+
+    const blend = preview.legs.find((l) => l.label === "Blend");
+    expect(blend?.driftPct).toBe(20);
+    expect(blend?.deltaUsd).toBe(2_000); // 70% - 50% of 10k
+
+    // gross movement = 2000 (buy) + 2000 (sell) => turnover 2000
+    expect(preview.totalTurnoverUsd).toBe(2_000);
+    expect(preview.estimatedFeeUsd).toBeCloseTo(4, 5); // 2000 * 20bps
+    expect(preview.maxDriftPct).toBe(20);
+  });
+
+  it("warns on high fees, stale data, and liquidity risk", () => {
+    const preview = simulateRebalance({
+      totalValueUsd: 10_000,
+      feeBps: 500, // 5% turnover fee -> high fees
+      dataAgeSeconds: REBALANCE_THRESHOLDS.staleDataSeconds + 60,
+      allocations: [
+        {
+          label: "Blend",
+          currentWeight: 30,
+          targetWeight: 80,
+          apy: 8,
+          liquidityUsd: 1_000, // buying $5k into $1k of liquidity
+        },
+        { label: "Soroswap", currentWeight: 70, targetWeight: 20, apy: 4 },
+      ],
+    });
+
+    expect(preview.warnings.some((w) => /High fees/.test(w))).toBe(true);
+    expect(preview.warnings.some((w) => /Stale data/.test(w))).toBe(true);
+    expect(preview.warnings.some((w) => /Liquidity risk/.test(w))).toBe(true);
+  });
+
+  it("validates weights that do not sum to 100%", () => {
+    const errors = validateRebalanceParams({
+      totalValueUsd: 10_000,
+      allocations: [
+        { label: "Blend", currentWeight: 50, targetWeight: 60, apy: 8 },
+        { label: "Soroswap", currentWeight: 50, targetWeight: 30, apy: 4 },
+      ],
+    });
+    expect(errors.some((e) => /Target weights must sum to 100%/.test(e))).toBe(
+      true,
+    );
+  });
+
+  it("rejects invalid totals and empty allocations", () => {
+    expect(
+      validateRebalanceParams({ totalValueUsd: 0, allocations: [] }),
+    ).toEqual(
+      expect.arrayContaining([
+        "totalValueUsd must be a positive number.",
+        "allocations must be a non-empty array.",
+      ]),
+    );
+  });
+
+  it("throws when simulateRebalance is given invalid params", () => {
+    expect(() =>
+      simulateRebalance({ totalValueUsd: -1, allocations: [] }),
+    ).toThrow(/Invalid rebalance parameters/);
   });
 });

--- a/server/src/__tests__/sourceHealth.test.ts
+++ b/server/src/__tests__/sourceHealth.test.ts
@@ -1,0 +1,35 @@
+import request from "supertest";
+import { createApp } from "../app";
+
+describe("GET /api/analytics/sources/health", () => {
+  it("returns 200 with the registry envelope", async () => {
+    const res = await request(createApp()).get("/api/analytics/sources/health");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(typeof res.body.data.generatedAt).toBe("string");
+    expect(typeof res.body.data.totalSources).toBe("number");
+    expect(Array.isArray(res.body.data.sources)).toBe(true);
+  });
+
+  it("returns one summary per source with the documented fields", async () => {
+    const res = await request(createApp()).get("/api/analytics/sources/health");
+    const { sources, totalSources, counts } = res.body.data;
+
+    expect(sources).toHaveLength(totalSources);
+    for (const source of sources) {
+      expect(typeof source.providerId).toBe("string");
+      expect(typeof source.providerName).toBe("string");
+      expect(["healthy", "degraded", "stale", "unavailable"]).toContain(
+        source.status,
+      );
+      expect(typeof source.uptimePct).toBe("number");
+      expect(typeof source.latencyMs).toBe("number");
+      expect(typeof source.latestFetch).toBe("string");
+    }
+
+    const summed =
+      counts.healthy + counts.degraded + counts.stale + counts.unavailable;
+    expect(summed).toBe(totalSources);
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -39,6 +39,7 @@ import governanceRouter from "./routes/governance";
 import presetsRouter from "./routes/presets";
 import analyticsRouter from "./routes/analytics";
 import fragmentationRouter from "./routes/fragmentation";
+import indexerRouter from "./routes/indexer";
 import { createAuthChallenge, verifyAuthChallenge } from "./utils/stellarAuth";
 import {
   getRecommendationTimeline,
@@ -124,6 +125,7 @@ export function createApp() {
   app.use("/api/presets", presetsRouter);
   app.use("/api/analytics", analyticsRouter);
   app.use("/api/liquidity", fragmentationRouter);
+  app.use("/api/indexer", indexerRouter);
 
   // Legacy JSON metrics (internal tooling)
   app.get("/api/metrics", getMetrics);

--- a/server/src/indexer/indexer.ts
+++ b/server/src/indexer/indexer.ts
@@ -1,4 +1,5 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
+import { recordReplayError } from './indexerStatus';
 const RPC_URL = process.env.RPC_URL || 'https://soroban-testnet.stellar.org';
 const CONTRACT_ID = process.env.VITE_CONTRACT_ID || '';
 const POLL_INTERVAL = 5000; // 5 seconds
@@ -28,7 +29,7 @@ type IndexerPrismaClient = {
 
 async function loadPrismaClient(): Promise<IndexerPrismaClient | null> {
   try {
-    const prismaModule = (await import('@prisma/client')) as {
+    const prismaModule = (await import('@prisma/client')) as unknown as {
       PrismaClient?: new () => IndexerPrismaClient;
     };
 
@@ -124,6 +125,10 @@ export async function startIndexer() {
       setTimeout(poll, POLL_INTERVAL);
     } catch (error) {
       console.error('[Indexer] Error:', error);
+      recordReplayError(
+        error instanceof Error ? error.message : String(error),
+        startLedger,
+      );
       setTimeout(poll, POLL_INTERVAL); // Retry
     }
   };

--- a/server/src/indexer/indexerStatus.ts
+++ b/server/src/indexer/indexerStatus.ts
@@ -1,0 +1,182 @@
+/**
+ * Indexer Replay Checkpoint Status
+ *
+ * Operator-facing view of the contract event indexer: the latest indexed
+ * ledger (replay checkpoint), the latest ledger on the network, the resulting
+ * lag, and recent replay errors. The status classifier is pure so it can be
+ * unit-tested without Prisma or a live Horizon connection.
+ */
+
+import * as StellarSdk from "@stellar/stellar-sdk";
+
+const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
+
+export type IndexerHealthStatus = "healthy" | "degraded" | "unavailable";
+
+export interface IndexerReplayError {
+  ledger: number | null;
+  message: string;
+  at: string; // ISO timestamp
+}
+
+export interface IndexerStatusInput {
+  /** Last ledger the indexer durably committed (replay checkpoint). */
+  indexedLedger: number | null;
+  /** Latest ledger observed on the network via Horizon/RPC. */
+  horizonLedger: number | null;
+  /** ISO timestamp of the last successful commit, when known. */
+  lastIndexedAt: string | null;
+  recentErrors: IndexerReplayError[];
+  now?: number;
+}
+
+export interface IndexerStatus {
+  status: IndexerHealthStatus;
+  reason: string | null;
+  indexedLedger: number | null;
+  horizonLedger: number | null;
+  lagLedgers: number | null;
+  lastIndexedAt: string | null;
+  heartbeatAgeSeconds: number | null;
+  recentErrors: IndexerReplayError[];
+  generatedAt: string;
+}
+
+export const INDEXER_THRESHOLDS = {
+  /** Lag (ledgers) at or above which the indexer is degraded. ~5m @ 5s ledgers. */
+  degradedLagLedgers: 60,
+  /** Lag (ledgers) at or above which the indexer is effectively unavailable. ~1h. */
+  unavailableLagLedgers: 720,
+  /** No commit in this many seconds downgrades the indexer to degraded. */
+  staleHeartbeatSeconds: 15 * 60,
+} as const;
+
+/**
+ * Pure classifier: map indexer signals to an operator status and reason.
+ */
+export function classifyIndexerStatus(input: IndexerStatusInput): IndexerStatus {
+  const now = input.now ?? Date.now();
+  const t = INDEXER_THRESHOLDS;
+
+  const lagLedgers =
+    input.indexedLedger !== null && input.horizonLedger !== null
+      ? Math.max(0, input.horizonLedger - input.indexedLedger)
+      : null;
+
+  const heartbeatAgeSeconds = input.lastIndexedAt
+    ? Math.max(0, Math.round((now - new Date(input.lastIndexedAt).getTime()) / 1000))
+    : null;
+
+  let status: IndexerHealthStatus = "healthy";
+  let reason: string | null = null;
+
+  if (input.indexedLedger === null) {
+    status = "unavailable";
+    reason = "Indexer checkpoint unavailable";
+  } else if (lagLedgers !== null && lagLedgers >= t.unavailableLagLedgers) {
+    status = "unavailable";
+    reason = `Indexer is ${lagLedgers} ledgers behind the network`;
+  } else if (
+    heartbeatAgeSeconds !== null &&
+    heartbeatAgeSeconds > t.staleHeartbeatSeconds
+  ) {
+    status = "degraded";
+    reason = `No indexed ledger committed for ${Math.round(heartbeatAgeSeconds / 60)}m`;
+  } else if (lagLedgers !== null && lagLedgers >= t.degradedLagLedgers) {
+    status = "degraded";
+    reason = `Indexer lag of ${lagLedgers} ledgers exceeds threshold`;
+  } else if (input.recentErrors.length > 0) {
+    status = "degraded";
+    reason = `${input.recentErrors.length} recent replay error(s)`;
+  }
+
+  return {
+    status,
+    reason,
+    indexedLedger: input.indexedLedger,
+    horizonLedger: input.horizonLedger,
+    lagLedgers,
+    lastIndexedAt: input.lastIndexedAt,
+    heartbeatAgeSeconds,
+    recentErrors: input.recentErrors,
+    generatedAt: new Date(now).toISOString(),
+  };
+}
+
+// ── Recent replay error ring buffer ───────────────────────────────────────
+// In-memory only; mirrors how the indexer's own state lives during runtime.
+
+const MAX_RECENT_ERRORS = 10;
+const recentErrors: IndexerReplayError[] = [];
+
+/** Record a replay error so the status route can surface it. Called by the indexer. */
+export function recordReplayError(message: string, ledger: number | null = null): void {
+  recentErrors.unshift({ ledger, message, at: new Date().toISOString() });
+  if (recentErrors.length > MAX_RECENT_ERRORS) {
+    recentErrors.length = MAX_RECENT_ERRORS;
+  }
+}
+
+/** Return a copy of the most recent replay errors (newest first). */
+export function getRecentReplayErrors(): IndexerReplayError[] {
+  return [...recentErrors];
+}
+
+// ── Snapshot assembly ─────────────────────────────────────────────────────
+
+type IndexerStatePrismaClient = {
+  indexerState: {
+    findUnique(args: {
+      where: { id: string };
+    }): Promise<{ id: string; lastLedger: number } | null>;
+  };
+};
+
+async function loadIndexerState(): Promise<number | null> {
+  try {
+    const prismaModule = (await import("@prisma/client")) as unknown as {
+      PrismaClient?: new () => IndexerStatePrismaClient;
+    };
+    if (!prismaModule.PrismaClient) return null;
+
+    const prisma = new prismaModule.PrismaClient();
+    const state = await prisma.indexerState.findUnique({
+      where: { id: "singleton" },
+    });
+    return state ? state.lastLedger : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadHorizonLedger(): Promise<number | null> {
+  try {
+    const rpcServer = new StellarSdk.rpc.Server(RPC_URL);
+    const latest = await Promise.race([
+      rpcServer.getLatestLedger(),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), 2_500)),
+    ]);
+    return latest && typeof latest.sequence === "number" ? latest.sequence : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort live snapshot of indexer health. Reads the replay checkpoint
+ * from Prisma and the latest ledger from Horizon, degrading gracefully (no
+ * throw) when either is unavailable.
+ */
+export async function getIndexerStatusSnapshot(): Promise<IndexerStatus> {
+  const indexedLedger = await loadIndexerState();
+
+  // Skip the network round-trip when we have no checkpoint to compare against.
+  const horizonLedger = indexedLedger === null ? null : await loadHorizonLedger();
+
+  return classifyIndexerStatus({
+    indexedLedger,
+    horizonLedger,
+    lastIndexedAt: null, // not persisted by the current indexer schema
+    recentErrors: getRecentReplayErrors(),
+  });
+}

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -6,6 +6,7 @@ import {
   yieldReliabilityEngine,
 } from '../services';
 import { strategyStateTransitionAuditService } from '../services/strategyStateTransitionAuditService';
+import { getSourceHealthRegistry } from '../services/yieldSourceRegistryService';
 import {
   generateRecommendationStabilityReport,
   type RecommendationOutput,
@@ -299,6 +300,34 @@ router.get('/health/:strategyId', async (req, res) => {
   } catch (error) {
     console.error(`Health score calculation failed for ${req.params.strategyId}:`, error);
     res.status(500).json({ error: 'Failed to calculate health score', message: error instanceof Error ? error.message : 'Unknown error' });
+  }
+});
+
+// ── Yield Data Source Registry ──────────────────────────────────────────
+
+/**
+ * GET /api/analytics/sources/health
+ * Read-only health registry for every registered yield data source.
+ * Returns each source's status (healthy/degraded/stale/unavailable), latest
+ * fetch time, uptime, latency, and failure reason.
+ */
+router.get('/sources/health', async (_req, res) => {
+  try {
+    const registry = await getSourceHealthRegistry();
+    res.setHeader(
+      'Cache-Control',
+      'public, max-age=30, stale-while-revalidate=15',
+    );
+    res.json({
+      success: true,
+      data: registry,
+    });
+  } catch (error) {
+    console.error('Source health registry generation failed:', error);
+    res.status(500).json({
+      error: 'Failed to build source health registry',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    });
   }
 });
 

--- a/server/src/routes/indexer.ts
+++ b/server/src/routes/indexer.ts
@@ -1,0 +1,30 @@
+/**
+ * indexer.ts (routes)
+ *
+ * Read-only operator route for the contract event indexer.
+ *
+ * GET /api/indexer/status
+ *   Returns the latest indexed ledger (replay checkpoint), the latest network
+ *   ledger, lag from Horizon, recent replay errors, and a degraded/unavailable
+ *   status when the indexer falls behind. Read-only — never mutates indexer state.
+ */
+import { Router, Request, Response } from "express";
+import { getIndexerStatusSnapshot } from "../indexer/indexerStatus";
+
+const router = Router();
+
+router.get("/status", async (_req: Request, res: Response) => {
+  try {
+    const snapshot = await getIndexerStatusSnapshot();
+    res.setHeader("Cache-Control", "public, max-age=10, stale-while-revalidate=10");
+    res.json({ success: true, data: snapshot });
+  } catch (error) {
+    console.error("Failed to build indexer status snapshot:", error);
+    res.status(500).json({
+      error: "Failed to build indexer status",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+export default router;

--- a/server/src/routes/simulator.ts
+++ b/server/src/routes/simulator.ts
@@ -1,5 +1,11 @@
 import { Router, Request, Response } from "express";
-import { simulateDeposit, SimulationParams } from "../services/simulationService";
+import {
+  simulateDeposit,
+  SimulationParams,
+  simulateRebalance,
+  validateRebalanceParams,
+  type RebalanceParams,
+} from "../services/simulationService";
 
 const router = Router();
 
@@ -38,6 +44,36 @@ router.post("/deposit", (req: Request, res: Response) => {
   } catch (e) {
     res.status(500).json({
       error: e instanceof Error ? e.message : "Simulation failed",
+    });
+  }
+});
+
+/**
+ * POST /api/simulator/rebalance
+ *
+ * Sandbox preview of a portfolio rebalance: projected blended APY before/after,
+ * estimated turnover fees, per-leg allocation drift, and warnings for high
+ * fees, stale data, and liquidity risk. Simulation-only — never executes a
+ * rebalance.
+ */
+router.post("/rebalance", (req: Request, res: Response) => {
+  try {
+    const params = req.body as RebalanceParams;
+
+    const validationErrors = validateRebalanceParams(params);
+    if (validationErrors.length > 0) {
+      res.status(400).json({
+        error: "Invalid rebalance parameters",
+        details: validationErrors,
+      });
+      return;
+    }
+
+    const preview = simulateRebalance(params);
+    res.json(preview);
+  } catch (e) {
+    res.status(500).json({
+      error: e instanceof Error ? e.message : "Rebalance simulation failed",
     });
   }
 });

--- a/server/src/services/__tests__/yieldSourceRegistryService.test.ts
+++ b/server/src/services/__tests__/yieldSourceRegistryService.test.ts
@@ -1,0 +1,189 @@
+import {
+  classifySourceHealth,
+  summarizeSourceHealth,
+  toSourceHealth,
+  getSourceHealthRegistry,
+  SOURCE_HEALTH_THRESHOLDS,
+  type SourceHealthInput,
+  type SourceHealthSummary,
+} from "../yieldSourceRegistryService";
+import type { DataSourceReliability } from "../yieldReliabilityService";
+
+const baseInput: SourceHealthInput = {
+  reliabilityStatus: "high",
+  reliabilityScore: 92,
+  consecutiveFailures: 0,
+  errorRate: 0.01,
+  latencyMs: 200,
+  freshness: 0.95,
+  ageSeconds: 120,
+};
+
+describe("classifySourceHealth", () => {
+  it("marks a fresh, low-error source as healthy with no failure reason", () => {
+    const result = classifySourceHealth(baseInput);
+    expect(result.status).toBe("healthy");
+    expect(result.failureReason).toBeNull();
+  });
+
+  it("marks a source unavailable after consecutive failures", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      consecutiveFailures: SOURCE_HEALTH_THRESHOLDS.unavailableConsecutiveFailures,
+    });
+    expect(result.status).toBe("unavailable");
+    expect(result.failureReason).toMatch(/consecutive fetch failures/);
+  });
+
+  it("marks an 'unreliable' source unavailable", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      reliabilityStatus: "unreliable",
+      reliabilityScore: 0,
+    });
+    expect(result.status).toBe("unavailable");
+  });
+
+  it("marks an old source stale even when connectivity looks fine", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      ageSeconds: SOURCE_HEALTH_THRESHOLDS.staleAgeSeconds + 60,
+    });
+    expect(result.status).toBe("stale");
+    expect(result.failureReason).toMatch(/No fresh data/);
+  });
+
+  it("marks a high-latency source degraded", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      latencyMs: SOURCE_HEALTH_THRESHOLDS.degradedMaxLatencyMs + 100,
+    });
+    expect(result.status).toBe("degraded");
+    expect(result.failureReason).toMatch(/Elevated latency/);
+  });
+
+  it("marks an elevated-error source degraded", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      errorRate: SOURCE_HEALTH_THRESHOLDS.degradedMaxErrorRate + 0.02,
+    });
+    expect(result.status).toBe("degraded");
+    expect(result.failureReason).toMatch(/Elevated error rate/);
+  });
+
+  it("prioritizes unavailable over stale", () => {
+    const result = classifySourceHealth({
+      ...baseInput,
+      reliabilityStatus: "unreliable",
+      ageSeconds: SOURCE_HEALTH_THRESHOLDS.staleAgeSeconds + 60,
+    });
+    expect(result.status).toBe("unavailable");
+  });
+});
+
+describe("toSourceHealth", () => {
+  const reliability: DataSourceReliability = {
+    providerId: "blend_api",
+    providerName: "Blend Protocol",
+    dataSource: "api",
+    reliabilityScore: 88.6,
+    status: "high",
+    lastUpdated: new Date().toISOString(),
+    trend: "stable",
+    recommendations: [],
+    failoverPriority: 5,
+    weightInRecommendations: 1,
+    metrics: {
+      freshness: 0.9,
+      consistency: 0.9,
+      historicalUptime: 0.985,
+      anomalyRate: 0.02,
+      latency: 250,
+      errorRate: 0.015,
+      coverage: 0.98,
+      accuracy: 0.95,
+    },
+    signals: {
+      lastSuccessfulFetch: new Date(Date.now() - 60_000).toISOString(),
+      consecutiveFailures: 0,
+      totalRequests: 1000,
+      successfulRequests: 985,
+      averageResponseTime: 250,
+      lastAnomaly: new Date().toISOString(),
+      dataPointsLast24h: 142,
+      expectedDataPoints24h: 144,
+      varianceFromMean: 0.02,
+      crossSourceDeviation: 0.05,
+    },
+  };
+
+  it("produces the documented response shape", () => {
+    const summary = toSourceHealth(reliability);
+    expect(summary).toMatchObject({
+      providerId: "blend_api",
+      providerName: "Blend Protocol",
+      dataSource: "api",
+    });
+    expect(typeof summary.status).toBe("string");
+    expect(typeof summary.uptimePct).toBe("number");
+    expect(typeof summary.latencyMs).toBe("number");
+    expect(typeof summary.latestFetch).toBe("string");
+    expect(summary.reliabilityScore).toBe(89); // rounded
+    expect(summary.uptimePct).toBeCloseTo(98.5, 1);
+    expect(summary.status).toBe("healthy");
+  });
+
+  it("flags stale when the last fetch is far in the past", () => {
+    const stale = toSourceHealth({
+      ...reliability,
+      signals: {
+        ...reliability.signals,
+        lastSuccessfulFetch: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      },
+    });
+    expect(stale.status).toBe("stale");
+    expect(stale.ageSeconds).toBeGreaterThan(
+      SOURCE_HEALTH_THRESHOLDS.staleAgeSeconds,
+    );
+  });
+});
+
+describe("summarizeSourceHealth", () => {
+  it("counts every status bucket", () => {
+    const sources = [
+      { status: "healthy" },
+      { status: "healthy" },
+      { status: "degraded" },
+      { status: "unavailable" },
+    ] as SourceHealthSummary[];
+    expect(summarizeSourceHealth(sources)).toEqual({
+      healthy: 2,
+      degraded: 1,
+      stale: 0,
+      unavailable: 1,
+    });
+  });
+});
+
+describe("getSourceHealthRegistry", () => {
+  it("returns a registry covering all registered sources", async () => {
+    const registry = await getSourceHealthRegistry();
+    expect(registry.totalSources).toBe(registry.sources.length);
+    expect(registry.totalSources).toBeGreaterThan(0);
+    expect(typeof registry.generatedAt).toBe("string");
+
+    const summed =
+      registry.counts.healthy +
+      registry.counts.degraded +
+      registry.counts.stale +
+      registry.counts.unavailable;
+    expect(summed).toBe(registry.totalSources);
+
+    for (const source of registry.sources) {
+      expect(typeof source.providerId).toBe("string");
+      expect(["healthy", "degraded", "stale", "unavailable"]).toContain(
+        source.status,
+      );
+    }
+  });
+});

--- a/server/src/services/simulationService.ts
+++ b/server/src/services/simulationService.ts
@@ -113,9 +113,208 @@ export function simulateDeposit(params: SimulationParams): SimulationResult {
   result.postDepositExposure.expectedApy = blendedApyBps / 100;
 
   // Assuming 1 token = 1 share for simplicity, with some small slippage loss mock
-  const slippageLoss = amount > 100000 ? netAmount * 0.01 : netAmount * 0.001; 
+  const slippageLoss = amount > 100000 ? netAmount * 0.01 : netAmount * 0.001;
   result.expectedShares = netAmount - slippageLoss;
   result.routing.expectedOutput = result.expectedShares;
 
   return result;
+}
+
+// ── Rebalance Simulation Sandbox ────────────────────────────────────────
+//
+// Previews the effect of moving from a current allocation to a target
+// allocation before any capital is committed: projected blended APY,
+// estimated turnover fees, and per-leg allocation drift, plus warnings for
+// high fees, stale data, and liquidity risk. Simulation-only — it never
+// executes a rebalance.
+
+export interface RebalanceAllocationInput {
+  label: string; // protocol / vault name
+  currentWeight: number; // 0-100, current share of the portfolio
+  targetWeight: number; // 0-100, desired share of the portfolio
+  apy: number; // annualized %, used for blended APY
+  liquidityUsd?: number; // available liquidity for this leg
+}
+
+export interface RebalanceParams {
+  totalValueUsd: number;
+  allocations: RebalanceAllocationInput[];
+  feeBps?: number; // turnover fee in bps (default 20 = 0.2%)
+  dataAgeSeconds?: number; // age of the market data feeding the preview
+}
+
+export interface RebalanceLeg {
+  label: string;
+  currentWeight: number;
+  targetWeight: number;
+  driftPct: number; // targetWeight - currentWeight (signed)
+  currentValueUsd: number;
+  targetValueUsd: number;
+  deltaUsd: number; // targetValue - currentValue (signed)
+}
+
+export interface RebalancePreview {
+  isSimulationOnly: true;
+  legs: RebalanceLeg[];
+  blendedApyBefore: number;
+  blendedApyAfter: number;
+  apyDeltaPct: number;
+  totalTurnoverUsd: number; // capital that actually moves
+  estimatedFeeUsd: number;
+  maxDriftPct: number; // largest absolute drift across legs
+  warnings: string[];
+}
+
+export const REBALANCE_THRESHOLDS = {
+  defaultFeeBps: 20, // 0.2%
+  /** Warn when estimated fees exceed this fraction of portfolio value. */
+  highFeeRatio: 0.005, // 0.5%
+  /** Data older than this (seconds) is considered stale. */
+  staleDataSeconds: 30 * 60,
+  /** Warn when a buy leg consumes more than this fraction of its liquidity. */
+  liquidityUtilizationLimit: 0.5,
+  /** Weights are valid when their sum is within this tolerance of 100. */
+  weightSumTolerance: 0.5,
+} as const;
+
+const round2 = (value: number): number => Math.round(value * 100) / 100;
+
+/**
+ * Validate rebalance inputs. Returns a list of human-readable errors; an
+ * empty array means the params are valid.
+ */
+export function validateRebalanceParams(params: RebalanceParams): string[] {
+  const errors: string[] = [];
+  const t = REBALANCE_THRESHOLDS;
+
+  if (!Number.isFinite(params.totalValueUsd) || params.totalValueUsd <= 0) {
+    errors.push("totalValueUsd must be a positive number.");
+  }
+
+  if (!Array.isArray(params.allocations) || params.allocations.length === 0) {
+    errors.push("allocations must be a non-empty array.");
+    return errors;
+  }
+
+  if (
+    params.feeBps !== undefined &&
+    (!Number.isFinite(params.feeBps) || params.feeBps < 0)
+  ) {
+    errors.push("feeBps must be a non-negative number.");
+  }
+
+  let currentSum = 0;
+  let targetSum = 0;
+  for (const alloc of params.allocations) {
+    if (!alloc.label) {
+      errors.push("Each allocation needs a label.");
+    }
+    for (const [field, value] of [
+      ["currentWeight", alloc.currentWeight],
+      ["targetWeight", alloc.targetWeight],
+    ] as const) {
+      if (!Number.isFinite(value) || value < 0 || value > 100) {
+        errors.push(
+          `${field} for ${alloc.label || "allocation"} must be between 0 and 100.`,
+        );
+      }
+    }
+    currentSum += alloc.currentWeight;
+    targetSum += alloc.targetWeight;
+  }
+
+  if (Math.abs(currentSum - 100) > t.weightSumTolerance) {
+    errors.push(`Current weights must sum to 100% (got ${round2(currentSum)}%).`);
+  }
+  if (Math.abs(targetSum - 100) > t.weightSumTolerance) {
+    errors.push(`Target weights must sum to 100% (got ${round2(targetSum)}%).`);
+  }
+
+  return errors;
+}
+
+/**
+ * Preview the effect of rebalancing from current to target allocations.
+ * @throws Error when params fail validation.
+ */
+export function simulateRebalance(params: RebalanceParams): RebalancePreview {
+  const errors = validateRebalanceParams(params);
+  if (errors.length > 0) {
+    throw new Error(`Invalid rebalance parameters: ${errors.join(" ")}`);
+  }
+
+  const t = REBALANCE_THRESHOLDS;
+  const { totalValueUsd, allocations } = params;
+  const feeBps = params.feeBps ?? t.defaultFeeBps;
+
+  let blendedApyBefore = 0;
+  let blendedApyAfter = 0;
+  let maxDriftPct = 0;
+  let grossMovement = 0;
+  const warnings: string[] = [];
+
+  const legs: RebalanceLeg[] = allocations.map((alloc) => {
+    const currentValueUsd = (totalValueUsd * alloc.currentWeight) / 100;
+    const targetValueUsd = (totalValueUsd * alloc.targetWeight) / 100;
+    const deltaUsd = targetValueUsd - currentValueUsd;
+    const driftPct = alloc.targetWeight - alloc.currentWeight;
+
+    blendedApyBefore += (alloc.apy * alloc.currentWeight) / 100;
+    blendedApyAfter += (alloc.apy * alloc.targetWeight) / 100;
+    maxDriftPct = Math.max(maxDriftPct, Math.abs(driftPct));
+    grossMovement += Math.abs(deltaUsd);
+
+    // Liquidity risk: a buy leg that consumes too much of its available pool.
+    if (
+      deltaUsd > 0 &&
+      alloc.liquidityUsd !== undefined &&
+      alloc.liquidityUsd >= 0 &&
+      deltaUsd > alloc.liquidityUsd * t.liquidityUtilizationLimit
+    ) {
+      warnings.push(
+        `Liquidity risk: rebalancing into ${alloc.label} moves $${round2(deltaUsd)} against $${round2(alloc.liquidityUsd)} of liquidity.`,
+      );
+    }
+
+    return {
+      label: alloc.label,
+      currentWeight: round2(alloc.currentWeight),
+      targetWeight: round2(alloc.targetWeight),
+      driftPct: round2(driftPct),
+      currentValueUsd: round2(currentValueUsd),
+      targetValueUsd: round2(targetValueUsd),
+      deltaUsd: round2(deltaUsd),
+    };
+  });
+
+  // Capital that actually moves is half the gross movement (buys == sells).
+  const totalTurnoverUsd = grossMovement / 2;
+  const estimatedFeeUsd = (totalTurnoverUsd * feeBps) / 10000;
+
+  if (estimatedFeeUsd > totalValueUsd * t.highFeeRatio) {
+    warnings.push(
+      `High fees: estimated rebalance cost $${round2(estimatedFeeUsd)} exceeds ${t.highFeeRatio * 100}% of portfolio value.`,
+    );
+  }
+
+  if (
+    params.dataAgeSeconds !== undefined &&
+    params.dataAgeSeconds > t.staleDataSeconds
+  ) {
+    warnings.push(
+      `Stale data: preview uses market data ${Math.round(params.dataAgeSeconds / 60)}m old; refresh before committing.`,
+    );
+  }
+
+  return {
+    isSimulationOnly: true,
+    legs,
+    blendedApyBefore: round2(blendedApyBefore),
+    blendedApyAfter: round2(blendedApyAfter),
+    apyDeltaPct: round2(blendedApyAfter - blendedApyBefore),
+    totalTurnoverUsd: round2(totalTurnoverUsd),
+    estimatedFeeUsd: round2(estimatedFeeUsd),
+    maxDriftPct: round2(maxDriftPct),
+    warnings,
+  };
 }

--- a/server/src/services/yieldSourceRegistryService.ts
+++ b/server/src/services/yieldSourceRegistryService.ts
@@ -1,0 +1,226 @@
+/**
+ * Yield Data Source Registry
+ *
+ * Turns the lower-level reliability signals produced by
+ * {@link yieldReliabilityEngine} into a contributor-friendly health registry:
+ * a flat list of every yield data source with its latest fetch time, uptime,
+ * latency, and (when unhealthy) a human-readable failure reason.
+ *
+ * The registry uses an operator-facing status vocabulary
+ * (`healthy | degraded | stale | unavailable`) that is intentionally simpler
+ * than the engine's internal reliability tiers.
+ */
+
+import {
+  yieldReliabilityEngine,
+  type DataSourceReliability,
+} from "./yieldReliabilityService";
+
+export type SourceHealthStatus =
+  | "healthy"
+  | "degraded"
+  | "stale"
+  | "unavailable";
+
+export interface SourceHealthSummary {
+  providerId: string;
+  providerName: string;
+  dataSource: string;
+  status: SourceHealthStatus;
+  reliabilityScore: number; // 0-100
+  uptimePct: number; // 0-100
+  freshnessPct: number; // 0-100
+  errorRatePct: number; // 0-100
+  latencyMs: number;
+  latestFetch: string; // ISO timestamp of the last successful fetch
+  ageSeconds: number; // seconds elapsed since latestFetch
+  consecutiveFailures: number;
+  failureReason: string | null;
+  trend: DataSourceReliability["trend"];
+}
+
+export interface SourceHealthRegistry {
+  generatedAt: string;
+  totalSources: number;
+  counts: Record<SourceHealthStatus, number>;
+  sources: SourceHealthSummary[];
+}
+
+// ── Classification thresholds ─────────────────────────────────────────────
+// Exported so tests (and operators) can reason about the exact boundaries.
+
+export const SOURCE_HEALTH_THRESHOLDS = {
+  /** Data older than this (seconds) is considered stale. Matches the engine's 30m window. */
+  staleAgeSeconds: 30 * 60,
+  /** Below this freshness ratio (0-1) a source is treated as stale. */
+  minFreshness: 0.5,
+  /** A degraded source tolerates error rates up to this ratio (0-1). */
+  degradedMaxErrorRate: 0.05,
+  /** Above this latency (ms) a healthy source is downgraded to degraded. */
+  degradedMaxLatencyMs: 800,
+  /** Reliability score (0-100) at or above which a source can be healthy. */
+  healthyMinScore: 70,
+  /** Consecutive failures at or above which a source is unavailable. */
+  unavailableConsecutiveFailures: 3,
+  /** Error rate (0-1) at or above which a source is unavailable. */
+  unavailableErrorRate: 0.5,
+} as const;
+
+/** Normalized inputs to the pure status classifier. */
+export interface SourceHealthInput {
+  reliabilityStatus: DataSourceReliability["status"];
+  reliabilityScore: number;
+  consecutiveFailures: number;
+  errorRate: number; // 0-1
+  latencyMs: number;
+  freshness: number; // 0-1
+  ageSeconds: number;
+}
+
+/**
+ * Pure classifier: map normalized signals to an operator status and reason.
+ * Kept separate from the engine so it is trivial to unit-test.
+ */
+export function classifySourceHealth(input: SourceHealthInput): {
+  status: SourceHealthStatus;
+  failureReason: string | null;
+} {
+  const t = SOURCE_HEALTH_THRESHOLDS;
+
+  // Unavailable — the source cannot be trusted at all.
+  if (
+    input.reliabilityStatus === "unreliable" ||
+    input.reliabilityScore <= 0 ||
+    input.consecutiveFailures >= t.unavailableConsecutiveFailures ||
+    input.errorRate >= t.unavailableErrorRate
+  ) {
+    let reason = "Provider marked unreliable";
+    if (input.consecutiveFailures >= t.unavailableConsecutiveFailures) {
+      reason = `${input.consecutiveFailures} consecutive fetch failures`;
+    } else if (input.errorRate >= t.unavailableErrorRate) {
+      reason = `Error rate ${Math.round(input.errorRate * 100)}% exceeds safe threshold`;
+    }
+    return { status: "unavailable", failureReason: reason };
+  }
+
+  // Stale — connectivity is fine but the data is too old.
+  if (input.ageSeconds > t.staleAgeSeconds || input.freshness < t.minFreshness) {
+    const minutes = Math.round(input.ageSeconds / 60);
+    return {
+      status: "stale",
+      failureReason: `No fresh data for ${minutes}m`,
+    };
+  }
+
+  // Degraded — usable but worth watching.
+  if (
+    input.reliabilityStatus === "low" ||
+    input.errorRate > t.degradedMaxErrorRate ||
+    input.latencyMs > t.degradedMaxLatencyMs ||
+    input.reliabilityScore < t.healthyMinScore
+  ) {
+    let reason = `Reliability score ${input.reliabilityScore} below target`;
+    if (input.latencyMs > t.degradedMaxLatencyMs) {
+      reason = `Elevated latency ${Math.round(input.latencyMs)}ms`;
+    } else if (input.errorRate > t.degradedMaxErrorRate) {
+      reason = `Elevated error rate ${Math.round(input.errorRate * 100)}%`;
+    }
+    return { status: "degraded", failureReason: reason };
+  }
+
+  return { status: "healthy", failureReason: null };
+}
+
+const round = (value: number, places = 2): number => {
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+};
+
+/**
+ * Map a single reliability record to a registry health summary.
+ */
+export function toSourceHealth(
+  reliability: DataSourceReliability,
+  now: number = Date.now(),
+): SourceHealthSummary {
+  const { metrics, signals } = reliability;
+  const lastFetchMs = new Date(signals.lastSuccessfulFetch).getTime();
+  const ageSeconds = Number.isFinite(lastFetchMs)
+    ? Math.max(0, Math.round((now - lastFetchMs) / 1000))
+    : Number.POSITIVE_INFINITY;
+
+  const { status, failureReason } = classifySourceHealth({
+    reliabilityStatus: reliability.status,
+    reliabilityScore: reliability.reliabilityScore,
+    consecutiveFailures: signals.consecutiveFailures,
+    errorRate: metrics.errorRate,
+    latencyMs: metrics.latency,
+    freshness: metrics.freshness,
+    ageSeconds,
+  });
+
+  return {
+    providerId: reliability.providerId,
+    providerName: reliability.providerName,
+    dataSource: reliability.dataSource,
+    status,
+    reliabilityScore: Math.round(reliability.reliabilityScore),
+    uptimePct: round(metrics.historicalUptime * 100),
+    freshnessPct: round(metrics.freshness * 100),
+    errorRatePct: round(metrics.errorRate * 100),
+    latencyMs: Math.round(metrics.latency),
+    latestFetch: signals.lastSuccessfulFetch,
+    ageSeconds: Number.isFinite(ageSeconds) ? ageSeconds : -1,
+    consecutiveFailures: signals.consecutiveFailures,
+    failureReason,
+    trend: reliability.trend,
+  };
+}
+
+/**
+ * Build a status-count summary keyed by every possible status.
+ */
+export function summarizeSourceHealth(
+  sources: SourceHealthSummary[],
+): Record<SourceHealthStatus, number> {
+  const counts: Record<SourceHealthStatus, number> = {
+    healthy: 0,
+    degraded: 0,
+    stale: 0,
+    unavailable: 0,
+  };
+  for (const source of sources) {
+    counts[source.status] += 1;
+  }
+  return counts;
+}
+
+/** Registered yield data sources tracked by the health dashboard. */
+const REGISTERED_SOURCES: Array<{ id: string; name: string; source: string }> =
+  [
+    { id: "blend_api", name: "Blend Protocol", source: "api" },
+    { id: "soroswap_api", name: "Soroswap", source: "api" },
+    { id: "defindex_api", name: "DeFindex", source: "api" },
+    { id: "stellar_expert", name: "Stellar Expert", source: "oracle" },
+    { id: "coingecko", name: "CoinGecko", source: "oracle" },
+  ];
+
+/**
+ * Read-only health registry for every registered yield data source.
+ */
+export async function getSourceHealthRegistry(): Promise<SourceHealthRegistry> {
+  const reliabilityScores =
+    await yieldReliabilityEngine.getReliabilityScores(REGISTERED_SOURCES);
+
+  const now = Date.now();
+  const sources = reliabilityScores
+    .map((reliability) => toSourceHealth(reliability, now))
+    .sort((a, b) => a.reliabilityScore - b.reliabilityScore);
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    totalSources: sources.length,
+    counts: summarizeSourceHealth(sources),
+    sources,
+  };
+}


### PR DESCRIPTION
## Summary

Implements four contributor-ready Wave features. Each turns an existing foundation into an operator-facing, read-only surface — none of them execute privileged actions.

### Yield Data Source Registry & Health Dashboard — Closes #411
- `GET /api/analytics/sources/health`: read-only registry of every yield data source with status (`healthy`/`degraded`/`stale`/`unavailable`), latest fetch time, uptime, latency, and a human-readable failure reason.
- Pure `classifySourceHealth` classifier over the existing `yieldReliabilityEngine` signals.
- `SourceHealthPanel` analytics panel + `sourceHealthStatus` UI status mapping.

### Rebalance Simulation Sandbox for Portfolio Builder — Closes #412
- `simulateRebalance` service + `POST /api/simulator/rebalance` API contract: projected blended APY before/after, estimated turnover fees, per-leg drift, and warnings for high fees, stale data, and liquidity risk. Flagged `isSimulationOnly` — never commits capital.
- `RebalancePreview` panel wired into `PortfolioBuilder` showing before/after allocation and blended APY.

### Contract Event Indexer Replay Checkpoint UI — Closes #414
- `GET /api/indexer/status`: latest indexed ledger (replay checkpoint), latest network ledger, lag from Horizon, and recent replay errors. Pure `classifyIndexerStatus` marks the indexer **degraded** past a lag threshold / stale heartbeat and **unavailable** when far behind. Degrades gracefully when Prisma/Horizon are unavailable.
- Indexer now records replay errors into an in-memory ring buffer surfaced by the route.
- `IndexerCheckpointPanel` transparency panel + `indexerStatus` UI mapping.

### Emergency Mode Operator Runbook Panel — Closes #415
- `EmergencyRunbookPanel`: checklist guiding operators through pause → verify → notify → resume. Shows current pause/health status, links each step to `docs/EMERGENCY_RUNBOOK.md` or a read-only status check, and renders every privileged-action button **disabled** (read-only by design — no automatic execution).
- Pure `deriveRunbookProgress` derives per-step state from pause/health status.

## Test plan
- [x] Server unit tests (pure logic): `cd server && npx jest simulationService indexerStatus yieldSourceRegistry` — **21 passing** (rebalance preview calc + validation errors, indexer status classifier incl. degraded/unavailable, source-health classifier).
- [x] Client tests: `cd client && npx vitest run` for the new suites — **31 passing** (source-health mapping, rebalance preview helpers, indexer status mapping, runbook progress + panel rendering + disabled action states).
- [x] Type-checks clean for all added/changed files (server `tsc --noEmit`, client `tsc --noEmit`).

## Out of scope / notes
- New panel components follow the repo's existing convention of standalone, independently-mountable panels (matching `SourceHealthPanel`, `RegistryDiff`, `RiskChronology`, and the other analytics panels).
- Pre-existing TypeScript errors on `main` in unrelated files (`strategyRotationService.ts` and several existing `__tests__`) prevent the `supertest` route suites (`sourceHealth.test.ts`, `indexerStatus.test.ts`) from compiling under `ts-jest`, since they transitively import the app. These errors are not introduced by this PR; the route logic is exercised via the pure classifier tests instead.
- No dependency changes (lock files untouched).

Closes #411
Closes #412
Closes #414
Closes #415