### PR TITLE
feat: rebalance backtest engine, fee deviation alerts, provider uptime, deposit impact warnings

### DIFF
--- a/client/src/features/alerts/FeeDeviationAlertBanner.tsx
+++ b/client/src/features/alerts/FeeDeviationAlertBanner.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Bell, CheckCircle, RefreshCw } from "lucide-react";
+import { apiUrl } from "../../lib/api";
+
+type FeeAlertLevel = "normal" | "warning" | "critical";
+
+interface FeeDeviationAlert {
+  level: FeeAlertLevel;
+  currentFee: number;
+  baselineFee: number;
+  deviationPct: number;
+  warningThresholdPct: number;
+  criticalThresholdPct: number;
+  message: string;
+  generatedAt: string;
+}
+
+interface FeeAlertResponse {
+  estimate: {
+    fees: { low: number; average: number; high: number };
+    utilization: { congestionRatio: number };
+    sampleSize: number;
+    generatedAt: string;
+  };
+  alert: FeeDeviationAlert;
+}
+
+const LEVEL_STYLES: Record<
+  FeeAlertLevel,
+  { bg: string; border: string; text: string; icon: React.ReactNode }
+> = {
+  normal: {
+    bg: "bg-green-500/10",
+    border: "border-green-500/30",
+    text: "text-green-400",
+    icon: <CheckCircle className="w-4 h-4 text-green-500 shrink-0" />,
+  },
+  warning: {
+    bg: "bg-amber-500/10",
+    border: "border-amber-500/30",
+    text: "text-amber-300",
+    icon: <AlertTriangle className="w-4 h-4 text-amber-500 shrink-0" />,
+  },
+  critical: {
+    bg: "bg-red-500/10",
+    border: "border-red-500/30",
+    text: "text-red-300",
+    icon: <AlertTriangle className="w-4 h-4 text-red-500 shrink-0" />,
+  },
+};
+
+export default function FeeDeviationAlertBanner() {
+  const [data, setData] = useState<FeeAlertResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAlert = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await fetch(apiUrl("/api/fees/alert"));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as FeeAlertResponse);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load fee alert");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchAlert();
+    const interval = setInterval(() => void fetchAlert(), 60_000);
+    return () => clearInterval(interval);
+  }, [fetchAlert]);
+
+  if (loading && !data) return null;
+  if (error || !data) return null;
+
+  const { alert, estimate } = data;
+  const styles = LEVEL_STYLES[alert.level];
+
+  return (
+    <div
+      className={`flex items-start gap-3 p-3 rounded-lg border ${styles.bg} ${styles.border}`}
+    >
+      {styles.icon}
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1.5">
+            <Bell className="w-3.5 h-3.5 text-gray-400" />
+            <span className="text-xs font-medium text-gray-300">Fee Oracle</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => void fetchAlert()}
+            disabled={loading}
+            className="text-gray-500 hover:text-gray-300"
+          >
+            <RefreshCw className={`w-3 h-3 ${loading ? "animate-spin" : ""}`} />
+          </button>
+        </div>
+        <p className={`text-sm mt-0.5 ${styles.text}`}>{alert.message}</p>
+        <div className="flex gap-4 mt-1 text-xs text-gray-500">
+          <span>
+            Current:{" "}
+            <span className="text-gray-300">{alert.currentFee.toLocaleString()} stroops</span>
+          </span>
+          <span>
+            Baseline:{" "}
+            <span className="text-gray-300">{alert.baselineFee.toLocaleString()} stroops</span>
+          </span>
+          <span>
+            Network fee (avg):{" "}
+            <span className="text-gray-300">{estimate.fees.average.toLocaleString()} stroops</span>
+          </span>
+          {estimate.utilization.congestionRatio > 0 && (
+            <span>
+              Congestion:{" "}
+              <span className="text-gray-300">
+                {(estimate.utilization.congestionRatio * 100).toFixed(0)}%
+              </span>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/analytics/ProviderUptimeReport.tsx
+++ b/client/src/features/analytics/ProviderUptimeReport.tsx
@@ -1,0 +1,200 @@
+import { useCallback, useEffect, useState } from "react";
+import { Activity, AlertTriangle, RefreshCw } from "lucide-react";
+import { apiUrl } from "../../lib/api";
+
+interface OutageWindow {
+  startedAt: string;
+  endedAt: string | null;
+  durationMinutes: number;
+}
+
+interface ProviderUptimeReport {
+  providerId: string;
+  providerName: string;
+  uptimePct: number;
+  downtimePct: number;
+  unknownPct: number;
+  sampleCount: number;
+  outageWindowCount: number;
+  totalOutageMinutes: number;
+  recentOutages: OutageWindow[];
+  generatedAt: string;
+}
+
+interface UptimeResponse {
+  success: boolean;
+  data: ProviderUptimeReport[];
+  generatedAt: string;
+}
+
+function UptimeBar({ pct }: { pct: number }) {
+  const color = pct >= 99 ? "bg-green-500" : pct >= 95 ? "bg-amber-400" : "bg-red-500";
+  return (
+    <div className="flex items-center gap-2 w-full">
+      <div className="flex-1 h-1.5 bg-white/10 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${pct}%` }} />
+      </div>
+      <span
+        className={`text-xs font-mono w-12 text-right ${
+          pct >= 99 ? "text-green-400" : pct >= 95 ? "text-amber-400" : "text-red-400"
+        }`}
+      >
+        {pct.toFixed(1)}%
+      </span>
+    </div>
+  );
+}
+
+function OutageList({ outages }: { outages: OutageWindow[] }) {
+  if (outages.length === 0) {
+    return <span className="text-xs text-gray-500">No recent outages</span>;
+  }
+  return (
+    <ul className="space-y-1">
+      {outages.map((o, i) => (
+        <li key={i} className="text-xs text-gray-400">
+          {new Date(o.startedAt).toLocaleDateString()} —{" "}
+          {o.endedAt ? new Date(o.endedAt).toLocaleDateString() : "ongoing"},{" "}
+          {o.durationMinutes}m
+          {o.endedAt === null && (
+            <span className="ml-1 text-red-400 font-medium">(ongoing)</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ProviderUptimeReport() {
+  const [reports, setReports] = useState<ProviderUptimeReport[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [generatedAt, setGeneratedAt] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  const fetchReports = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const res = await fetch(apiUrl("/api/analytics/providers/uptime"));
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as UptimeResponse;
+      setReports(body.data);
+      setGeneratedAt(body.generatedAt);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load uptime report");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchReports();
+  }, [fetchReports]);
+
+  const hasOutages = reports.some((r) => r.outageWindowCount > 0);
+
+  return (
+    <div className="glass-panel p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity size={20} className="text-indigo-400" />
+          <h2 className="text-xl font-semibold">Provider Uptime Report</h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => void fetchReports()}
+          disabled={isLoading}
+          aria-label="Refresh uptime report"
+          className="flex items-center gap-2 text-sm text-gray-300 hover:text-white disabled:opacity-50"
+        >
+          <RefreshCw size={16} className={isLoading ? "animate-spin" : ""} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-500" />
+          <span className="text-sm text-red-400">{error}</span>
+        </div>
+      )}
+
+      {!error && isLoading && reports.length === 0 && (
+        <p className="text-sm text-gray-400">Loading uptime data…</p>
+      )}
+
+      {hasOutages && (
+        <div className="flex items-center gap-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-lg">
+          <AlertTriangle className="w-4 h-4 text-yellow-500" />
+          <span className="text-sm text-yellow-400">
+            One or more providers have recent outage windows.
+          </span>
+        </div>
+      )}
+
+      {reports.length > 0 && (
+        <div className="space-y-2">
+          {reports.map((r) => (
+            <div
+              key={r.providerId}
+              className="bg-white/5 rounded-xl p-4 space-y-2"
+            >
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="font-medium text-white">{r.providerName}</p>
+                  <p className="text-xs text-gray-500">{r.providerId}</p>
+                </div>
+                <div className="flex-1 max-w-xs">
+                  <UptimeBar pct={r.uptimePct} />
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setExpanded(expanded === r.providerId ? null : r.providerId)}
+                  className="text-xs text-indigo-400 hover:text-indigo-300 whitespace-nowrap"
+                >
+                  {expanded === r.providerId ? "Hide" : "Details"}
+                </button>
+              </div>
+
+              {expanded === r.providerId && (
+                <div className="pt-2 border-t border-white/10 space-y-3">
+                  <div className="grid grid-cols-3 gap-3 text-xs">
+                    <div>
+                      <p className="text-gray-500">Downtime</p>
+                      <p className="text-white font-mono">{r.downtimePct.toFixed(1)}%</p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Samples</p>
+                      <p className="text-white font-mono">{r.sampleCount}</p>
+                    </div>
+                    <div>
+                      <p className="text-gray-500">Total outage</p>
+                      <p className="text-white font-mono">{r.totalOutageMinutes}m</p>
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 mb-1">
+                      Recent outages ({r.outageWindowCount} total, showing last 5)
+                    </p>
+                    <OutageList outages={r.recentOutages} />
+                  </div>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {reports.length === 0 && !isLoading && !error && (
+        <p className="text-sm text-gray-500">No provider uptime data available yet.</p>
+      )}
+
+      {generatedAt && (
+        <p className="text-xs text-gray-500">
+          Generated {new Date(generatedAt).toLocaleString()} · read-only
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/simulator/RebalanceBacktestPanel.tsx
+++ b/client/src/features/simulator/RebalanceBacktestPanel.tsx
@@ -1,0 +1,410 @@
+import { useState, useCallback } from "react";
+import { BarChart2, Plus, Trash2, Loader2, AlertCircle, TrendingUp, TrendingDown } from "lucide-react";
+import {
+  fetchRebalanceBacktest,
+  type RebalanceAllocationRule,
+  type RebalanceBacktestParams,
+  type RebalanceBacktestResult,
+} from "./rebalanceBacktestService";
+
+interface AllocationRow extends RebalanceAllocationRule {
+  id: number;
+}
+
+let nextId = 1;
+
+function mkRow(label = "", targetWeight = 0, apy = 0): AllocationRow {
+  return { id: nextId++, label, targetWeight, apy };
+}
+
+const DEFAULT_ROWS: AllocationRow[] = [
+  mkRow("Pool A", 50, 8),
+  mkRow("Pool B", 50, 12),
+];
+
+function weightTotal(rows: AllocationRow[]) {
+  return rows.reduce((s, r) => s + r.targetWeight, 0);
+}
+
+function returnColor(pct: number) {
+  return pct >= 0 ? "text-green-400" : "text-red-400";
+}
+
+function fmt2(n: number) {
+  return n.toFixed(2);
+}
+
+export default function RebalanceBacktestPanel() {
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [initialValue, setInitialValue] = useState("100000");
+  const [strategy, setStrategy] = useState<"schedule" | "threshold">("schedule");
+  const [intervalDays, setIntervalDays] = useState("30");
+  const [driftThreshold, setDriftThreshold] = useState("5");
+  const [feeBps, setFeeBps] = useState("20");
+  const [rows, setRows] = useState<AllocationRow[]>(DEFAULT_ROWS);
+  const [result, setResult] = useState<RebalanceBacktestResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const updateRow = useCallback(
+    (id: number, field: keyof RebalanceAllocationRule, value: string | number) => {
+      setRows((prev) =>
+        prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)),
+      );
+    },
+    [],
+  );
+
+  const addRow = useCallback(() => {
+    setRows((prev) => [...prev, mkRow()]);
+  }, []);
+
+  const removeRow = useCallback((id: number) => {
+    setRows((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  const handleRun = useCallback(async () => {
+    setError("");
+    if (!startDate || !endDate) {
+      setError("Start and end dates are required");
+      return;
+    }
+    if (new Date(startDate) >= new Date(endDate)) {
+      setError("Start date must be before end date");
+      return;
+    }
+    if (rows.length === 0) {
+      setError("Add at least one allocation");
+      return;
+    }
+    const total = weightTotal(rows);
+    if (Math.abs(total - 100) > 0.01) {
+      setError(`Allocation weights must sum to 100% (currently ${fmt2(total)}%)`);
+      return;
+    }
+    if (rows.some((r) => !r.label.trim())) {
+      setError("All allocation rows need a label");
+      return;
+    }
+
+    const params: RebalanceBacktestParams = {
+      initialValueUsd: parseFloat(initialValue) || 100_000,
+      startDate,
+      endDate,
+      allocations: rows.map(({ label, targetWeight, apy }) => ({ label, targetWeight, apy })),
+      strategy,
+      ...(strategy === "schedule"
+        ? { rebalanceIntervalDays: parseInt(intervalDays, 10) || 30 }
+        : { driftThresholdPct: parseFloat(driftThreshold) || 5 }),
+      feeBps: parseInt(feeBps, 10) || 20,
+    };
+
+    setLoading(true);
+    try {
+      setResult(await fetchRebalanceBacktest(params));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Backtest failed");
+    } finally {
+      setLoading(false);
+    }
+  }, [startDate, endDate, initialValue, strategy, intervalDays, driftThreshold, feeBps, rows]);
+
+  const total = weightTotal(rows);
+  const weightOk = Math.abs(total - 100) <= 0.01;
+
+  return (
+    <div className="space-y-6">
+      <div className="glass-panel p-6 space-y-5">
+        <div className="flex items-center gap-2">
+          <BarChart2 size={20} className="text-indigo-400" />
+          <h2 className="text-xl font-semibold">Rebalance Strategy Backtest</h2>
+        </div>
+
+        {/* Date range + initial value */}
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1.5">Start Date</label>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1.5">End Date</label>
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1.5">Initial Value (USD)</label>
+            <input
+              type="number"
+              value={initialValue}
+              onChange={(e) => setInitialValue(e.target.value)}
+              min={1}
+              className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            />
+          </div>
+        </div>
+
+        {/* Strategy */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm text-gray-400 mb-1.5">Strategy</label>
+            <select
+              value={strategy}
+              onChange={(e) => setStrategy(e.target.value as "schedule" | "threshold")}
+              className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            >
+              <option value="schedule">Scheduled (fixed interval)</option>
+              <option value="threshold">Threshold (drift-based)</option>
+            </select>
+          </div>
+          <div>
+            {strategy === "schedule" ? (
+              <>
+                <label className="block text-sm text-gray-400 mb-1.5">Rebalance Interval (days)</label>
+                <input
+                  type="number"
+                  value={intervalDays}
+                  onChange={(e) => setIntervalDays(e.target.value)}
+                  min={1}
+                  className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+                />
+              </>
+            ) : (
+              <>
+                <label className="block text-sm text-gray-400 mb-1.5">Drift Threshold (%)</label>
+                <input
+                  type="number"
+                  value={driftThreshold}
+                  onChange={(e) => setDriftThreshold(e.target.value)}
+                  min={0.1}
+                  step={0.1}
+                  className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+                />
+              </>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm text-gray-400 mb-1.5">Fee (bps)</label>
+            <input
+              type="number"
+              value={feeBps}
+              onChange={(e) => setFeeBps(e.target.value)}
+              min={0}
+              className="w-full bg-black/50 border border-gray-600 rounded-lg px-3 py-2 text-white"
+            />
+          </div>
+        </div>
+
+        {/* Allocations */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-sm text-gray-400">
+              Allocations{" "}
+              <span className={`font-mono text-xs ${weightOk ? "text-green-400" : "text-amber-400"}`}>
+                ({fmt2(total)}% total)
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={addRow}
+              className="flex items-center gap-1 text-xs text-indigo-400 hover:text-indigo-300"
+            >
+              <Plus size={12} />
+              Add pool
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <div className="grid grid-cols-12 gap-2 text-xs text-gray-500 px-1">
+              <span className="col-span-5">Label</span>
+              <span className="col-span-3 text-right">Weight %</span>
+              <span className="col-span-3 text-right">APY %</span>
+              <span className="col-span-1" />
+            </div>
+            {rows.map((row) => (
+              <div key={row.id} className="grid grid-cols-12 gap-2 items-center">
+                <input
+                  className="col-span-5 bg-black/50 border border-gray-700 rounded px-2 py-1.5 text-sm text-white"
+                  placeholder="Pool label"
+                  value={row.label}
+                  onChange={(e) => updateRow(row.id, "label", e.target.value)}
+                />
+                <input
+                  type="number"
+                  className="col-span-3 bg-black/50 border border-gray-700 rounded px-2 py-1.5 text-sm text-white text-right"
+                  placeholder="50"
+                  value={row.targetWeight || ""}
+                  min={0}
+                  max={100}
+                  step={0.1}
+                  onChange={(e) => updateRow(row.id, "targetWeight", parseFloat(e.target.value) || 0)}
+                />
+                <input
+                  type="number"
+                  className="col-span-3 bg-black/50 border border-gray-700 rounded px-2 py-1.5 text-sm text-white text-right"
+                  placeholder="8"
+                  value={row.apy || ""}
+                  min={0}
+                  step={0.01}
+                  onChange={(e) => updateRow(row.id, "apy", parseFloat(e.target.value) || 0)}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeRow(row.id)}
+                  disabled={rows.length === 1}
+                  className="col-span-1 flex justify-center text-gray-600 hover:text-red-400 disabled:opacity-30"
+                >
+                  <Trash2 size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {error && (
+          <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+            <AlertCircle className="w-4 h-4 text-red-500 shrink-0" />
+            <span className="text-sm text-red-400">{error}</span>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={() => void handleRun()}
+          disabled={loading}
+          className="w-full bg-gradient-to-r from-indigo-600 to-purple-600 hover:from-indigo-700 hover:to-purple-700 disabled:opacity-50 text-white font-semibold py-3 rounded-lg flex items-center justify-center gap-2"
+        >
+          {loading ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Running…
+            </>
+          ) : (
+            <>
+              <BarChart2 className="w-4 h-4" />
+              Run Backtest
+            </>
+          )}
+        </button>
+      </div>
+
+      {result && (
+        <div className="space-y-4">
+          {/* Summary cards */}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div className="glass-panel p-4">
+              <p className="text-xs text-gray-500">Portfolio return</p>
+              <p className={`text-2xl font-bold ${returnColor(result.portfolioReturnPct)}`}>
+                {result.portfolioReturnPct >= 0 ? "+" : ""}
+                {fmt2(result.portfolioReturnPct)}%
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                ${result.finalPortfolioValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+              </p>
+            </div>
+            <div className="glass-panel p-4">
+              <p className="text-xs text-gray-500">Passive (no rebalance)</p>
+              <p className={`text-2xl font-bold ${returnColor(result.passiveReturnPct)}`}>
+                {result.passiveReturnPct >= 0 ? "+" : ""}
+                {fmt2(result.passiveReturnPct)}%
+              </p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                ${result.finalPassiveValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+              </p>
+            </div>
+            <div className="glass-panel p-4">
+              <p className="text-xs text-gray-500">Outperformance</p>
+              <div className="flex items-center gap-1">
+                {result.outperformancePct >= 0 ? (
+                  <TrendingUp size={18} className="text-green-400" />
+                ) : (
+                  <TrendingDown size={18} className="text-red-400" />
+                )}
+                <p className={`text-2xl font-bold ${returnColor(result.outperformancePct)}`}>
+                  {result.outperformancePct >= 0 ? "+" : ""}
+                  {fmt2(result.outperformancePct)}%
+                </p>
+              </div>
+            </div>
+            <div className="glass-panel p-4">
+              <p className="text-xs text-gray-500">Rebalances / Fees</p>
+              <p className="text-2xl font-bold text-white">{result.rebalanceCount}</p>
+              <p className="text-xs text-gray-500 mt-0.5">
+                ${fmt2(result.totalFeesUsd)} total fees
+              </p>
+            </div>
+          </div>
+
+          {/* Simulation note */}
+          <div className="text-xs text-gray-500 text-right">
+            Simulation only · {result.startDate} → {result.endDate}
+          </div>
+
+          {/* Equity snapshots (last 20) */}
+          <div className="glass-panel p-6">
+            <h3 className="text-base font-semibold mb-3">Equity Curve (last 20 days)</h3>
+            <div className="space-y-1 max-h-64 overflow-y-auto">
+              <div className="grid grid-cols-4 gap-2 text-xs text-gray-500 pb-1 border-b border-white/10">
+                <span>Date</span>
+                <span className="text-right">Portfolio</span>
+                <span className="text-right">Passive</span>
+                <span className="text-right">Blended APY</span>
+              </div>
+              {result.snapshots.slice(-20).map((s) => (
+                <div
+                  key={s.date}
+                  className={`grid grid-cols-4 gap-2 text-xs py-0.5 rounded px-1 ${
+                    s.rebalanced ? "bg-indigo-500/10 text-indigo-200" : "text-gray-300"
+                  }`}
+                >
+                  <span className="font-mono">{s.date}{s.rebalanced ? " ↻" : ""}</span>
+                  <span className="text-right font-mono">
+                    ${s.portfolioValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  </span>
+                  <span className="text-right font-mono">
+                    ${s.passiveValue.toLocaleString(undefined, { maximumFractionDigits: 0 })}
+                  </span>
+                  <span className="text-right font-mono">{fmt2(s.blendedApyPct)}%</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Rebalance events */}
+          {result.rebalanceEvents.length > 0 && (
+            <div className="glass-panel p-6">
+              <h3 className="text-base font-semibold mb-3">
+                Rebalance Events ({result.rebalanceEvents.length})
+              </h3>
+              <div className="space-y-1 max-h-48 overflow-y-auto">
+                <div className="grid grid-cols-4 gap-2 text-xs text-gray-500 pb-1 border-b border-white/10">
+                  <span>Date</span>
+                  <span>Reason</span>
+                  <span className="text-right">Max drift</span>
+                  <span className="text-right">Fee</span>
+                </div>
+                {result.rebalanceEvents.map((ev, i) => (
+                  <div key={i} className="grid grid-cols-4 gap-2 text-xs text-gray-300 py-0.5">
+                    <span className="font-mono">{ev.date}</span>
+                    <span className="text-gray-400 truncate">{ev.reason}</span>
+                    <span className="text-right font-mono">{fmt2(ev.maxDriftPct)}%</span>
+                    <span className="text-right font-mono">${fmt2(ev.feeUsd)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/simulator/index.ts
+++ b/client/src/features/simulator/index.ts
@@ -1,3 +1,13 @@
 export { default as BacktestPanel } from "./BacktestPanel";
 export { fetchBacktestData, calculateCompoundInterest, calculateTotalReturn } from "./backtestService";
 export type { BacktestRequest, BacktestResult, DailySnapshot } from "./types";
+
+export { default as RebalanceBacktestPanel } from "./RebalanceBacktestPanel";
+export { fetchRebalanceBacktest } from "./rebalanceBacktestService";
+export type {
+  RebalanceAllocationRule,
+  RebalanceBacktestParams,
+  RebalanceBacktestSnapshot,
+  RebalanceEvent,
+  RebalanceBacktestResult,
+} from "./rebalanceBacktestService";

--- a/client/src/features/simulator/rebalanceBacktestService.ts
+++ b/client/src/features/simulator/rebalanceBacktestService.ts
@@ -1,0 +1,69 @@
+import { apiUrl } from "../../lib/api";
+
+export interface RebalanceAllocationRule {
+  label: string;
+  targetWeight: number;
+  apy: number;
+  liquidityUsd?: number;
+}
+
+export interface RebalanceBacktestParams {
+  initialValueUsd: number;
+  startDate: string;
+  endDate: string;
+  allocations: RebalanceAllocationRule[];
+  strategy: "schedule" | "threshold";
+  rebalanceIntervalDays?: number;
+  driftThresholdPct?: number;
+  feeBps?: number;
+}
+
+export interface RebalanceBacktestSnapshot {
+  date: string;
+  portfolioValue: number;
+  passiveValue: number;
+  rebalanced: boolean;
+  blendedApyPct: number;
+}
+
+export interface RebalanceEvent {
+  date: string;
+  reason: string;
+  maxDriftPct: number;
+  feeUsd: number;
+}
+
+export interface RebalanceBacktestResult {
+  isSimulationOnly: true;
+  startDate: string;
+  endDate: string;
+  initialValueUsd: number;
+  finalPortfolioValue: number;
+  finalPassiveValue: number;
+  portfolioReturnPct: number;
+  passiveReturnPct: number;
+  outperformancePct: number;
+  rebalanceCount: number;
+  totalFeesUsd: number;
+  snapshots: RebalanceBacktestSnapshot[];
+  rebalanceEvents: RebalanceEvent[];
+}
+
+export async function fetchRebalanceBacktest(
+  params: RebalanceBacktestParams,
+): Promise<RebalanceBacktestResult> {
+  const res = await fetch(apiUrl("/api/simulator/rebalance-backtest"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error ?? `Backtest failed: ${res.statusText}`,
+    );
+  }
+
+  return (await res.json()) as RebalanceBacktestResult;
+}

--- a/client/src/features/zap/DepositRouteMaterialImpactWarning.tsx
+++ b/client/src/features/zap/DepositRouteMaterialImpactWarning.tsx
@@ -1,0 +1,77 @@
+import { AlertTriangle, ShieldAlert } from "lucide-react";
+import { useDepositImpact } from "./useDepositImpact";
+import type { ImpactSeverity } from "./useDepositImpact";
+
+export interface DepositRouteMaterialImpactWarningProps {
+  amountUsd: number;
+  slippageTolerance: number;
+  isFallback: boolean;
+  isStale: boolean;
+  executionQualityScore?: number;
+  materialImpact?: boolean;
+}
+
+const SEVERITY_STYLES: Record<
+  Exclude<ImpactSeverity, "none">,
+  { bg: string; border: string; title: string; titleColor: string; bodyColor: string }
+> = {
+  warning: {
+    bg: "bg-amber-500/10",
+    border: "border-amber-500/30",
+    title: "Deposit route may affect execution quality",
+    titleColor: "text-amber-300",
+    bodyColor: "text-amber-200/70",
+  },
+  critical: {
+    bg: "bg-red-500/10",
+    border: "border-red-500/30",
+    title: "High execution risk for this deposit route",
+    titleColor: "text-red-300",
+    bodyColor: "text-red-200/70",
+  },
+};
+
+export default function DepositRouteMaterialImpactWarning({
+  amountUsd,
+  slippageTolerance,
+  isFallback,
+  isStale,
+  executionQualityScore,
+  materialImpact,
+}: DepositRouteMaterialImpactWarningProps) {
+  const impact = useDepositImpact({
+    amountUsd,
+    slippageTolerance,
+    isFallback,
+    isStale,
+    executionQualityScore,
+    materialImpact,
+  });
+
+  if (impact.severity === "none") return null;
+
+  const styles = SEVERITY_STYLES[impact.severity];
+  const Icon = impact.severity === "critical" ? ShieldAlert : AlertTriangle;
+
+  return (
+    <div
+      className={`flex items-start gap-2 p-3 rounded-lg border ${styles.bg} ${styles.border}`}
+      role="alert"
+    >
+      <Icon className={`w-4 h-4 shrink-0 mt-0.5 ${styles.titleColor}`} />
+      <div>
+        <p className={`text-sm font-medium ${styles.titleColor}`}>{styles.title}</p>
+        <ul className={`mt-1 space-y-0.5 text-xs ${styles.bodyColor}`}>
+          {impact.reasons.map((reason) => (
+            <li key={reason}>· {reason}</li>
+          ))}
+        </ul>
+        {impact.severity === "critical" && (
+          <p className="mt-1.5 text-xs text-red-300/80 font-medium">
+            Review the route carefully. Deposit is not blocked but proceed with caution.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -19,6 +19,7 @@ import {
 import type { ZapAssetOption, ZapQuoteResponse } from "./types";
 import { useSettings } from "../settings/SettingsContext";
 import { resolveSlippage } from "../settings/types";
+import DepositRouteMaterialImpactWarning from "./DepositRouteMaterialImpactWarning";
 
 export interface ZapDepositPanelProps {
   walletAddress: string | null;
@@ -461,6 +462,18 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
               </p>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Deposit route impact warning */}
+      {needsSwap && amount && parseFloat(amount) > 0 && (
+        <div className="mb-4">
+          <DepositRouteMaterialImpactWarning
+            amountUsd={0}
+            slippageTolerance={slippageTolerance}
+            isFallback={isFallback}
+            isStale={isStale}
+          />
         </div>
       )}
 

--- a/client/src/features/zap/useDepositImpact.test.ts
+++ b/client/src/features/zap/useDepositImpact.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useDepositImpact } from "./useDepositImpact";
+
+const base = {
+  amountUsd: 0,
+  slippageTolerance: 1,
+  isFallback: false,
+  isStale: false,
+};
+
+describe("useDepositImpact", () => {
+  it("returns severity=none for baseline inputs", () => {
+    const { result } = renderHook(() => useDepositImpact(base));
+    expect(result.current.severity).toBe("none");
+    expect(result.current.reasons).toHaveLength(0);
+    expect(result.current.impactScore).toBe(0);
+  });
+
+  it("adds slippage reason for elevated slippage (3–7%)", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, slippageTolerance: 5 }),
+    );
+    expect(result.current.reasons.some((r) => r.includes("slippage"))).toBe(true);
+    expect(result.current.impactScore).toBe(20);
+  });
+
+  it("reaches warning severity when elevated slippage combines with fallback", () => {
+    // slippage 5%: +20, fallback: +15 → 35 → warning
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, slippageTolerance: 5, isFallback: true }),
+    );
+    expect(result.current.severity).toBe("warning");
+    expect(result.current.impactScore).toBe(35);
+  });
+
+  it("reaches warning severity for high slippage (>=8%)", () => {
+    // high slippage: +40 → warning
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, slippageTolerance: 8 }),
+    );
+    expect(result.current.severity).toBe("warning");
+    expect(result.current.reasons.some((r) => r.includes("8%"))).toBe(true);
+    expect(result.current.impactScore).toBe(40);
+  });
+
+  it("reaches critical severity when high slippage and large deposit combine", () => {
+    // high slippage: +40, large deposit: +40 → 80 → critical
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, slippageTolerance: 8, amountUsd: 600_000 }),
+    );
+    expect(result.current.severity).toBe("critical");
+    expect(result.current.impactScore).toBe(80);
+  });
+
+  it("adds reason for moderate deposit size (>=50k USD)", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, amountUsd: 75_000 }),
+    );
+    expect(result.current.reasons.some((r) => r.includes("75k"))).toBe(true);
+    expect(result.current.impactScore).toBe(20);
+  });
+
+  it("adds reason and higher score for large deposit size (>=500k USD)", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, amountUsd: 600_000 }),
+    );
+    expect(result.current.reasons.some((r) => r.includes("600k"))).toBe(true);
+    expect(result.current.impactScore).toBe(40);
+  });
+
+  it("adds fallback reason when isFallback=true", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, isFallback: true }),
+    );
+    expect(result.current.reasons.some((r) => r.toLowerCase().includes("fallback"))).toBe(true);
+    expect(result.current.impactScore).toBe(15);
+  });
+
+  it("adds stale reason when isStale=true", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, isStale: true }),
+    );
+    expect(result.current.reasons.some((r) => r.toLowerCase().includes("stale"))).toBe(true);
+    expect(result.current.impactScore).toBe(10);
+  });
+
+  it("fallback + stale together reach warning threshold (score=25)", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, isFallback: true, isStale: true }),
+    );
+    expect(result.current.impactScore).toBe(25);
+    expect(result.current.severity).toBe("warning");
+  });
+
+  it("adds degraded execution quality reason for score 50–69", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, executionQualityScore: 60 }),
+    );
+    expect(result.current.reasons.some((r) => r.includes("60/100"))).toBe(true);
+    expect(result.current.impactScore).toBe(20);
+  });
+
+  it("adds critical execution quality reason for score <50", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, executionQualityScore: 40 }),
+    );
+    expect(result.current.reasons.some((r) => r.includes("40/100"))).toBe(true);
+    expect(result.current.severity).toBe("warning");
+    expect(result.current.impactScore).toBe(35);
+  });
+
+  it("reaches critical when very low execution quality combines with large deposit", () => {
+    // low quality: +35, large deposit: +40 → 75 → critical
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, executionQualityScore: 40, amountUsd: 600_000 }),
+    );
+    expect(result.current.severity).toBe("critical");
+  });
+
+  it("adds materialImpact reason when flag is true", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({ ...base, materialImpact: true }),
+    );
+    expect(result.current.reasons.some((r) => r.toLowerCase().includes("material impact"))).toBe(true);
+    expect(result.current.impactScore).toBe(15);
+  });
+
+  it("clamps impactScore at 100", () => {
+    const { result } = renderHook(() =>
+      useDepositImpact({
+        amountUsd: 600_000,
+        slippageTolerance: 10,
+        isFallback: true,
+        isStale: true,
+        executionQualityScore: 30,
+        materialImpact: true,
+      }),
+    );
+    expect(result.current.impactScore).toBeLessThanOrEqual(100);
+    expect(result.current.severity).toBe("critical");
+  });
+});

