### PR TITLE
feat(#503): add risk-adjusted deposit recommendation wizard

### DIFF
--- a/client/src/components/AIAdvisor.tsx
+++ b/client/src/components/AIAdvisor.tsx
@@ -8,9 +8,11 @@ import {
   DollarSign,
   Activity,
   Shield,
+  Wand2,
 } from "lucide-react";
 import { apiUrl } from "../lib/api";
 import { getRiskExplanation } from "../config/riskConfig";
+import DepositWizard from "./AIAdvisor/DepositWizard";
 
 interface ReasonCodeDetail {
   code: string;
@@ -90,8 +92,14 @@ export default function AIAdvisor() {
       </p>
 
       <div className="glass-panel p-8 mt-12 max-w-3xl w-full text-left">
-        <div className="h-40 border-2 border-dashed border-[#6C5DD3]/30 rounded-xl flex items-center justify-center text-gray-500 mb-6">
-          Coming Soon: Interactive AI Chatbot Widget
+        <div className="p-4 bg-white/5 border border-white/10 rounded-xl mb-5">
+          <div className="flex items-center gap-2 mb-4">
+            <Wand2 size={16} className="text-[#6C5DD3]" />
+            <h3 className="text-sm font-semibold text-white">
+              Deposit Recommendation Wizard
+            </h3>
+          </div>
+          <DepositWizard />
         </div>
 
         {/* Risk Badge Integration Demo */}

--- a/client/src/components/AIAdvisor/DepositWizard.tsx
+++ b/client/src/components/AIAdvisor/DepositWizard.tsx
@@ -1,0 +1,275 @@
+/**
+ * DepositWizard – multi-step risk-adjusted deposit recommendation wizard.
+ *
+ * Steps:
+ *   1. Risk tolerance  (conservative / balanced / aggressive)
+ *   2. Time horizon    (short / medium / long)
+ *   3. Liquidity needs (high / medium / low)
+ *   4. Results         (ranked vault recommendations with explanations)
+ */
+import { useState } from "react";
+import { ChevronRight, ChevronLeft, Loader2, ShieldCheck, TrendingUp, Droplets } from "lucide-react";
+import { apiUrl } from "../../lib/api";
+
+type Profile = "conservative" | "balanced" | "aggressive";
+type TimeHorizon = "short" | "medium" | "long";
+type Liquidity = "high" | "medium" | "low";
+
+interface Recommendation {
+  rank: number;
+  id: string;
+  name: string;
+  strategyType: string;
+  apy: number;
+  tvlUsd: number;
+  riskScore: number;
+  riskAdjustedYield: number;
+  ilVolatilityPct: number;
+  explanation: string;
+}
+
+interface WizardResult {
+  profile: string;
+  timeHorizon: string;
+  liquidity: string;
+  recommendations: Recommendation[];
+}
+
+const STEP_COUNT = 3;
+
+function OptionButton({
+  label,
+  description,
+  selected,
+  onClick,
+}: {
+  label: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`w-full text-left p-4 rounded-xl border transition-all ${
+        selected
+          ? "border-[#6C5DD3] bg-[#6C5DD3]/20 text-white"
+          : "border-white/10 bg-white/5 text-gray-300 hover:border-[#6C5DD3]/50"
+      }`}
+    >
+      <p className="font-semibold text-sm">{label}</p>
+      <p className="text-xs text-gray-400 mt-0.5">{description}</p>
+    </button>
+  );
+}
+
+export default function DepositWizard() {
+  const [step, setStep] = useState(0);
+  const [profile, setProfile] = useState<Profile>("balanced");
+  const [timeHorizon, setTimeHorizon] = useState<TimeHorizon>("medium");
+  const [liquidity, setLiquidity] = useState<Liquidity>("medium");
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<WizardResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchRecommendations() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(apiUrl("/api/wizard/recommend"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ profile, timeHorizon, liquidity }),
+      });
+      if (!res.ok) throw new Error(`Server error ${res.status}`);
+      const data: WizardResult = await res.json();
+      setResult(data);
+      setStep(STEP_COUNT + 1);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to fetch recommendations.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function reset() {
+    setStep(0);
+    setResult(null);
+    setError(null);
+  }
+
+  const steps = [
+    {
+      icon: <ShieldCheck size={20} className="text-[#6C5DD3]" />,
+      title: "Risk Tolerance",
+      content: (
+        <div className="space-y-3">
+          {(
+            [
+              ["conservative", "Conservative", "Prioritise capital preservation. Lower APY, minimal volatility."],
+              ["balanced", "Balanced", "Mix of yield and safety. Moderate risk exposure."],
+              ["aggressive", "Aggressive", "Maximise yield. Higher volatility and drawdown accepted."],
+            ] as [Profile, string, string][]
+          ).map(([val, label, desc]) => (
+            <OptionButton
+              key={val}
+              label={label}
+              description={desc}
+              selected={profile === val}
+              onClick={() => setProfile(val)}
+            />
+          ))}
+        </div>
+      ),
+    },
+    {
+      icon: <TrendingUp size={20} className="text-[#6C5DD3]" />,
+      title: "Time Horizon",
+      content: (
+        <div className="space-y-3">
+          {(
+            [
+              ["short", "Short (< 1 month)", "Need funds available soon. Prefer high-TVL, liquid vaults."],
+              ["medium", "Medium (1–6 months)", "Balanced between flexibility and yield optimisation."],
+              ["long", "Long (6+ months)", "Can lock funds for extended periods to maximise compounding."],
+            ] as [TimeHorizon, string, string][]
+          ).map(([val, label, desc]) => (
+            <OptionButton
+              key={val}
+              label={label}
+              description={desc}
+              selected={timeHorizon === val}
+              onClick={() => setTimeHorizon(val)}
+            />
+          ))}
+        </div>
+      ),
+    },
+    {
+      icon: <Droplets size={20} className="text-[#6C5DD3]" />,
+      title: "Liquidity Needs",
+      content: (
+        <div className="space-y-3">
+          {(
+            [
+              ["high", "High", "May need to withdraw at any time. Avoid high-IL vaults."],
+              ["medium", "Medium", "Occasional withdrawals expected. Standard liquidity."],
+              ["low", "Low", "Comfortable with illiquid positions for better yield."],
+            ] as [Liquidity, string, string][]
+          ).map(([val, label, desc]) => (
+            <OptionButton
+              key={val}
+              label={label}
+              description={desc}
+              selected={liquidity === val}
+              onClick={() => setLiquidity(val)}
+            />
+          ))}
+        </div>
+      ),
+    },
+  ];
+
+  // Results view
+  if (step === STEP_COUNT + 1 && result) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h3 className="text-base font-semibold text-white">Top Vault Recommendations</h3>
+          <button onClick={reset} className="text-xs text-[#6C5DD3] hover:underline">
+            Start over
+          </button>
+        </div>
+        {result.recommendations.map((rec) => (
+          <div
+            key={rec.id}
+            className="rounded-xl border border-white/10 bg-white/5 p-4 space-y-2"
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-xs font-bold text-[#6C5DD3] uppercase tracking-wider">
+                #{rec.rank}
+              </span>
+              <span className="text-xs text-gray-400">{rec.strategyType}</span>
+            </div>
+            <p className="text-sm font-semibold text-white">{rec.name}</p>
+            <div className="flex gap-4 text-xs text-gray-400">
+              <span>APY: <span className="text-green-400 font-medium">{rec.apy.toFixed(2)}%</span></span>
+              <span>Risk: <span className="text-white font-medium">{rec.riskScore}/10</span></span>
+              <span>RAY: <span className="text-[#6C5DD3] font-medium">{rec.riskAdjustedYield.toFixed(4)}</span></span>
+            </div>
+            <p className="text-xs text-gray-400 leading-relaxed">{rec.explanation}</p>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const current = steps[step];
+
+  return (
+    <div className="space-y-5">
+      {/* Progress */}
+      <div className="flex items-center gap-2">
+        {steps.map((s, i) => (
+          <div key={i} className="flex items-center gap-2">
+            <div
+              className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-bold transition-colors ${
+                i < step
+                  ? "bg-[#6C5DD3] text-white"
+                  : i === step
+                  ? "border-2 border-[#6C5DD3] text-[#6C5DD3]"
+                  : "border border-white/20 text-gray-500"
+              }`}
+            >
+              {i + 1}
+            </div>
+            {i < steps.length - 1 && (
+              <div className={`h-px w-8 ${i < step ? "bg-[#6C5DD3]" : "bg-white/10"}`} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Step header */}
+      <div className="flex items-center gap-2">
+        {current.icon}
+        <h3 className="text-sm font-semibold text-white">{current.title}</h3>
+      </div>
+
+      {/* Step content */}
+      {current.content}
+
+      {/* Error */}
+      {error && <p className="text-xs text-red-400">{error}</p>}
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-2">
+        <button
+          onClick={() => setStep((s) => s - 1)}
+          disabled={step === 0}
+          className="flex items-center gap-1 text-xs text-gray-400 hover:text-white disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          <ChevronLeft size={14} /> Back
+        </button>
+
+        {step < STEP_COUNT - 1 ? (
+          <button
+            onClick={() => setStep((s) => s + 1)}
+            className="flex items-center gap-1 text-xs bg-[#6C5DD3] text-white px-4 py-2 rounded-lg hover:bg-[#5a4bc2]"
+          >
+            Next <ChevronRight size={14} />
+          </button>
+        ) : (
+          <button
+            onClick={fetchRecommendations}
+            disabled={loading}
+            className="flex items-center gap-1 text-xs bg-[#6C5DD3] text-white px-4 py-2 rounded-lg hover:bg-[#5a4bc2] disabled:opacity-60"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : null}
+            Get Recommendations <ChevronRight size={14} />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/__tests__/DepositWizard.test.tsx
+++ b/client/src/components/__tests__/DepositWizard.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import DepositWizard from "../AIAdvisor/DepositWizard";
+
+const mockRecommendations = (profile: string) => ({
+  profile,
+  timeHorizon: "medium",
+  liquidity: "medium",
+  recommendations: [
+    {
+      rank: 1,
+      id: "blend",
+      name: "Blend USDC Vault",
+      strategyType: "blend",
+      apy: 8.5,
+      tvlUsd: 2500000,
+      riskScore: 8,
+      riskAdjustedYield: 0.72,
+      ilVolatilityPct: 3,
+      explanation: `Ranked #1 for a ${profile} profile.`,
+    },
+  ],
+});
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => mockRecommendations("balanced"),
+    }),
+  );
+});
+
+describe("DepositWizard", () => {
+  it("renders step 1 with risk tolerance options", () => {
+    render(<DepositWizard />);
+    expect(screen.getByText("Risk Tolerance")).toBeInTheDocument();
+    expect(screen.getByText("Conservative")).toBeInTheDocument();
+    expect(screen.getByText("Balanced")).toBeInTheDocument();
+    expect(screen.getByText("Aggressive")).toBeInTheDocument();
+  });
+
+  it("advances to step 2 on Next click", () => {
+    render(<DepositWizard />);
+    fireEvent.click(screen.getByText(/Next/i));
+    expect(screen.getByText("Time Horizon")).toBeInTheDocument();
+  });
+
+  it("advances to step 3 on second Next click", () => {
+    render(<DepositWizard />);
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Next/i));
+    expect(screen.getByText("Liquidity Needs")).toBeInTheDocument();
+  });
+
+  it("calls the wizard API and shows recommendations", async () => {
+    render(<DepositWizard />);
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Get Recommendations/i));
+
+    await waitFor(() => {
+      expect(screen.getByText("Top Vault Recommendations")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Blend USDC Vault")).toBeInTheDocument();
+  });
+
+  it("shows an error message when the API fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 500 }),
+    );
+    render(<DepositWizard />);
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Get Recommendations/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Server error 500/i)).toBeInTheDocument();
+    });
+  });
+
+  it("can restart the wizard from the results view", async () => {
+    render(<DepositWizard />);
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Next/i));
+    fireEvent.click(screen.getByText(/Get Recommendations/i));
+
+    await waitFor(() => screen.getByText("Top Vault Recommendations"));
+    fireEvent.click(screen.getByText("Start over"));
+    expect(screen.getByText("Risk Tolerance")).toBeInTheDocument();
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -42,6 +42,7 @@ import analyticsRouter from "./routes/analytics";
 import fragmentationRouter from "./routes/fragmentation";
 import indexerRouter from "./routes/indexer";
 import rewardsRouter from "./routes/rewards";
