### PR TITLE
feat(#504): add provider failover incident history

### DIFF
--- a/client/src/pages/transparency/TransparencyDashboard.test.tsx
+++ b/client/src/pages/transparency/TransparencyDashboard.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import TransparencyDashboard from "../TransparencyDashboard";
+
+const mockTransparencyData = {
+  totalRevenueLumens: 372000,
+  totalBurnedTokens: 96000,
+  deflationaryRatio: 32,
+  history: Array.from({ length: 30 }, (_, i) => ({
+    date: `2026-04-${String(i + 1).padStart(2, "0")}`,
+    revenue: 12000 + i * 100,
+    burned: 3200 + i * 10,
+  })),
+};
+
+function makeFetchMock(incidents: unknown[]) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (String(url).includes("failover-history")) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ incidents }),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      json: async () => mockTransparencyData,
+    });
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal("localStorage", {
+    getItem: vi.fn().mockReturnValue(null),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+  });
+});
+
+describe("TransparencyDashboard – failover incident history", () => {
+  it("shows 'No failover incidents recorded' when history is empty", async () => {
+    vi.stubGlobal("fetch", makeFetchMock([]));
+    render(<TransparencyDashboard />);
+    await waitFor(() =>
+      expect(screen.getByText("Provider Failover Incident History")).toBeInTheDocument(),
+    );
+    expect(screen.getByText("No failover incidents recorded.")).toBeInTheDocument();
+  });
+
+  it("renders an active incident", async () => {
+    const incidents = [
+      {
+        id: "1",
+        protocolId: "blend",
+        protocolName: "Blend",
+        trigger: "stale_data",
+        reasons: ["data is stale"],
+        startedAt: "2026-05-01T10:00:00.000Z",
+        resolved: false,
+      },
+    ];
+    vi.stubGlobal("fetch", makeFetchMock(incidents));
+    render(<TransparencyDashboard />);
+    await waitFor(() => expect(screen.getByText("Blend")).toBeInTheDocument());
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText(/stale data/i)).toBeInTheDocument();
+  });
+
+  it("renders a recovered incident with duration", async () => {
+    const incidents = [
+      {
+        id: "2",
+        protocolId: "soroswap",
+        protocolName: "Soroswap",
+        trigger: "outage",
+        reasons: ["status=down"],
+        startedAt: "2026-05-01T10:00:00.000Z",
+        recoveredAt: "2026-05-01T10:05:00.000Z",
+        durationMs: 300000,
+        resolved: true,
+      },
+    ];
+    vi.stubGlobal("fetch", makeFetchMock(incidents));
+    render(<TransparencyDashboard />);
+    await waitFor(() => expect(screen.getByText("Soroswap")).toBeInTheDocument());
+    expect(screen.getByText("Recovered")).toBeInTheDocument();
+    expect(screen.getByText(/300s outage/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/transparency/TransparencyDashboard.tsx
+++ b/client/src/pages/transparency/TransparencyDashboard.tsx
@@ -13,7 +13,7 @@
  * the first fetch is in flight.
  */
 import { useState, useEffect } from "react";
-import { Loader2, TrendingUp, Flame, BarChart2 } from "lucide-react";
+import { Loader2, TrendingUp, Flame, BarChart2, AlertTriangle, CheckCircle, Clock } from "lucide-react";
 import {
     LineChart,
     Line,
@@ -42,6 +42,18 @@ interface TransparencyData {
     totalBurnedTokens: number;
     deflationaryRatio: number;
     history: HistoryPoint[];
+}
+
+interface FailoverIncident {
+    id: string;
+    protocolId: string;
+    protocolName: string;
+    trigger: string;
+    reasons: string[];
+    startedAt: string;
+    recoveredAt?: string;
+    durationMs?: number;
+    resolved: boolean;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -99,6 +111,7 @@ export default function TransparencyDashboard() {
     const [error, setError] = useState<string | null>(null);
     const [smokeStatus, setSmokeStatus] = useState<ReturnType<typeof parseSmokeRunResult>>(null);
     const [smokeHistory, setSmokeHistory] = useState<Array<ReturnType<typeof parseSmokeRunResult>>>([]);
+    const [failoverIncidents, setFailoverIncidents] = useState<FailoverIncident[]>([]);
 
     useEffect(() => {
         async function fetchData() {
@@ -139,6 +152,13 @@ export default function TransparencyDashboard() {
                 setSmokeHistory([]);
             }
         }
+    }, []);
+
+    useEffect(() => {
+        fetch(`${API_BASE}/api/transparency/failover-history`)
+            .then((res) => (res.ok ? res.json() : Promise.resolve({ incidents: [] })))
+            .then((data: { incidents: FailoverIncident[] }) => setFailoverIncidents(data.incidents))
+            .catch(() => setFailoverIncidents([]));
     }, []);
 
     // ── Truncate X-axis labels to MM/DD ───────────────────────────────────
@@ -266,6 +286,65 @@ export default function TransparencyDashboard() {
                         />
                     </LineChart>
                 </ResponsiveContainer>
+            </div>
+
+            <div className="glass-panel rounded-2xl p-6">
+                <div className="flex items-center gap-2 mb-4">
+                    <AlertTriangle size={18} className="text-amber-400" />
+                    <h3 className="font-semibold text-white">Provider Failover Incident History</h3>
+                </div>
+                {failoverIncidents.length === 0 ? (
+                    <p className="text-sm text-gray-400">No failover incidents recorded.</p>
+                ) : (
+                    <ul className="space-y-3">
+                        {failoverIncidents.slice(0, 10).map((inc) => (
+                            <li
+                                key={inc.id}
+                                className={`rounded-xl border p-3 ${
+                                    inc.resolved
+                                        ? "border-green-500/20 bg-green-500/5"
+                                        : "border-amber-500/20 bg-amber-500/5"
+                                }`}
+                            >
+                                <div className="flex items-center justify-between mb-1">
+                                    <span className="text-sm font-semibold text-white">
+                                        {inc.protocolName}
+                                    </span>
+                                    <span
+                                        className={`flex items-center gap-1 text-xs font-medium ${
+                                            inc.resolved ? "text-green-400" : "text-amber-400"
+                                        }`}
+                                    >
+                                        {inc.resolved ? (
+                                            <><CheckCircle size={12} /> Recovered</>
+                                        ) : (
+                                            <><Clock size={12} /> Active</>
+                                        )}
+                                    </span>
+                                </div>
+                                <p className="text-xs text-gray-400 capitalize">
+                                    Trigger: {inc.trigger.replace("_", " ")}
+                                </p>
+                                <p className="text-xs text-gray-500 mt-0.5">
+                                    Started: {new Date(inc.startedAt).toLocaleString()}
+                                </p>
+                                {inc.recoveredAt && (
+                                    <p className="text-xs text-green-400 mt-0.5">
+                                        Recovered: {new Date(inc.recoveredAt).toLocaleString()}
+                                        {inc.durationMs !== undefined && (
+                                            <> ({Math.round(inc.durationMs / 1000)}s outage)</>
+                                        )}
+                                    </p>
+                                )}
+                                {inc.reasons.length > 0 && (
+                                    <p className="text-xs text-gray-500 mt-1 truncate">
+                                        {inc.reasons[0]}
+                                    </p>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </div>
 
             <div className="glass-panel rounded-2xl p-6">

--- a/server/src/routes/transparency.ts
+++ b/server/src/routes/transparency.ts
@@ -11,6 +11,7 @@
  * on every page load.
  */
 import { Router, Request, Response } from "express";
+import { failoverIncidentHistoryService } from "../services/failoverIncidentHistoryService";
 
 const transparencyRouter = Router();
 
@@ -102,6 +103,70 @@ transparencyRouter.get(
             res.status(500).json({ error: "Unable to fetch transparency data." });
         }
     },
+);
+
+/**
+ * GET /api/transparency/failover-history
+ *
+ * Returns the in-memory failover incident history, newest first.
+ * Optional query param: ?protocolId=<id>
+ */
+transparencyRouter.get(
+  "/failover-history",
+  (req: Request, res: Response): void => {
+    const protocolId = req.query.protocolId as string | undefined;
+    res.json({ incidents: failoverIncidentHistoryService.getHistory(protocolId) });
+  },
+);
+
+/**
+ * POST /api/transparency/failover-history
+ *
+ * Record a new failover incident.
+ * Body: { protocolId, protocolName, reasons, startedAt? }
+ */
+transparencyRouter.post(
+  "/failover-history",
+  (req: Request, res: Response): void => {
+    const { protocolId, protocolName, reasons, startedAt } = req.body as {
+      protocolId?: string;
+      protocolName?: string;
+      reasons?: string[];
+      startedAt?: string;
+    };
+    if (!protocolId || !protocolName || !Array.isArray(reasons)) {
+      res.status(400).json({ error: "protocolId, protocolName, and reasons are required." });
+      return;
+    }
+    const incident = failoverIncidentHistoryService.recordIncident({
+      protocolId,
+      protocolName,
+      reasons,
+      startedAt,
+    });
+    res.status(201).json(incident);
+  },
+);
+
+/**
+ * POST /api/transparency/failover-history/:protocolId/resolve
+ *
+ * Mark the most recent open incident for a protocol as resolved.
+ */
+transparencyRouter.post(
+  "/failover-history/:protocolId/resolve",
+  (req: Request, res: Response): void => {
+    const { recoveredAt } = req.body as { recoveredAt?: string };
+    const incident = failoverIncidentHistoryService.resolveIncident(
+      req.params.protocolId,
+      recoveredAt,
+    );
+    if (!incident) {
+      res.status(404).json({ error: "No open incident found for this protocol." });
+      return;
+    }
+    res.json(incident);
+  },
 );
 
 export { aggregateTransparencyData };

--- a/server/src/services/__tests__/failoverIncidentHistoryService.test.ts
+++ b/server/src/services/__tests__/failoverIncidentHistoryService.test.ts
@@ -1,0 +1,132 @@
+import { failoverIncidentHistoryService } from "../../services/failoverIncidentHistoryService";
+
+beforeEach(() => {
+  failoverIncidentHistoryService.reset();
+});
+
+describe("failoverIncidentHistoryService", () => {
+  describe("recordIncident", () => {
+    it("creates an incident with the correct fields", () => {
+      const incident = failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["data is stale (age=360000ms > maxDataAgeMs=300000ms)"],
+      });
+
+      expect(incident.protocolId).toBe("blend");
+      expect(incident.protocolName).toBe("Blend");
+      expect(incident.trigger).toBe("stale_data");
+      expect(incident.resolved).toBe(false);
+      expect(incident.recoveredAt).toBeUndefined();
+      expect(incident.id).toBeDefined();
+    });
+
+    it("classifies outage trigger from reasons", () => {
+      const incident = failoverIncidentHistoryService.recordIncident({
+        protocolId: "soroswap",
+        protocolName: "Soroswap",
+        reasons: ["status=down"],
+      });
+      expect(incident.trigger).toBe("outage");
+    });
+
+    it("classifies degraded trigger from uptime reasons", () => {
+      const incident = failoverIncidentHistoryService.recordIncident({
+        protocolId: "defindex",
+        protocolName: "DeFindex",
+        reasons: ["uptime=0.90 < minUptimeRatio=0.95"],
+      });
+      expect(incident.trigger).toBe("degraded");
+    });
+
+    it("accepts a custom startedAt timestamp", () => {
+      const ts = "2026-01-01T00:00:00.000Z";
+      const incident = failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["status=down"],
+        startedAt: ts,
+      });
+      expect(incident.startedAt).toBe(ts);
+    });
+  });
+
+  describe("resolveIncident", () => {
+    it("marks the open incident as resolved and sets durationMs", () => {
+      const startedAt = "2026-01-01T00:00:00.000Z";
+      const recoveredAt = "2026-01-01T00:05:00.000Z";
+
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["status=down"],
+        startedAt,
+      });
+
+      const resolved = failoverIncidentHistoryService.resolveIncident("blend", recoveredAt);
+
+      expect(resolved).not.toBeNull();
+      expect(resolved!.resolved).toBe(true);
+      expect(resolved!.recoveredAt).toBe(recoveredAt);
+      expect(resolved!.durationMs).toBe(5 * 60 * 1000); // 5 minutes
+    });
+
+    it("returns null when there is no open incident for the protocol", () => {
+      const result = failoverIncidentHistoryService.resolveIncident("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("does not resolve an already-resolved incident", () => {
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["status=down"],
+      });
+      failoverIncidentHistoryService.resolveIncident("blend");
+      const second = failoverIncidentHistoryService.resolveIncident("blend");
+      expect(second).toBeNull();
+    });
+  });
+
+  describe("getHistory", () => {
+    it("returns empty array when no incidents exist", () => {
+      expect(failoverIncidentHistoryService.getHistory()).toEqual([]);
+    });
+
+    it("returns incidents newest first", () => {
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["status=down"],
+        startedAt: "2026-01-01T00:00:00.000Z",
+      });
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "soroswap",
+        protocolName: "Soroswap",
+        reasons: ["status=down"],
+        startedAt: "2026-01-02T00:00:00.000Z",
+      });
+
+      const history = failoverIncidentHistoryService.getHistory();
+      expect(history[0].protocolId).toBe("soroswap");
+      expect(history[1].protocolId).toBe("blend");
+    });
+
+    it("filters by protocolId when provided", () => {
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "blend",
+        protocolName: "Blend",
+        reasons: ["status=down"],
+      });
+      failoverIncidentHistoryService.recordIncident({
+        protocolId: "soroswap",
+        protocolName: "Soroswap",
+        reasons: ["status=down"],
+      });
+
+      const history = failoverIncidentHistoryService.getHistory("blend");
+      expect(history).toHaveLength(1);
+      expect(history[0].protocolId).toBe("blend");
+    });
+  });
+});

--- a/server/src/services/failoverIncidentHistoryService.ts
+++ b/server/src/services/failoverIncidentHistoryService.ts
@@ -1,0 +1,96 @@
+/**
+ * Failover Incident History Service
+ *
+ * Records provider failover incidents (stale data, outage, recovery) in an
+ * in-memory store and exposes helpers to create, resolve, and query them.
+ *
+ * Each incident captures:
+ *   - affected protocol
+ *   - trigger reason (stale data / outage / degraded)
+ *   - start time and optional recovery time
+ *   - outage duration (ms) once resolved
+ */
+
+export type FailoverIncidentTrigger = "stale_data" | "outage" | "degraded" | "unknown";
+
+export interface FailoverIncident {
+  id: string;
+  protocolId: string;
+  protocolName: string;
+  trigger: FailoverIncidentTrigger;
+  reasons: string[];
+  startedAt: string;   // ISO-8601
+  recoveredAt?: string; // ISO-8601, set on recovery
+  durationMs?: number;  // set on recovery
+  resolved: boolean;
+}
+
+let _incidents: FailoverIncident[] = [];
+let _nextId = 1;
+
+function triggerFromReasons(reasons: string[]): FailoverIncidentTrigger {
+  const joined = reasons.join(" ").toLowerCase();
+  if (joined.includes("stale")) return "stale_data";
+  if (joined.includes("down") || joined.includes("critical")) return "outage";
+  if (joined.includes("degraded") || joined.includes("uptime")) return "degraded";
+  return "unknown";
+}
+
+export const failoverIncidentHistoryService = {
+  /**
+   * Record a new failover incident. Returns the created incident.
+   */
+  recordIncident(params: {
+    protocolId: string;
+    protocolName: string;
+    reasons: string[];
+    startedAt?: string;
+  }): FailoverIncident {
+    const incident: FailoverIncident = {
+      id: String(_nextId++),
+      protocolId: params.protocolId,
+      protocolName: params.protocolName,
+      trigger: triggerFromReasons(params.reasons),
+      reasons: params.reasons,
+      startedAt: params.startedAt ?? new Date().toISOString(),
+      resolved: false,
+    };
+    _incidents.push(incident);
+    return incident;
+  },
+
+  /**
+   * Mark an open incident for a protocol as resolved.
+   * Returns the updated incident, or null if none was open.
+   */
+  resolveIncident(protocolId: string, recoveredAt?: string): FailoverIncident | null {
+    const incident = _incidents
+      .slice()
+      .reverse()
+      .find((i) => i.protocolId === protocolId && !i.resolved);
+    if (!incident) return null;
+
+    const recoveryTs = recoveredAt ?? new Date().toISOString();
+    incident.recoveredAt = recoveryTs;
+    incident.durationMs =
+      new Date(recoveryTs).getTime() - new Date(incident.startedAt).getTime();
+    incident.resolved = true;
+    return incident;
+  },
+
+  /**
+   * Return all incidents, newest first. Optionally filter by protocolId.
+   */
+  getHistory(protocolId?: string): FailoverIncident[] {
+    const list = protocolId
+      ? _incidents.filter((i) => i.protocolId === protocolId)
+      : _incidents;
+    return list.slice().reverse();
+  },
+
+  /** Reset store (test hook). */
+  reset(): void {
+    _incidents = [];
+    _nextId = 1;
+  },
+};


### PR DESCRIPTION
closes #504 

## Summary

Implements issue #504: Provider Failover Incident History.

## Changes

**Server**
- `server/src/services/failoverIncidentHistoryService.ts` — in-memory store for failover incidents with `recordIncident()`, `resolveIncident()`, and `getHistory()`; auto-classifies trigger type (stale_data / outage / degraded) from reasons
- `server/src/routes/transparency.ts` — three new endpoints:
  - `GET /api/transparency/failover-history` — returns incident list, newest first; optional `?protocolId` filter
  - `POST /api/transparency/failover-history` — record a new incident
  - `POST /api/transparency/failover-history/:protocolId/resolve` — mark open incident as resolved, sets `recoveredAt` and `durationMs`

**Client**
- `client/src/pages/transparency/TransparencyDashboard.tsx` — new "Provider Failover Incident History" panel showing active/recovered status, trigger type, outage duration, and reasons

**Tests**
- `server/src/services/__tests__/failoverIncidentHistoryService.test.ts` — covers incident creation, recovery, empty history, and filtering
- `client/src/pages/transparency/TransparencyDashboard.test.tsx` — covers empty state, active incident, and recovered incident with duration

## Acceptance Criteria
- [x] Record failover incident summaries in memory
- [x] Expose a safe incident history endpoint
- [x] Render incident history in transparency UI
- [x] Tests for incident creation, recovery, and empty history