--- a/client/src/features/zap/useDepositImpact.ts
+++ b/client/src/features/zap/useDepositImpact.ts
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+
+export type ImpactSeverity = "none" | "warning" | "critical";
+
+export interface DepositImpactResult {
+  severity: ImpactSeverity;
+  reasons: string[];
+  /** Estimated execution-quality degradation 0-100 */
+  impactScore: number;
+}
+
+interface UseDepositImpactInput {
+  /** Amount the user is depositing, in the token's base units */
+  amountUsd: number;
+  /** Slippage tolerance the user has configured (%) */
+  slippageTolerance: number;
+  /** True when the quote came from the fallback rate estimator */
+  isFallback: boolean;
+  /** True when the quote is stale (over STALE_QUOTE_AGE_MS old) */
+  isStale: boolean;
+  /** If the fragmentation API is available, pass executionQualityScore (0-100) */
+  executionQualityScore?: number;
+  /** materialImpact flag from the fragmentation API */
+  materialImpact?: boolean;
+}
+
+const WARNING_SLIPPAGE_PCT = 3;
+const CRITICAL_SLIPPAGE_PCT = 8;
+const WARNING_AMOUNT_USD = 50_000;
+const CRITICAL_AMOUNT_USD = 500_000;
+const LOW_EXECUTION_QUALITY = 70;
+const CRITICAL_EXECUTION_QUALITY = 50;
+
+/**
+ * Pure hook — computes deposit route impact without side effects.
+ * Returns the severity, human-readable reasons, and a composite impact score.
+ */
+export function useDepositImpact(input: UseDepositImpactInput): DepositImpactResult {
+  return useMemo(() => {
+    const reasons: string[] = [];
+    let impactScore = 0;
+
+    // Slippage signal
+    if (input.slippageTolerance >= CRITICAL_SLIPPAGE_PCT) {
+      reasons.push(`High slippage tolerance (${input.slippageTolerance}%) increases execution risk`);
+      impactScore += 40;
+    } else if (input.slippageTolerance >= WARNING_SLIPPAGE_PCT) {
+      reasons.push(`Elevated slippage tolerance (${input.slippageTolerance}%) may widen price impact`);
+      impactScore += 20;
+    }
+
+    // Deposit size signal
+    if (input.amountUsd >= CRITICAL_AMOUNT_USD) {
+      reasons.push(`Large deposit ($${(input.amountUsd / 1000).toFixed(0)}k) may fragment liquidity pools`);
+      impactScore += 40;
+    } else if (input.amountUsd >= WARNING_AMOUNT_USD) {
+      reasons.push(`Moderate deposit size ($${(input.amountUsd / 1000).toFixed(0)}k) could affect routing quality`);
+      impactScore += 20;
+    }
+
+    // Quote quality signals
+    if (input.isFallback) {
+      reasons.push("Fallback quote active — actual output may differ from estimate");
+      impactScore += 15;
+    }
+    if (input.isStale) {
+      reasons.push("Quote is stale — market conditions may have shifted");
+      impactScore += 10;
+    }
+
+    // Fragmentation signals
+    if (input.executionQualityScore !== undefined) {
+      if (input.executionQualityScore < CRITICAL_EXECUTION_QUALITY) {
+        reasons.push(`Critical execution quality (${input.executionQualityScore}/100) — high fragmentation detected`);
+        impactScore += 35;
+      } else if (input.executionQualityScore < LOW_EXECUTION_QUALITY) {
+        reasons.push(`Degraded execution quality (${input.executionQualityScore}/100) due to fragmented liquidity`);
+        impactScore += 20;
+      }
+    }
+
+    if (input.materialImpact) {
+      reasons.push("This deposit route has a material impact on pool allocation");
+      impactScore += 15;
+    }
+
+    const clampedScore = Math.min(100, impactScore);
+
+    let severity: ImpactSeverity = "none";
+    if (clampedScore >= 60) {
+      severity = "critical";
+    } else if (clampedScore >= 25) {
+      severity = "warning";
+    }
+
+    return { severity, reasons, impactScore: clampedScore };
+  }, [input]);
+}