+import wizardRouter from "./routes/wizard";
 import { createAuthChallenge, verifyAuthChallenge } from "./utils/stellarAuth";
 import {
   getRecommendationTimeline,
@@ -130,6 +131,7 @@ export function createApp() {
   app.use("/api/liquidity", fragmentationRouter);
   app.use("/api/indexer", indexerRouter);
   app.use("/api/rewards", rewardsRouter);
+  app.use("/api/wizard", wizardRouter);
 
   // Legacy JSON metrics (internal tooling)
   app.get("/api/metrics", getMetrics);

--- a/server/src/routes/__tests__/wizard.test.ts
+++ b/server/src/routes/__tests__/wizard.test.ts
@@ -1,0 +1,74 @@
+import { rankStrategies } from "../../services/riskAdjustedYieldService";
+import { DrawdownToleranceProfile } from "../../services/drawdownService";
+
+// Test the core ranking logic used by the wizard for all three profiles
+describe("Risk-Adjusted Wizard – rankStrategies profiles", () => {
+  const strategies = [
+    {
+      id: "safe",
+      name: "Safe Vault",
+      strategyType: "blend",
+      apy: 6,
+      tvlUsd: 3_000_000,
+      ilVolatilityPct: 2,
+      riskScore: 9,
+      historicalDepthDays: 365,
+    },
+    {
+      id: "mid",
+      name: "Mid Vault",
+      strategyType: "soroswap",
+      apy: 15,
+      tvlUsd: 800_000,
+      ilVolatilityPct: 18,
+      riskScore: 6,
+      historicalDepthDays: 180,
+    },
+    {
+      id: "risky",
+      name: "Risky Vault",
+      strategyType: "soroswap",
+      apy: 40,
+      tvlUsd: 200_000,
+      ilVolatilityPct: 50,
+      riskScore: 3,
+      historicalDepthDays: 90,
+    },
+  ];
+
+  it("conservative profile ranks the safest vault first", () => {
+    const ranked = rankStrategies(strategies, "conservative" as DrawdownToleranceProfile);
+    expect(ranked[0].id).toBe("safe");
+    expect(ranked[0].rank).toBe(1);
+  });
+
+  it("balanced profile produces a middle-ground ranking", () => {
+    const ranked = rankStrategies(strategies, "balanced" as DrawdownToleranceProfile);
+    // safe or mid should lead; risky should not be #1
+    expect(ranked[0].id).not.toBe("risky");
+    expect(ranked.map((r) => r.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("aggressive (tolerant) profile allows high-yield vaults to rank higher", () => {
+    const ranked = rankStrategies(strategies, "tolerant" as DrawdownToleranceProfile);
+    // risky vault should rank higher than in conservative
+    const riskyRankAggressive = ranked.find((r) => r.id === "risky")!.rank;
+    const conservativeRanked = rankStrategies(strategies, "conservative");
+    const riskyRankConservative = conservativeRanked.find((r) => r.id === "risky")!.rank;
+    expect(riskyRankAggressive).toBeLessThanOrEqual(riskyRankConservative);
+  });
+
+  it("all ranked strategies have riskAdjustedYield >= 0", () => {
+    for (const profile of ["conservative", "balanced", "tolerant"] as DrawdownToleranceProfile[]) {
+      const ranked = rankStrategies(strategies, profile);
+      ranked.forEach((r) => {
+        expect(r.riskAdjustedYield).toBeGreaterThanOrEqual(0);
+      });
+    }
+  });
+
+  it("returns strategies in ascending rank order (1, 2, 3)", () => {
+    const ranked = rankStrategies(strategies, "balanced");
+    expect(ranked.map((r) => r.rank)).toEqual([1, 2, 3]);
+  });
+});

--- a/server/src/routes/wizard.ts
+++ b/server/src/routes/wizard.ts
@@ -1,0 +1,177 @@
+/**
+ * POST /api/wizard/recommend
+ *
+ * Accepts a risk profile from the multi-step deposit wizard and returns
+ * ranked vault suggestions with explanations.
+ *
+ * Body:
+ *   profile      — "conservative" | "balanced" | "aggressive"
+ *   timeHorizon  — "short" | "medium" | "long"
+ *   liquidity    — "high" | "medium" | "low"
+ */
+import { Router, Request, Response } from "express";
+import {
+  rankStrategies,
+  StrategyInput,
+} from "../services/riskAdjustedYieldService";
+import { DrawdownToleranceProfile } from "../services/drawdownService";
+
+const router = Router();
+
+// Map wizard "aggressive" to the internal "tolerant" profile
+function toDrawdownProfile(profile: string): DrawdownToleranceProfile {
+  if (profile === "conservative") return "conservative";
+  if (profile === "aggressive") return "tolerant";
+  return "balanced";
+}
+
+// Liquidity multiplier: high-liquidity users prefer lower-volatility vaults
+function liquidityPenalty(liquidity: string, ilVolatilityPct: number): number {
+  if (liquidity === "high") return ilVolatilityPct > 10 ? 0.7 : 1.0;
+  if (liquidity === "low") return 1.0;
+  return ilVolatilityPct > 20 ? 0.85 : 1.0;
+}
+
+// Time-horizon multiplier: short-horizon users penalise low-TVL vaults
+function horizonMultiplier(timeHorizon: string, tvlUsd: number): number {
+  if (timeHorizon === "short") return tvlUsd < 100_000 ? 0.8 : 1.0;
+  if (timeHorizon === "long") return 1.0;
+  return tvlUsd < 50_000 ? 0.9 : 1.0;
+}
+
+function buildExplanation(
+  strategy: StrategyInput & { rank: number; riskAdjustedYield: number },
+  profile: string,
+  timeHorizon: string,
+  liquidity: string,
+): string {
+  const parts: string[] = [];
+  parts.push(
+    `Ranked #${strategy.rank} for a ${profile} profile with ${timeHorizon} time horizon.`,
+  );
+  parts.push(
+    `APY ${strategy.apy.toFixed(2)}% adjusted to ${strategy.riskAdjustedYield.toFixed(4)} after risk scoring (${strategy.riskScore}/10).`,
+  );
+  if (liquidity === "high" && strategy.ilVolatilityPct > 10) {
+    parts.push(
+      "IL volatility is elevated; a liquidity discount was applied because you need quick access.",
+    );
+  }
+  if (timeHorizon === "short" && strategy.tvlUsd < 100_000) {
+    parts.push(
+      "TVL is relatively low; a short-horizon penalty was applied to favour deeper liquidity.",
+    );
+  }
+  return parts.join(" ");
+}
+
+// Seed strategies (in production these would come from the yield service)
+const SEED_STRATEGIES: StrategyInput[] = [
+  {
+    id: "blend",
+    name: "Blend USDC Vault",
+    strategyType: "blend",
+    apy: 8.5,
+    tvlUsd: 2_500_000,
+    ilVolatilityPct: 3,
+    riskScore: 8,
+    fetchedAt: new Date().toISOString(),
+    historicalDepthDays: 365,
+  },
+  {
+    id: "soroswap-xlm-usdc",
+    name: "Soroswap XLM/USDC LP",
+    strategyType: "soroswap",
+    apy: 18.2,
+    tvlUsd: 800_000,
+    ilVolatilityPct: 22,
+    riskScore: 5,
+    fetchedAt: new Date().toISOString(),
+    historicalDepthDays: 180,
+  },
+  {
+    id: "defindex-stable",
+    name: "DeFindex Stable Basket",
+    strategyType: "defindex",
+    apy: 6.1,
+    tvlUsd: 4_200_000,
+    ilVolatilityPct: 1.5,
+    riskScore: 9,
+    fetchedAt: new Date().toISOString(),
+    historicalDepthDays: 365,
+  },
+  {
+    id: "soroswap-aqua-xlm",
+    name: "Soroswap AQUA/XLM LP",
+    strategyType: "soroswap",
+    apy: 34.7,
+    tvlUsd: 320_000,
+    ilVolatilityPct: 45,
+    riskScore: 3,
+    fetchedAt: new Date().toISOString(),
+    historicalDepthDays: 90,
+  },
+  {
+    id: "blend-xlm",
+    name: "Blend XLM Vault",
+    strategyType: "blend",
+    apy: 11.3,
+    tvlUsd: 1_100_000,
+    ilVolatilityPct: 8,
+    riskScore: 7,
+    fetchedAt: new Date().toISOString(),
+    historicalDepthDays: 270,
+  },
+];
+
+router.post("/recommend", (req: Request, res: Response): void => {
+  const { profile = "balanced", timeHorizon = "medium", liquidity = "medium" } =
+    req.body as {
+      profile?: string;
+      timeHorizon?: string;
+      liquidity?: string;
+    };
+
+  const validProfiles = ["conservative", "balanced", "aggressive"];
+  const validHorizons = ["short", "medium", "long"];
+  const validLiquidity = ["high", "medium", "low"];
+
+  if (
+    !validProfiles.includes(profile) ||
+    !validHorizons.includes(timeHorizon) ||
+    !validLiquidity.includes(liquidity)
+  ) {
+    res.status(400).json({ error: "Invalid wizard parameters." });
+    return;
+  }
+
+  const drawdownProfile = toDrawdownProfile(profile);
+
+  // Apply liquidity and horizon adjustments to a copy of the seed strategies
+  const adjusted = SEED_STRATEGIES.map((s) => ({
+    ...s,
+    apy:
+      s.apy *
+      liquidityPenalty(liquidity, s.ilVolatilityPct) *
+      horizonMultiplier(timeHorizon, s.tvlUsd),
+  }));
+
+  const ranked = rankStrategies(adjusted, drawdownProfile);
+
+  const recommendations = ranked.slice(0, 3).map((s) => ({
+    rank: s.rank,
+    id: s.id,
+    name: s.name,
+    strategyType: s.strategyType,
+    apy: SEED_STRATEGIES.find((x) => x.id === s.id)!.apy, // original APY
+    tvlUsd: s.tvlUsd,
+    riskScore: s.riskScore,
+    riskAdjustedYield: s.riskAdjustedYield,
+    ilVolatilityPct: s.ilVolatilityPct,
+    explanation: buildExplanation(s, profile, timeHorizon, liquidity),
+  }));
+
+  res.json({ profile, timeHorizon, liquidity, recommendations });
+});
+
+export default router;


### PR DESCRIPTION
closes #503 

## Summary

Implements issue #503: Risk-Adjusted Deposit Recommendation Wizard.

## Changes

**Server**
- `server/src/routes/wizard.ts` — `POST /api/wizard/recommend` endpoint that accepts `profile` (conservative/balanced/aggressive), `timeHorizon` (short/medium/long), and `liquidity` (high/medium/low), then returns top-3 ranked vault suggestions with per-vault explanations
- Reuses `rankStrategies()` from `riskAdjustedYieldService` with the appropriate `DrawdownToleranceProfile`; maps wizard "aggressive" → internal "tolerant"
- Applies liquidity and time-horizon multipliers before ranking
- Registered at `/api/wizard` in `app.ts`

**Client**
- `client/src/components/AIAdvisor/DepositWizard.tsx` — 3-step wizard UI (risk tolerance → time horizon → liquidity needs → results) embedded in `AIAdvisor.tsx`, replacing the "Coming Soon" placeholder

**Tests**
- `server/src/routes/__tests__/wizard.test.ts` — covers conservative, balanced, and aggressive profiles; verifies rank ordering and non-negative RAY scores
- `client/src/components/__tests__/DepositWizard.test.tsx` — covers step navigation, API call, error handling, and restart flow

## Acceptance Criteria
- [x] Multi-step wizard UI
- [x] Calls/reuses risk-adjusted yield scoring logic
- [x] Explains why each recommendation was selected
- [x] Tests for conservative, balanced, and aggressive profiles