--- a/server/src/routes/analytics.ts
+++ b/server/src/routes/analytics.ts
@@ -631,4 +631,25 @@ router.post(
   },
 );
 
+/**
+ * GET /api/analytics/providers/uptime
+ * Returns historical uptime reports for all known yield data providers.
+ */
+router.get('/providers/uptime', async (_req, res) => {
+  try {
+    const reports = await yieldReliabilityEngine.getAllProviderUptimeReports();
+    res.json({
+      success: true,
+      data: reports,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error('Failed to fetch provider uptime reports:', error);
+    res.status(500).json({
+      success: false,
+      error: { code: 'UPTIME_FETCH_FAILED', message: 'Unable to fetch provider uptime reports.' },
+    });
+  }
+});
+
 export default router;

--- a/server/src/routes/fees.ts
+++ b/server/src/routes/fees.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getFeeOracleEstimate } from "../services/feeOracleService";
+import { getFeeOracleEstimate, getFeeDeviationAlert } from "../services/feeOracleService";
 import { sendError } from "../utils/errorResponse";
 
 const feesRouter = Router();
@@ -11,6 +11,16 @@ feesRouter.get("/", async (_req, res) => {
   } catch (error) {
     console.error("Failed to serve /api/fees", error);
     sendError(res, 500, "FEE_ESTIMATE_FAILED", "Unable to estimate fees right now.");
+  }
+});
+
+feesRouter.get("/alert", async (_req, res) => {
+  try {
+    const result = await getFeeDeviationAlert();
+    res.json(result);
+  } catch (error) {
+    console.error("Failed to serve /api/fees/alert", error);
+    sendError(res, 500, "FEE_ALERT_FAILED", "Unable to compute fee deviation alert.");
   }
 });
 

--- a/server/src/routes/simulator.ts
+++ b/server/src/routes/simulator.ts
@@ -4,7 +4,10 @@ import {
   SimulationParams,
   simulateRebalance,
   validateRebalanceParams,
+  runRebalanceBacktest,
+  validateRebalanceBacktestParams,
   type RebalanceParams,
+  type RebalanceBacktestParams,
 } from "../services/simulationService";
 
 const router = Router();
@@ -74,6 +77,29 @@ router.post("/rebalance", (req: Request, res: Response) => {
   } catch (e) {
     res.status(500).json({
       error: e instanceof Error ? e.message : "Rebalance simulation failed",
+    });
+  }
+});
+
+/**
+ * POST /api/simulator/rebalance-backtest
+ *
+ * Runs a deterministic historical rebalance backtest and compares the
+ * rebalanced portfolio against a passive-hold benchmark. Simulation-only.
+ */
+router.post("/rebalance-backtest", (req: Request, res: Response) => {
+  try {
+    const params = req.body as RebalanceBacktestParams;
+    const errors = validateRebalanceBacktestParams(params);
+    if (errors.length > 0) {
+      res.status(400).json({ error: "Invalid backtest parameters", details: errors });
+      return;
+    }
+    const result = runRebalanceBacktest(params);
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({
+      error: e instanceof Error ? e.message : "Rebalance backtest failed",
     });
   }
 });

--- a/server/src/services/__tests__/feeOracleDeviation.test.ts
+++ b/server/src/services/__tests__/feeOracleDeviation.test.ts
@@ -1,0 +1,81 @@
+import {
+  computeFeeDeviationAlert,
+  checkFeeDeviation,
+  resetFeeBaseline,
+} from "../feeOracleService";
+
+beforeEach(() => {
+  resetFeeBaseline();
+});
+
+describe("computeFeeDeviationAlert", () => {
+  it("returns normal when fee equals baseline", () => {
+    const alert = computeFeeDeviationAlert(100, 100);
+    expect(alert.level).toBe("normal");
+    expect(alert.deviationPct).toBe(0);
+  });
+
+  it("returns warning at 25% above baseline", () => {
+    const alert = computeFeeDeviationAlert(125, 100);
+    expect(alert.level).toBe("warning");
+    expect(alert.deviationPct).toBeGreaterThanOrEqual(20);
+  });
+
+  it("returns critical at 60% above baseline", () => {
+    const alert = computeFeeDeviationAlert(160, 100);
+    expect(alert.level).toBe("critical");
+    expect(alert.deviationPct).toBeGreaterThanOrEqual(50);
+  });
+
+  it("returns normal for small deviation below baseline", () => {
+    const alert = computeFeeDeviationAlert(90, 100);
+    expect(alert.level).toBe("normal");
+  });
+
+  it("returns warning for large drop below baseline", () => {
+    const alert = computeFeeDeviationAlert(70, 100);
+    expect(alert.level).toBe("warning");
+    expect(alert.deviationPct).toBeLessThan(0);
+  });
+
+  it("handles zero baseline gracefully", () => {
+    const alert = computeFeeDeviationAlert(100, 0);
+    expect(alert.level).toBe("normal");
+    expect(alert.deviationPct).toBe(0);
+  });
+
+  it("includes all required fields", () => {
+    const alert = computeFeeDeviationAlert(200, 100);
+    expect(alert).toMatchObject({
+      currentFee: 200,
+      baselineFee: 100,
+      warningThresholdPct: 20,
+      criticalThresholdPct: 50,
+    });
+    expect(alert.message).toBeTruthy();
+    expect(alert.generatedAt).toBeTruthy();
+  });
+});
+
+describe("checkFeeDeviation (stateful)", () => {
+  it("baseline initialises to first observation", () => {
+    const alert = checkFeeDeviation(100);
+    expect(alert.level).toBe("normal");
+    expect(alert.baselineFee).toBe(100);
+  });
+
+  it("detects spike after baseline is established", () => {
+    checkFeeDeviation(100);
+    checkFeeDeviation(100);
+    checkFeeDeviation(100);
+    const spike = checkFeeDeviation(500);
+    expect(spike.level).not.toBe("normal");
+  });
+
+  it("baseline resets after resetFeeBaseline()", () => {
+    checkFeeDeviation(1000);
+    resetFeeBaseline();
+    const alert = checkFeeDeviation(100);
+    expect(alert.baselineFee).toBe(100);
+  });
+});

--- a/server/src/services/__tests__/providerUptimeReport.test.ts
+++ b/server/src/services/__tests__/providerUptimeReport.test.ts
@@ -1,0 +1,109 @@
+import { YieldReliabilityEngine, type DataSourceReliability } from "../yieldReliabilityService";
+
+function makeSample(
+  status: DataSourceReliability["status"],
+  offsetMs = 0,
+): DataSourceReliability {
+  return {
+    providerId: "test_provider",
+    providerName: "Test Provider",
+    dataSource: "api",
+    reliabilityScore:
+      status === "high" ? 90 : status === "medium" ? 75 : status === "low" ? 55 : 0,
+    metrics: {
+      freshness: 0.9,
+      consistency: 0.9,
+      historicalUptime: 0.9,
+      anomalyRate: 0.05,
+      latency: 200,
+      errorRate: 0.01,
+      coverage: 0.95,
+      accuracy: 0.95,
+    },
+    signals: {
+      lastSuccessfulFetch: new Date().toISOString(),
+      consecutiveFailures: 0,
+      totalRequests: 100,
+      successfulRequests: 99,
+      averageResponseTime: 200,
+      lastAnomaly: new Date().toISOString(),
+      dataPointsLast24h: 140,
+      expectedDataPoints24h: 144,
+      varianceFromMean: 0.01,
+      crossSourceDeviation: 0.02,
+    },
+    status,
+    lastUpdated: new Date(Date.now() + offsetMs).toISOString(),
+    trend: "stable",
+    recommendations: [],
+    failoverPriority: 10,
+    weightInRecommendations: 1.0,
+  };
+}
+
+type EngineInternals = { historicalData: Map<string, DataSourceReliability[]> };
+
+describe("YieldReliabilityEngine.getProviderUptimeReport", () => {
+  let engine: YieldReliabilityEngine;
+
+  beforeEach(() => {
+    engine = new YieldReliabilityEngine();
+  });
+
+  it("returns 100% uptime when there is no history", () => {
+    const report = engine.getProviderUptimeReport("unknown", "Unknown");
+    expect(report.uptimePct).toBe(100);
+    expect(report.sampleCount).toBe(0);
+    expect(report.outageWindowCount).toBe(0);
+  });
+
+  it("computes 100% uptime for all-healthy samples", () => {
+    (engine as unknown as EngineInternals).historicalData.set("p1", [
+      makeSample("high", 0),
+      makeSample("high", 60_000),
+      makeSample("medium", 120_000),
+    ]);
+    const report = engine.getProviderUptimeReport("p1", "P1");
+    expect(report.uptimePct).toBe(100);
+    expect(report.downtimePct).toBe(0);
+    expect(report.sampleCount).toBe(3);
+  });
+
+  it("computes downtime when low/unreliable samples are present", () => {
+    (engine as unknown as EngineInternals).historicalData.set("p2", [
+      makeSample("high", 0),
+      makeSample("unreliable", 60_000),
+      makeSample("high", 120_000),
+    ]);
+    const report = engine.getProviderUptimeReport("p2", "P2");
+    expect(report.downtimePct).toBeGreaterThan(0);
+    expect(report.outageWindowCount).toBe(1);
+  });
+
+  it("caps recentOutages at 5", () => {
+    const samples: DataSourceReliability[] = [];
+    for (let i = 0; i < 12; i++) {
+      samples.push(makeSample(i % 2 === 0 ? "high" : "unreliable", i * 60_000));
+    }
+    (engine as unknown as EngineInternals).historicalData.set("p3", samples);
+    const report = engine.getProviderUptimeReport("p3", "P3");
+    expect(report.recentOutages.length).toBeLessThanOrEqual(5);
+  });
+
+  it("marks ongoing outage with endedAt = null", () => {
+    (engine as unknown as EngineInternals).historicalData.set("p4", [
+      makeSample("high", 0),
+      makeSample("unreliable", 60_000),
+      makeSample("unreliable", 120_000),
+    ]);
+    const report = engine.getProviderUptimeReport("p4", "P4");
+    const ongoing = report.recentOutages.find((o) => o.endedAt === null);
+    expect(ongoing).toBeDefined();
+  });
+
+  it("includes providerId and providerName in report", () => {
+    const report = engine.getProviderUptimeReport("xyz", "XYZ Provider");
+    expect(report.providerId).toBe("xyz");
+    expect(report.providerName).toBe("XYZ Provider");
+  });
+});

--- a/server/src/services/__tests__/rebalanceBacktest.test.ts
+++ b/server/src/services/__tests__/rebalanceBacktest.test.ts
@@ -1,0 +1,124 @@
+import {
+  runRebalanceBacktest,
+  validateRebalanceBacktestParams,
+  type RebalanceBacktestParams,
+} from "../simulationService";
+
+const BASE_PARAMS: RebalanceBacktestParams = {
+  initialValueUsd: 10_000,
+  startDate: "2024-01-01",
+  endDate: "2024-03-31",
+  allocations: [
+    { label: "Blend", targetWeight: 60, apy: 8 },
+    { label: "Soroswap", targetWeight: 40, apy: 12 },
+  ],
+  strategy: "schedule",
+  rebalanceIntervalDays: 30,
+  feeBps: 20,
+};
+
+describe("validateRebalanceBacktestParams", () => {
+  it("accepts valid params", () => {
+    expect(validateRebalanceBacktestParams(BASE_PARAMS)).toEqual([]);
+  });
+
+  it("rejects when startDate >= endDate", () => {
+    const params = { ...BASE_PARAMS, startDate: "2024-03-31", endDate: "2024-01-01" };
+    expect(validateRebalanceBacktestParams(params)).toContain(
+      "startDate must be before endDate.",
+    );
+  });
+
+  it("rejects when weights do not sum to 100", () => {
+    const params = {
+      ...BASE_PARAMS,
+      allocations: [
+        { label: "A", targetWeight: 50, apy: 8 },
+        { label: "B", targetWeight: 40, apy: 12 },
+      ],
+    };
+    const errors = validateRebalanceBacktestParams(params);
+    expect(errors.some((e) => e.includes("sum to 100"))).toBe(true);
+  });
+
+  it("rejects invalid strategy", () => {
+    const params = { ...BASE_PARAMS, strategy: "unknown" as "schedule" };
+    expect(validateRebalanceBacktestParams(params)).toContain(
+      "strategy must be 'schedule' or 'threshold'.",
+    );
+  });
+
+  it("rejects non-positive initialValueUsd", () => {
+    const params = { ...BASE_PARAMS, initialValueUsd: 0 };
+    expect(validateRebalanceBacktestParams(params)).toContain(
+      "initialValueUsd must be a positive number.",
+    );
+  });
+});
+
+describe("runRebalanceBacktest", () => {
+  it("is marked simulation-only", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.isSimulationOnly).toBe(true);
+  });
+
+  it("produces one snapshot per day (91 days for Jan-Mar 2024)", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.snapshots.length).toBe(91);
+  });
+
+  it("portfolioReturnPct > 0 for positive APY allocations", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.portfolioReturnPct).toBeGreaterThan(0);
+  });
+
+  it("first snapshot date matches startDate", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.snapshots[0].date).toBe("2024-01-01");
+  });
+
+  it("last snapshot date matches endDate", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.snapshots[result.snapshots.length - 1].date).toBe("2024-03-31");
+  });
+
+  it("schedule strategy fires rebalance events on interval days", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.rebalanceCount).toBeGreaterThan(0);
+    expect(result.rebalanceCount).toBeLessThanOrEqual(3);
+  });
+
+  it("threshold strategy fires rebalance when drift exceeds threshold", () => {
+    const params: RebalanceBacktestParams = {
+      ...BASE_PARAMS,
+      strategy: "threshold",
+      driftThresholdPct: 0.01,
+    };
+    const result = runRebalanceBacktest(params);
+    expect(result.rebalanceCount).toBeGreaterThan(0);
+  });
+
+  it("higher feeBps reduces final portfolio value", () => {
+    const withFees = runRebalanceBacktest({ ...BASE_PARAMS, feeBps: 200 });
+    const noFees = runRebalanceBacktest({ ...BASE_PARAMS, feeBps: 0 });
+    expect(withFees.finalPortfolioValue).toBeLessThan(noFees.finalPortfolioValue);
+  });
+
+  it("passive benchmark grows without rebalancing", () => {
+    const result = runRebalanceBacktest(BASE_PARAMS);
+    expect(result.finalPassiveValue).toBeGreaterThan(BASE_PARAMS.initialValueUsd);
+  });
+
+  it("throws for invalid params", () => {
+    const bad = { ...BASE_PARAMS, initialValueUsd: -1 };
+    expect(() => runRebalanceBacktest(bad)).toThrow("Invalid backtest parameters");
+  });
+
+  it("is deterministic — same inputs always produce same outputs", () => {
+    const r1 = runRebalanceBacktest(BASE_PARAMS);
+    const r2 = runRebalanceBacktest(BASE_PARAMS);
+    expect(r1.finalPortfolioValue).toBe(r2.finalPortfolioValue);
+    expect(r1.rebalanceCount).toBe(r2.rebalanceCount);
+    expect(r1.snapshots.length).toBe(r2.snapshots.length);
+  });
+});

--- a/server/src/services/feeOracleService.ts
+++ b/server/src/services/feeOracleService.ts
@@ -98,3 +98,93 @@ export async function getFeeOracleEstimate(): Promise<FeeOracleResponse> {
   cacheExpiresAt = now + CACHE_TTL_MS;
   return result;
 }
+
+// ── Fee Oracle Deviation Alerting ────────────────────────────────────────
+
+export type FeeAlertLevel = 'normal' | 'warning' | 'critical';
+
+export interface FeeDeviationAlert {
+  level: FeeAlertLevel;
+  currentFee: number;            // stroops, the observed average fee
+  baselineFee: number;           // stroops, EMA-smoothed baseline
+  deviationPct: number;          // signed: positive = above baseline
+  warningThresholdPct: number;   // always WARNING_DEVIATION_PCT
+  criticalThresholdPct: number;  // always CRITICAL_DEVIATION_PCT
+  message: string;               // human-readable summary
+  generatedAt: string;           // ISO timestamp
+}
+
+const WARNING_DEVIATION_PCT = 20;
+const CRITICAL_DEVIATION_PCT = 50;
+const EMA_ALPHA = 0.3; // weight given to the most recent observation
+
+let feeBaseline: number | null = null;
+
+/** Reset the EMA baseline (useful in tests). */
+export function resetFeeBaseline(): void {
+  feeBaseline = null;
+}
+
+/**
+ * Pure computation of a fee deviation alert.
+ * Keeps baseline tracking separate so this function can be tested without
+ * module-level state.
+ */
+export function computeFeeDeviationAlert(
+  currentFee: number,
+  baselineFee: number,
+): FeeDeviationAlert {
+  const deviationPct =
+    baselineFee > 0 ? ((currentFee - baselineFee) / baselineFee) * 100 : 0;
+  const absDeviation = Math.abs(deviationPct);
+
+  let level: FeeAlertLevel = 'normal';
+  if (absDeviation >= CRITICAL_DEVIATION_PCT) {
+    level = 'critical';
+  } else if (absDeviation >= WARNING_DEVIATION_PCT) {
+    level = 'warning';
+  }
+
+  const direction = deviationPct >= 0 ? 'above' : 'below';
+  const message =
+    level === 'normal'
+      ? `Fees within normal range (${deviationPct.toFixed(1)}% ${direction} baseline)`
+      : level === 'warning'
+        ? `Fee spike: ${Math.abs(deviationPct).toFixed(1)}% ${direction} baseline — costs elevated`
+        : `Critical fee spike: ${Math.abs(deviationPct).toFixed(1)}% ${direction} baseline — consider delaying transactions`;
+
+  return {
+    level,
+    currentFee: Math.round(currentFee),
+    baselineFee: Math.round(baselineFee),
+    deviationPct: Math.round(deviationPct * 10) / 10,
+    warningThresholdPct: WARNING_DEVIATION_PCT,
+    criticalThresholdPct: CRITICAL_DEVIATION_PCT,
+    message,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Stateful: updates the EMA baseline and returns a deviation alert.
+ */
+export function checkFeeDeviation(currentFee: number): FeeDeviationAlert {
+  if (feeBaseline === null) {
+    feeBaseline = currentFee;
+  } else {
+    feeBaseline = EMA_ALPHA * currentFee + (1 - EMA_ALPHA) * feeBaseline;
+  }
+  return computeFeeDeviationAlert(currentFee, feeBaseline);
+}
+
+/**
+ * Convenience: fetch the latest fee estimate and compute a deviation alert.
+ */
+export async function getFeeDeviationAlert(): Promise<{
+  estimate: FeeOracleResponse;
+  alert: FeeDeviationAlert;
+}> {
+  const estimate = await getFeeOracleEstimate();
+  const alert = checkFeeDeviation(estimate.fees.average);
+  return { estimate, alert };
+}

--- a/server/src/services/simulationService.ts
+++ b/server/src/services/simulationService.ts
@@ -318,3 +318,244 @@ export function simulateRebalance(params: RebalanceParams): RebalancePreview {
     warnings,
   };
 }
+
+// ── Rebalance Backtest Engine ─────────────────────────────────────────────
+//
+// Simulates a historical rebalancing strategy (schedule or drift-threshold
+// based) day-by-day and compares against a passive hold benchmark.
+// Fully deterministic — same inputs always produce the same outputs.
+
+export interface RebalanceAllocationRule {
+  label: string;
+  targetWeight: number;   // 0-100, must sum to ~100 across all allocations
+  apy: number;            // annual %, e.g. 10 = 10%
+  liquidityUsd?: number;  // optional, for context only
+}
+
+export interface RebalanceBacktestParams {
+  initialValueUsd: number;
+  startDate: string;               // "YYYY-MM-DD"
+  endDate: string;                 // "YYYY-MM-DD"
+  allocations: RebalanceAllocationRule[];
+  strategy: 'schedule' | 'threshold';
+  rebalanceIntervalDays?: number;  // for schedule (default 30)
+  driftThresholdPct?: number;      // for threshold: max allowed weight drift (default 5)
+  feeBps?: number;                 // rebalance turnover fee in bps (default 20)
+}
+
+export interface RebalanceBacktestSnapshot {
+  date: string;
+  portfolioValue: number;   // rebalanced portfolio
+  passiveValue: number;     // passive benchmark (never rebalanced)
+  rebalanced: boolean;
+  blendedApyPct: number;   // weighted APY of current allocation
+}
+
+export interface RebalanceEvent {
+  date: string;
+  reason: string;
+  maxDriftPct: number;
+  feeUsd: number;
+}
+
+export interface RebalanceBacktestResult {
+  isSimulationOnly: true;
+  startDate: string;
+  endDate: string;
+  initialValueUsd: number;
+  finalPortfolioValue: number;
+  finalPassiveValue: number;
+  portfolioReturnPct: number;
+  passiveReturnPct: number;
+  outperformancePct: number;    // portfolio - passive return, expressed as % of initial
+  rebalanceCount: number;
+  totalFeesUsd: number;
+  snapshots: RebalanceBacktestSnapshot[];
+  rebalanceEvents: RebalanceEvent[];
+}
+
+export const BACKTEST_LIMITS = {
+  maxDays: 1825,      // 5 years
+  maxAllocations: 20,
+} as const;
+
+/**
+ * Validate backtest params. Returns array of error strings; empty means valid.
+ */
+export function validateRebalanceBacktestParams(params: RebalanceBacktestParams): string[] {
+  const errors: string[] = [];
+
+  if (!params.startDate || !params.endDate) {
+    errors.push("startDate and endDate are required.");
+  } else {
+    const start = new Date(params.startDate);
+    const end = new Date(params.endDate);
+    if (isNaN(start.getTime()) || isNaN(end.getTime())) {
+      errors.push("startDate and endDate must be valid ISO date strings.");
+    } else if (start >= end) {
+      errors.push("startDate must be before endDate.");
+    } else {
+      const dayDiff = Math.round((end.getTime() - start.getTime()) / 86_400_000);
+      if (dayDiff > BACKTEST_LIMITS.maxDays) {
+        errors.push(`Date range exceeds maximum of ${BACKTEST_LIMITS.maxDays} days.`);
+      }
+    }
+  }
+
+  if (!Number.isFinite(params.initialValueUsd) || params.initialValueUsd <= 0) {
+    errors.push("initialValueUsd must be a positive number.");
+  }
+
+  if (!Array.isArray(params.allocations) || params.allocations.length === 0) {
+    errors.push("allocations must be a non-empty array.");
+    return errors;
+  }
+
+  if (params.allocations.length > BACKTEST_LIMITS.maxAllocations) {
+    errors.push(`Too many allocations (max ${BACKTEST_LIMITS.maxAllocations}).`);
+  }
+
+  let weightSum = 0;
+  for (const alloc of params.allocations) {
+    if (!alloc.label) errors.push("Each allocation must have a label.");
+    if (!Number.isFinite(alloc.targetWeight) || alloc.targetWeight < 0 || alloc.targetWeight > 100) {
+      errors.push(`targetWeight for "${alloc.label || 'allocation'}" must be 0-100.`);
+    }
+    if (!Number.isFinite(alloc.apy) || alloc.apy < 0) {
+      errors.push(`apy for "${alloc.label || 'allocation'}" must be a non-negative number.`);
+    }
+    weightSum += alloc.targetWeight;
+  }
+
+  if (Math.abs(weightSum - 100) > 0.5) {
+    errors.push(`targetWeights must sum to 100 (got ${round2(weightSum)}).`);
+  }
+
+  if (params.strategy !== 'schedule' && params.strategy !== 'threshold') {
+    errors.push("strategy must be 'schedule' or 'threshold'.");
+  }
+
+  return errors;
+}
+
+/**
+ * Run a deterministic historical rebalance backtest.
+ * @throws Error when params fail validation.
+ */
+export function runRebalanceBacktest(params: RebalanceBacktestParams): RebalanceBacktestResult {
+  const errors = validateRebalanceBacktestParams(params);
+  if (errors.length > 0) {
+    throw new Error(`Invalid backtest parameters: ${errors.join(" ")}`);
+  }
+
+  const feeBps = params.feeBps ?? 20;
+  const rebalanceIntervalDays = params.rebalanceIntervalDays ?? 30;
+  const driftThresholdPct = params.driftThresholdPct ?? 5;
+
+  const targetWeights = params.allocations.map(a => a.targetWeight / 100);
+  const dailyFactors = params.allocations.map(a => 1 + (a.apy / 100) / 365);
+
+  // Per-allocation values for the rebalanced portfolio and the passive benchmark
+  let portfolioAlloc = targetWeights.map(w => params.initialValueUsd * w);
+  let passiveAlloc = [...portfolioAlloc];
+
+  const snapshots: RebalanceBacktestSnapshot[] = [];
+  const rebalanceEvents: RebalanceEvent[] = [];
+  let totalFeesUsd = 0;
+  let dayNumber = 0;
+
+  const startMs = new Date(params.startDate).getTime();
+  const endMs = new Date(params.endDate).getTime();
+
+  for (let ms = startMs; ms <= endMs; ms += 86_400_000) {
+    const dateStr = new Date(ms).toISOString().slice(0, 10);
+
+    // Compound growth for each allocation
+    portfolioAlloc = portfolioAlloc.map((v, i) => v * dailyFactors[i]);
+    passiveAlloc = passiveAlloc.map((v, i) => v * dailyFactors[i]);
+
+    const totalPortfolio = portfolioAlloc.reduce((s, v) => s + v, 0);
+    const currentWeights = portfolioAlloc.map(v => (v / totalPortfolio) * 100);
+
+    // Determine whether a rebalance should occur today
+    let shouldRebalance = false;
+    let rebalanceReason = '';
+    let maxDrift = 0;
+
+    if (params.strategy === 'schedule') {
+      if (dayNumber > 0 && dayNumber % rebalanceIntervalDays === 0) {
+        shouldRebalance = true;
+        rebalanceReason = `Scheduled rebalance every ${rebalanceIntervalDays} days`;
+      }
+    } else {
+      const drifts = params.allocations.map((a, i) =>
+        Math.abs(currentWeights[i] - a.targetWeight),
+      );
+      maxDrift = Math.max(...drifts);
+      if (maxDrift > driftThresholdPct) {
+        shouldRebalance = true;
+        rebalanceReason = `Max weight drift ${round2(maxDrift)}% exceeded ${driftThresholdPct}% threshold`;
+      }
+    }
+
+    let feeToday = 0;
+    if (shouldRebalance) {
+      const targetValues = targetWeights.map(w => totalPortfolio * w);
+      const grossMovement = portfolioAlloc.reduce(
+        (s, v, i) => s + Math.abs(v - targetValues[i]),
+        0,
+      );
+      const turnover = grossMovement / 2;
+      feeToday = (turnover * feeBps) / 10_000;
+      totalFeesUsd += feeToday;
+
+      const valueAfterFee = totalPortfolio - feeToday;
+      portfolioAlloc = targetWeights.map(w => valueAfterFee * w);
+
+      rebalanceEvents.push({
+        date: dateStr,
+        reason: rebalanceReason,
+        maxDriftPct: round2(maxDrift),
+        feeUsd: round2(feeToday),
+      });
+    }
+
+    const portfolioTotal = portfolioAlloc.reduce((s, v) => s + v, 0);
+    const passiveTotal = passiveAlloc.reduce((s, v) => s + v, 0);
+    const blendedApy = params.allocations.reduce(
+      (sum, a, i) => sum + a.apy * (portfolioAlloc[i] / portfolioTotal),
+      0,
+    );
+
+    snapshots.push({
+      date: dateStr,
+      portfolioValue: round2(portfolioTotal),
+      passiveValue: round2(passiveTotal),
+      rebalanced: shouldRebalance,
+      blendedApyPct: round2(blendedApy),
+    });
+
+    dayNumber++;
+  }
+
+  const last = snapshots[snapshots.length - 1];
+  const finalPortfolio = last?.portfolioValue ?? params.initialValueUsd;
+  const finalPassive = last?.passiveValue ?? params.initialValueUsd;
+  const init = params.initialValueUsd;
+
+  return {
+    isSimulationOnly: true,
+    startDate: params.startDate,
+    endDate: params.endDate,
+    initialValueUsd: init,
+    finalPortfolioValue: round2(finalPortfolio),
+    finalPassiveValue: round2(finalPassive),
+    portfolioReturnPct: round2(((finalPortfolio - init) / init) * 100),
+    passiveReturnPct: round2(((finalPassive - init) / init) * 100),
+    outperformancePct: round2(((finalPortfolio - finalPassive) / init) * 100),
+    rebalanceCount: rebalanceEvents.length,
+    totalFeesUsd: round2(totalFeesUsd),
+    snapshots,
+    rebalanceEvents,
+  };
+}

--- a/server/src/services/yieldReliabilityService.ts
+++ b/server/src/services/yieldReliabilityService.ts
@@ -62,6 +62,25 @@ export interface ProviderComparison {
   overallRank: number;
 }
 
+export interface OutageWindow {
+  startedAt: string;
+  endedAt: string | null; // null means the outage was ongoing at sample time
+  durationMinutes: number;
+}
+
+export interface ProviderUptimeReport {
+  providerId: string;
+  providerName: string;
+  uptimePct: number;         // 0-100
+  downtimePct: number;       // 0-100
+  unknownPct: number;        // 0-100, periods with no data
+  sampleCount: number;
+  outageWindowCount: number;
+  totalOutageMinutes: number;
+  recentOutages: OutageWindow[];  // up to 5 most recent outage windows
+  generatedAt: string;
+}
+
 // ── Configuration ───────────────────────────────────────────────────────
 
 const DEFAULT_CONFIG: ReliabilityConfig = {
@@ -550,6 +569,107 @@ export class YieldReliabilityEngine {
     } else {
       cache.flushAll();
     }
+  }
+
+  /**
+   * Build a provider uptime report from the in-memory reliability history.
+   * Each historical DataSourceReliability entry represents one sample.
+   * A sample is "up" when its status is 'high' or 'medium'.
+   */
+  getProviderUptimeReport(providerId: string, providerName: string): ProviderUptimeReport {
+    const history = this.historicalData.get(providerId) ?? [];
+
+    if (history.length === 0) {
+      return {
+        providerId,
+        providerName,
+        uptimePct: 100,
+        downtimePct: 0,
+        unknownPct: 0,
+        sampleCount: 0,
+        outageWindowCount: 0,
+        totalOutageMinutes: 0,
+        recentOutages: [],
+        generatedAt: new Date().toISOString(),
+      };
+    }
+
+    const upSamples = history.filter(
+      h => h.status === 'high' || h.status === 'medium',
+    ).length;
+    const downSamples = history.filter(
+      h => h.status === 'low' || h.status === 'unreliable',
+    ).length;
+    const total = history.length;
+
+    const uptimePct = Math.round((upSamples / total) * 1000) / 10;
+    const downtimePct = Math.round((downSamples / total) * 1000) / 10;
+    const unknownPct = Math.round(((total - upSamples - downSamples) / total) * 1000) / 10;
+
+    // Build outage windows: contiguous runs of low/unreliable samples
+    const outageWindows: OutageWindow[] = [];
+    let outageStart: string | null = null;
+
+    for (let i = 0; i < history.length; i++) {
+      const sample = history[i];
+      const isDown = sample.status === 'low' || sample.status === 'unreliable';
+
+      if (isDown && outageStart === null) {
+        outageStart = sample.lastUpdated;
+      } else if (!isDown && outageStart !== null) {
+        const startMs = new Date(outageStart).getTime();
+        const endMs = new Date(sample.lastUpdated).getTime();
+        outageWindows.push({
+          startedAt: outageStart,
+          endedAt: sample.lastUpdated,
+          durationMinutes: Math.round((endMs - startMs) / 60_000),
+        });
+        outageStart = null;
+      }
+    }
+
+    // Handle ongoing outage at end of history
+    if (outageStart !== null) {
+      const last = history[history.length - 1];
+      const startMs = new Date(outageStart).getTime();
+      const endMs = new Date(last.lastUpdated).getTime();
+      outageWindows.push({
+        startedAt: outageStart,
+        endedAt: null,
+        durationMinutes: Math.round((endMs - startMs) / 60_000),
+      });
+    }
+
+    const totalOutageMinutes = outageWindows.reduce(
+      (sum, w) => sum + w.durationMinutes,
+      0,
+    );
+    const recentOutages = outageWindows.slice(-5);
+
+    return {
+      providerId,
+      providerName,
+      uptimePct,
+      downtimePct,
+      unknownPct,
+      sampleCount: total,
+      outageWindowCount: outageWindows.length,
+      totalOutageMinutes,
+      recentOutages,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Get uptime reports for all known providers.
+   */
+  async getAllProviderUptimeReports(): Promise<ProviderUptimeReport[]> {
+    const providers = await this.getAllProviderIds();
+    // Ensure reliability scores are calculated so historicalData is populated
+    await this.getReliabilityScores(providers);
+    return providers.map(p =>
+      this.getProviderUptimeReport(p.id, p.name),
+    );
   }
 }
 


### PR DESCRIPTION
## What changed

- **#511 — Rebalance backtest engine**: Added `runRebalanceBacktest` service (server) implementing deterministic day-by-day portfolio simulation for `schedule` and `threshold` rebalance strategies with fee accounting. Client-side `fetchRebalanceBacktest`, `RebalanceBacktestPanel` UI component, and simulator index exports.

- **#517 — Fee deviation alerting**: Added EMA-based `checkFeeDeviation` / `computeFeeDeviationAlert` to `feeOracleService`, `GET /api/fees/alert` route, and `FeeDeviationAlertBanner` React component that polls every 60 s and renders level-styled banners (normal / warning / critical).

- **#521 — Provider uptime reports**: Added `getProviderUptimeReport` and `getAllProviderUptimeReports` to `YieldReliabilityEngine` deriving uptime percentage, outage windows, and downtime minutes from historical data. `GET /api/analytics/providers/uptime` route and `ProviderUptimeReport` React component with expandable per-provider details.

- **#522 — Deposit route material impact warnings**: Added `useDepositImpact` pure hook computing composite impact score from slippage, deposit size, fallback/stale quote status, execution quality score, and materialImpact flag. `DepositRouteMaterialImpactWarning` component renders warning/critical banners. Integrated into `ZapDepositPanel`. 15 unit tests for the hook.

## Why

Each issue introduced a distinct monitoring/simulation capability — isolated to their own service methods, routes, and UI components to keep blast radius small.

## How to test

- POST `/api/simulator/rebalance-backtest` with a valid `RebalanceBacktestParams` body; confirm deterministic results.
- GET `/api/fees/alert` returns `{ estimate, alert }` with a computed deviation level.
- GET `/api/analytics/providers/uptime` returns per-provider uptime percentages and outage windows.
- In the ZapDepositPanel, set slippage ≥ 3% with a stale/fallback quote and observe the impact warning banner.
- `npx vitest run` (client) — 15 new useDepositImpact tests pass alongside existing suite.
- Server: `jest rebalanceBacktest feeOracleDeviation providerUptimeReport` — 32 tests pass.

Closes #511
Closes #517
Closes #521
Closes #522