### PR TITLE
feat: queue health panel, snapshot rollback preview, leaderboard filter persistence, failover simulation

### DIFF
--- a/backend/keepers/src/__tests__/queueHealth.test.ts
+++ b/backend/keepers/src/__tests__/queueHealth.test.ts
@@ -1,0 +1,134 @@
+import { getQueueHealth, QUEUE_HEALTH_THRESHOLDS } from '../queues/health';
+import type { Queue } from 'bullmq';
+
+function makeQueue(name: string, counts: Record<string, number>): Queue {
+  return {
+    name,
+    getJobCounts: jest.fn().mockResolvedValue(counts),
+  } as unknown as Queue;
+}
+
+describe('getQueueHealth', () => {
+  it('returns healthy status when all counts are below thresholds', async () => {
+    const queues = [
+      makeQueue('liquidation', { waiting: 2, active: 1, completed: 50, failed: 0, delayed: 0 }),
+      makeQueue('compound', { waiting: 0, active: 0, completed: 10, failed: 1, delayed: 3 }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.overallStatus).toBe('healthy');
+    expect(summary.queues).toHaveLength(2);
+    expect(summary.queues[0].status).toBe('healthy');
+    expect(summary.queues[0].warnings).toHaveLength(0);
+    expect(summary.queues[1].status).toBe('healthy');
+  });
+
+  it('returns warning when failed jobs exceed threshold', async () => {
+    const failedCount = QUEUE_HEALTH_THRESHOLDS.failed + 1;
+    const queues = [
+      makeQueue('liquidation', { waiting: 0, active: 0, completed: 0, failed: failedCount, delayed: 0 }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.overallStatus).toBe('warning');
+    expect(summary.queues[0].status).toBe('warning');
+    expect(summary.queues[0].warnings).toHaveLength(1);
+    expect(summary.queues[0].warnings[0]).toMatch(/failed jobs/);
+  });
+
+  it('returns warning when delayed jobs exceed threshold', async () => {
+    const delayedCount = QUEUE_HEALTH_THRESHOLDS.delayed + 1;
+    const queues = [
+      makeQueue('compound', { waiting: 0, active: 0, completed: 0, failed: 0, delayed: delayedCount }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.overallStatus).toBe('warning');
+    expect(summary.queues[0].status).toBe('warning');
+    expect(summary.queues[0].warnings[0]).toMatch(/delayed jobs/);
+  });
+
+  it('emits two warnings when both failed and delayed exceed thresholds', async () => {
+    const queues = [
+      makeQueue('liquidation', {
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: QUEUE_HEALTH_THRESHOLDS.failed + 5,
+        delayed: QUEUE_HEALTH_THRESHOLDS.delayed + 10,
+      }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.queues[0].warnings).toHaveLength(2);
+  });
+
+  it('sets overallStatus to warning when at least one queue warns', async () => {
+    const queues = [
+      makeQueue('liquidation', { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 }),
+      makeQueue('compound', {
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: QUEUE_HEALTH_THRESHOLDS.failed + 1,
+        delayed: 0,
+      }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.queues[0].status).toBe('healthy');
+    expect(summary.queues[1].status).toBe('warning');
+    expect(summary.overallStatus).toBe('warning');
+  });
+
+  it('includes all five count fields in each entry', async () => {
+    const queues = [
+      makeQueue('liquidation', { waiting: 3, active: 2, completed: 100, failed: 1, delayed: 4 }),
+    ];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.queues[0].counts).toEqual({
+      waiting: 3,
+      active: 2,
+      completed: 100,
+      failed: 1,
+      delayed: 4,
+    });
+  });
+
+  it('defaults missing count fields to 0', async () => {
+    const queues = [makeQueue('liquidation', {})];
+
+    const summary = await getQueueHealth(queues);
+
+    expect(summary.queues[0].counts).toEqual({
+      waiting: 0,
+      active: 0,
+      completed: 0,
+      failed: 0,
+      delayed: 0,
+    });
+  });
+
+  it('includes a valid ISO timestamp', async () => {
+    const before = Date.now();
+    const summary = await getQueueHealth([makeQueue('liquidation', {})]);
+    const after = Date.now();
+
+    const ts = new Date(summary.timestamp).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('returns results for an empty queue list', async () => {
+    const summary = await getQueueHealth([]);
+    expect(summary.queues).toHaveLength(0);
+    expect(summary.overallStatus).toBe('healthy');
+  });
+});

--- a/backend/keepers/src/queues/health.ts
+++ b/backend/keepers/src/queues/health.ts
@@ -1,0 +1,67 @@
+import { Queue } from 'bullmq';
+
+export interface QueueJobCounts {
+  waiting: number;
+  active: number;
+  completed: number;
+  failed: number;
+  delayed: number;
+}
+
+export interface QueueHealthEntry {
+  name: string;
+  counts: QueueJobCounts;
+  status: 'healthy' | 'warning';
+  warnings: string[];
+}
+
+export interface QueueHealthSummary {
+  queues: QueueHealthEntry[];
+  overallStatus: 'healthy' | 'warning';
+  timestamp: string;
+}
+
+export const QUEUE_HEALTH_THRESHOLDS = {
+  failed: Number(process.env.QUEUE_FAILED_THRESHOLD ?? '10'),
+  delayed: Number(process.env.QUEUE_DELAYED_THRESHOLD ?? '50'),
+} as const;
+
+export async function getQueueHealth(queues: Queue[]): Promise<QueueHealthSummary> {
+  const entries = await Promise.all(
+    queues.map(async (queue): Promise<QueueHealthEntry> => {
+      const raw = await queue.getJobCounts('waiting', 'active', 'completed', 'failed', 'delayed');
+      const counts: QueueJobCounts = {
+        waiting: raw.waiting ?? 0,
+        active: raw.active ?? 0,
+        completed: raw.completed ?? 0,
+        failed: raw.failed ?? 0,
+        delayed: raw.delayed ?? 0,
+      };
+
+      const warnings: string[] = [];
+      if (counts.failed > QUEUE_HEALTH_THRESHOLDS.failed) {
+        warnings.push(
+          `failed jobs (${counts.failed}) exceed threshold (${QUEUE_HEALTH_THRESHOLDS.failed})`,
+        );
+      }
+      if (counts.delayed > QUEUE_HEALTH_THRESHOLDS.delayed) {
+        warnings.push(
+          `delayed jobs (${counts.delayed}) exceed threshold (${QUEUE_HEALTH_THRESHOLDS.delayed})`,
+        );
+      }
+
+      return {
+        name: queue.name,
+        counts,
+        status: warnings.length > 0 ? 'warning' : 'healthy',
+        warnings,
+      };
+    }),
+  );
+
+  return {
+    queues: entries,
+    overallStatus: entries.some((e) => e.status === 'warning') ? 'warning' : 'healthy',
+    timestamp: new Date().toISOString(),
+  };
+}

--- a/backend/keepers/src/queues/index.ts
+++ b/backend/keepers/src/queues/index.ts
@@ -8,6 +8,9 @@ import {
   CompoundJobData,
 } from './types';
 
+export { getQueueHealth } from './health';
+export type { QueueHealthSummary, QueueHealthEntry, QueueJobCounts } from './health';
+
 const defaultJobOptions = {
   attempts: config.keeper.jobMaxAttempts,
   backoff: { type: 'exponential', delay: 5_000 } as const,

--- a/client/src/hooks/useLeaderboardFilters.ts
+++ b/client/src/hooks/useLeaderboardFilters.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from "react";
+
+export const TIME_WINDOWS = ["all", "24h", "7d", "30d"] as const;
+export const STRATEGY_TYPES = ["all", "blend", "soroswap", "defindex"] as const;
+
+export type TimeWindow = (typeof TIME_WINDOWS)[number];
+export type StrategyType = (typeof STRATEGY_TYPES)[number];
+
+export interface LeaderboardFilters {
+  timeWindow: TimeWindow;
+  strategyType: StrategyType;
+}
+
+const STORAGE_KEY = "stellar_yield.leaderboard_filters";
+const DEFAULTS: LeaderboardFilters = { timeWindow: "all", strategyType: "all" };
+
+function isValidTimeWindow(v: unknown): v is TimeWindow {
+  return TIME_WINDOWS.includes(v as TimeWindow);
+}
+
+function isValidStrategyType(v: unknown): v is StrategyType {
+  return STRATEGY_TYPES.includes(v as StrategyType);
+}
+
+function loadFilters(): LeaderboardFilters {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULTS;
+    const parsed = JSON.parse(raw) as unknown;
+    if (typeof parsed !== "object" || parsed === null) return DEFAULTS;
+    const { timeWindow, strategyType } = parsed as Record<string, unknown>;
+    return {
+      timeWindow: isValidTimeWindow(timeWindow) ? timeWindow : DEFAULTS.timeWindow,
+      strategyType: isValidStrategyType(strategyType) ? strategyType : DEFAULTS.strategyType,
+    };
+  } catch {
+    return DEFAULTS;
+  }
+}
+
+function saveFilters(filters: LeaderboardFilters): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(filters));
+  } catch {
+    // Storage may be unavailable (private browsing quota exceeded, etc.)
+  }
+}
+
+export interface UseLeaderboardFiltersReturn {
+  timeWindow: TimeWindow;
+  strategyType: StrategyType;
+  setTimeWindow: (v: TimeWindow) => void;
+  setStrategyType: (v: StrategyType) => void;
+  resetFilters: () => void;
+  isDefault: boolean;
+}
+
+export function useLeaderboardFilters(): UseLeaderboardFiltersReturn {
+  const [filters, setFilters] = useState<LeaderboardFilters>(loadFilters);
+
+  useEffect(() => {
+    saveFilters(filters);
+  }, [filters]);
+
+  const setTimeWindow = useCallback((v: TimeWindow) => {
+    setFilters((prev) => ({ ...prev, timeWindow: v }));
+  }, []);
+
+  const setStrategyType = useCallback((v: StrategyType) => {
+    setFilters((prev) => ({ ...prev, strategyType: v }));
+  }, []);
+
+  const resetFilters = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // ignore
+    }
+    setFilters(DEFAULTS);
+  }, []);
+
+  const isDefault =
+    filters.timeWindow === DEFAULTS.timeWindow &&
+    filters.strategyType === DEFAULTS.strategyType;
+
+  return {
+    timeWindow: filters.timeWindow,
+    strategyType: filters.strategyType,
+    setTimeWindow,
+    setStrategyType,
+    resetFilters,
+    isDefault,
+  };
+}

--- a/client/src/pages/leaderboard/StrategyLeaderboard.tsx
+++ b/client/src/pages/leaderboard/StrategyLeaderboard.tsx
@@ -1,7 +1,12 @@
 import React, { useEffect, useState } from "react";
-import { Trophy, Medal, TrendingUp, Filter, AlertCircle, RefreshCw, BarChart3 } from "lucide-react";
+import { Trophy, Medal, TrendingUp, Filter, AlertCircle, RefreshCw, BarChart3, RotateCcw } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 import { ConfidenceBadge } from "../../components/AIAdvisor/ConfidenceBadge";
+import {
+  useLeaderboardFilters,
+  TIME_WINDOWS,
+  STRATEGY_TYPES,
+} from "../../hooks/useLeaderboardFilters";
 
 interface RankedStrategy {
   rank: number;
@@ -22,15 +27,19 @@ interface LeaderboardResponse {
   scoringMethodology: string;
 }
 
-const TIME_WINDOWS = ["all", "24h", "7d", "30d"] as const;
-const STRATEGY_TYPES = ["all", "blend", "soroswap", "defindex"] as const;
-
 const StrategyLeaderboard: React.FC = () => {
   const [data, setData] = useState<LeaderboardResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [timeWindow, setTimeWindow] = useState<string>("all");
-  const [strategyType, setStrategyType] = useState<string>("all");
+
+  const {
+    timeWindow,
+    strategyType,
+    setTimeWindow,
+    setStrategyType,
+    resetFilters,
+    isDefault,
+  } = useLeaderboardFilters();
 
   // #375 Rotation Confidence Explorer
   const [rotationData, setRotationData] = useState<{
@@ -149,6 +158,16 @@ const StrategyLeaderboard: React.FC = () => {
             </button>
           ))}
         </div>
+        {!isDefault && (
+          <button
+            onClick={resetFilters}
+            className="ml-auto flex items-center gap-1.5 px-3 py-1 rounded-lg text-xs font-semibold text-gray-400 hover:text-white bg-white/5 hover:bg-white/10 transition-colors"
+            title="Reset filters to defaults"
+          >
+            <RotateCcw size={12} />
+            Reset
+          </button>
+        )}
       </div>
 
       {loading ? (

--- a/server/src/__tests__/health.test.ts
+++ b/server/src/__tests__/health.test.ts
@@ -2,6 +2,27 @@ import request from "supertest";
 import express from "express";
 import healthRouter from "../routes/health";
 
+// ── Queue health mocks ──────────────────────────────────────────────────────
+
+const mockGetJobCounts = jest.fn();
+const mockQueueClose = jest.fn().mockResolvedValue(undefined);
+
+jest.mock("bullmq", () => ({
+  Queue: jest.fn().mockImplementation((name: string) => ({
+    name,
+    getJobCounts: mockGetJobCounts,
+    close: mockQueueClose,
+  })),
+}));
+
+jest.mock("ioredis", () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    quit: jest.fn().mockResolvedValue("OK"),
+    status: "ready",
+  })),
+}));
+
 jest.mock("@prisma/client", () => {
   return {
     PrismaClient: jest.fn().mockImplementation(() => ({
@@ -39,6 +60,7 @@ describe("GET /api/health", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.STELLAR_HORIZON_TIMEOUT_MS = "100";
+    mockGetJobCounts.mockResolvedValue({ waiting: 0, active: 0, completed: 10, failed: 0, delayed: 0 });
   });
 
   afterEach(() => {
@@ -59,5 +81,97 @@ describe("GET /api/health", () => {
     const response = await request(app).get("/api/health");
     expect(response.status).toBe(503);
     expect(response.body.horizon).toBe("down");
+  });
+});
+
+describe("GET /api/health/queues", () => {
+  const app = express();
+  app.use("/api/health", healthRouter);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 200 with healthy overall status when all queues are within thresholds", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 2, active: 1, completed: 50, failed: 0, delayed: 0 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(res.status).toBe(200);
+    expect(res.body.overallStatus).toBe("healthy");
+    expect(Array.isArray(res.body.queues)).toBe(true);
+    expect(res.body.queues.length).toBe(6);
+  });
+
+  it("returns 200 with warning status when failed jobs exceed threshold", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 99, delayed: 0 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(res.status).toBe(200);
+    expect(res.body.overallStatus).toBe("warning");
+    for (const entry of res.body.queues) {
+      expect(entry.status).toBe("warning");
+      expect(entry.warnings.some((w: string) => w.includes("failed jobs"))).toBe(true);
+    }
+  });
+
+  it("returns 200 with warning status when delayed jobs exceed threshold", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 99 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(res.status).toBe(200);
+    expect(res.body.overallStatus).toBe("warning");
+    for (const entry of res.body.queues) {
+      expect(entry.warnings.some((w: string) => w.includes("delayed jobs"))).toBe(true);
+    }
+  });
+
+  it("returns 503 when a queue fails to return counts", async () => {
+    mockGetJobCounts.mockRejectedValue(new Error("Redis unavailable"));
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(res.status).toBe(503);
+    expect(res.body.overallStatus).toBe("error");
+    for (const entry of res.body.queues) {
+      expect(entry.status).toBe("error");
+    }
+  });
+
+  it("response includes all five count fields per queue entry", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 3, active: 1, completed: 20, failed: 0, delayed: 2 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(res.status).toBe(200);
+    for (const entry of res.body.queues) {
+      expect(typeof entry.counts.waiting).toBe("number");
+      expect(typeof entry.counts.active).toBe("number");
+      expect(typeof entry.counts.completed).toBe("number");
+      expect(typeof entry.counts.failed).toBe("number");
+      expect(typeof entry.counts.delayed).toBe("number");
+    }
+  });
+
+  it("response includes a timestamp", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    expect(typeof res.body.timestamp).toBe("string");
+    expect(new Date(res.body.timestamp).toString()).not.toBe("Invalid Date");
+  });
+
+  it("each queue entry includes the queue name", async () => {
+    mockGetJobCounts.mockResolvedValue({ waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 });
+
+    const res = await request(app).get("/api/health/queues");
+
+    const names = res.body.queues.map((q: { name: string }) => q.name);
+    expect(names).toContain("liquidation");
+    expect(names).toContain("compound");
+    expect(names).toContain("rebalance-execution");
   });
 });

--- a/server/src/__tests__/strategySnapshotVersioning.test.ts
+++ b/server/src/__tests__/strategySnapshotVersioning.test.ts
@@ -1,5 +1,8 @@
 import { STRATEGY_EVENT_TYPE, VERSION_CHANGE_TYPE } from '../queues/types';
 import { StrategySnapshotVersioningService } from '../services/strategySnapshotVersioningService';
+import request from 'supertest';
+import express from 'express';
+import strategiesRouter from '../routes/strategies';
 
 // Mock Prisma — singleton pattern so the module-level `prisma` and test's
 // mockPrisma reference the same object.
@@ -476,5 +479,225 @@ describe('StrategySnapshotVersioningService', () => {
       expect(oldVersion).toBeDefined();
       expect(oldVersion?.id).toBe('snap-1');
     });
+  });
+
+  describe('Rollback Preview', () => {
+    const baseSnapshot = {
+      id: 'snap-3',
+      strategyId: 'strategy-1',
+      version: 3,
+      name: 'Current Strategy',
+      description: 'Current description',
+      keyWeights: { BTC: 0.5, ETH: 0.3, USDC: 0.2 },
+      riskParameters: { volatility: 0.2 },
+      constraints: { maxAllocation: 0.5 },
+      status: 'ACTIVE',
+      createdAt: new Date(),
+      supersededAt: null,
+      supersededByVersion: null,
+      changeReason: null,
+      changeAuthor: null,
+    };
+
+    const targetSnapshot = {
+      id: 'snap-1',
+      strategyId: 'strategy-1',
+      version: 1,
+      name: 'Original Strategy',
+      description: 'Original description',
+      keyWeights: { BTC: 0.4, ETH: 0.3, USDC: 0.3 },
+      riskParameters: { volatility: 0.25 },
+      constraints: { maxAllocation: 0.5 },
+      status: 'SUPERSEDED',
+      createdAt: new Date(),
+      supersededAt: new Date(),
+      supersededByVersion: 2,
+      changeReason: null,
+      changeAuthor: null,
+    };
+
+    it('returns changed fields between current and target snapshot', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)   // current ACTIVE
+        .mockResolvedValueOnce(targetSnapshot); // target version
+
+      const preview = await service.previewRollback('strategy-1', 1);
+
+      expect(preview.currentVersion).toBe(3);
+      expect(preview.targetVersion).toBe(1);
+      const fieldNames = preview.changedFields.map((d) => d.field);
+      expect(fieldNames).toContain('keyWeights');
+      expect(fieldNames).toContain('riskParameters');
+      expect(fieldNames).toContain('name');
+      expect(fieldNames).toContain('description');
+    });
+
+    it('does not include unchanged fields in changedFields', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce(targetSnapshot);
+
+      const preview = await service.previewRollback('strategy-1', 1);
+
+      const fieldNames = preview.changedFields.map((d) => d.field);
+      // constraints are identical between the two snapshots
+      expect(fieldNames).not.toContain('constraints');
+    });
+
+    it('includes the full target snapshot DTO in the response', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce(targetSnapshot);
+
+      const preview = await service.previewRollback('strategy-1', 1);
+
+      expect(preview.targetSnapshot.version).toBe(1);
+      expect(preview.targetSnapshot.name).toBe('Original Strategy');
+      expect(preview.targetSnapshot.keyWeights).toEqual({ BTC: 0.4, ETH: 0.3, USDC: 0.3 });
+    });
+
+    it('marks preview as safe when target is SUPERSEDED (not ARCHIVED)', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce({ ...targetSnapshot, status: 'SUPERSEDED' });
+
+      const preview = await service.previewRollback('strategy-1', 1);
+
+      expect(preview.safe).toBe(true);
+    });
+
+    it('marks preview as unsafe (safe: false) when target is ARCHIVED', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce({ ...targetSnapshot, status: 'ARCHIVED' });
+
+      const preview = await service.previewRollback('strategy-1', 1);
+
+      expect(preview.safe).toBe(false);
+    });
+
+    it('passes rollbackReason through to the preview', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce(targetSnapshot);
+
+      const preview = await service.previewRollback('strategy-1', 1, 'Emergency revert');
+
+      expect(preview.rollbackReason).toBe('Emergency revert');
+    });
+
+    it('throws when no active snapshot exists', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(null)  // no active
+        .mockResolvedValueOnce(targetSnapshot);
+
+      await expect(service.previewRollback('strategy-1', 1)).rejects.toThrow(
+        /No active snapshot/,
+      );
+    });
+
+    it('throws when target version does not exist', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce(null); // target missing
+
+      await expect(service.previewRollback('strategy-1', 99)).rejects.toThrow(
+        /not found/,
+      );
+    });
+
+    it('returns empty changedFields when both snapshots are identical', async () => {
+      mockPrisma.strategySnapshot.findFirst
+        .mockResolvedValueOnce(baseSnapshot)
+        .mockResolvedValueOnce({ ...baseSnapshot, version: 2, status: 'SUPERSEDED' });
+
+      const preview = await service.previewRollback('strategy-1', 2);
+
+      expect(preview.changedFields).toHaveLength(0);
+    });
+  });
+});
+
+// ── Route-level tests for GET /api/strategies/:id/snapshots/:v/rollback-preview ──
+
+jest.mock('../services/strategySnapshotVersioningService', () => ({
+  strategySnapshotVersioningService: {
+    previewRollback: jest.fn(),
+  },
+}));
+
+describe('GET /api/strategies/:strategyId/snapshots/:targetVersion/rollback-preview', () => {
+  const app = express();
+  app.use('/api/strategies', strategiesRouter);
+
+  const { strategySnapshotVersioningService: mockSvc } = require('../services/strategySnapshotVersioningService');
+
+  beforeEach(() => jest.clearAllMocks());
+
+  const basePreview = {
+    strategyId: 'strategy-1',
+    currentVersion: 3,
+    targetVersion: 1,
+    changedFields: [{ field: 'keyWeights', current: { BTC: 0.5 }, target: { BTC: 0.4 } }],
+    targetSnapshot: { version: 1, name: 'Original Strategy' },
+    safe: true,
+  };
+
+  it('returns 200 with rollback preview', async () => {
+    mockSvc.previewRollback.mockResolvedValue(basePreview);
+
+    const res = await request(app)
+      .get('/api/strategies/strategy-1/snapshots/1/rollback-preview');
+
+    expect(res.status).toBe(200);
+    expect(res.body.currentVersion).toBe(3);
+    expect(res.body.targetVersion).toBe(1);
+    expect(Array.isArray(res.body.changedFields)).toBe(true);
+  });
+
+  it('passes optional reason query param to the service', async () => {
+    mockSvc.previewRollback.mockResolvedValue(basePreview);
+
+    await request(app)
+      .get('/api/strategies/strategy-1/snapshots/1/rollback-preview?reason=Emergency+revert');
+
+    expect(mockSvc.previewRollback).toHaveBeenCalledWith('strategy-1', 1, 'Emergency revert');
+  });
+
+  it('returns 400 for non-integer targetVersion', async () => {
+    const res = await request(app)
+      .get('/api/strategies/strategy-1/snapshots/abc/rollback-preview');
+
+    expect(res.status).toBe(400);
+    expect(mockSvc.previewRollback).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when active snapshot is missing', async () => {
+    mockSvc.previewRollback.mockRejectedValue(new Error('No active snapshot found for strategy "strategy-1".'));
+
+    const res = await request(app)
+      .get('/api/strategies/strategy-1/snapshots/1/rollback-preview');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when target version does not exist', async () => {
+    mockSvc.previewRollback.mockRejectedValue(new Error('Snapshot version 99 not found for strategy "strategy-1".'));
+
+    const res = await request(app)
+      .get('/api/strategies/strategy-1/snapshots/99/rollback-preview');
+
+    expect(res.status).toBe(404);
+  });
+
+  it('does not mutate state — previewRollback is called, not an actual rollback', async () => {
+    mockSvc.previewRollback.mockResolvedValue(basePreview);
+
+    await request(app)
+      .get('/api/strategies/strategy-1/snapshots/1/rollback-preview');
+
+    expect(mockSvc.previewRollback).toHaveBeenCalledTimes(1);
+    // Confirm no write method was invoked
+    expect(mockSvc.createSnapshot).toBeUndefined();
   });
 });

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -1,6 +1,8 @@
 import { Router, Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
 import { Horizon, rpc as SorobanRpc } from "@stellar/stellar-sdk";
+import { Queue } from "bullmq";
+import { Redis } from "ioredis";
 
 const router = Router();
 const prisma = new PrismaClient();
@@ -11,8 +13,42 @@ const SOROBAN_RPC_URL =
   process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
 const HEALTH_TIMEOUT_MS = Number(process.env.HEALTH_CHECK_TIMEOUT_MS ?? "5000");
 const _INDEXER_LAG_WARN_THRESHOLD = Number(process.env.INDEXER_LAG_WARN_LEDGERS ?? "50");
+const REDIS_URL = process.env.REDIS_URL ?? "redis://localhost:6379";
+const QUEUE_FAILED_THRESHOLD = Number(process.env.QUEUE_FAILED_THRESHOLD ?? "10");
+const QUEUE_DELAYED_THRESHOLD = Number(process.env.QUEUE_DELAYED_THRESHOLD ?? "50");
+
+const ALL_QUEUE_NAMES = [
+  "liquidation",
+  "compound",
+  "digest-generation",
+  "digest-threshold-check",
+  "rebalance-execution",
+  "rebalance-retry",
+];
 
 type ComponentStatus = "up" | "down" | "warning";
+type QueueStatus = "healthy" | "warning" | "error";
+
+export interface QueueJobCounts {
+  waiting: number;
+  active: number;
+  completed: number;
+  failed: number;
+  delayed: number;
+}
+
+export interface QueueHealthEntry {
+  name: string;
+  counts: QueueJobCounts;
+  status: QueueStatus;
+  warnings: string[];
+}
+
+export interface QueueHealthSummary {
+  queues: QueueHealthEntry[];
+  overallStatus: QueueStatus;
+  timestamp: string;
+}
 
 export type HealthStatus = {
   database: ComponentStatus;
@@ -116,6 +152,72 @@ router.get("/", async (_req: Request, res: Response) => {
   ).every((k) => body[k] !== "down");
 
   res.status(isHealthy ? 200 : 503).json(body);
+});
+
+router.get("/queues", async (_req: Request, res: Response) => {
+  const redis = new Redis(REDIS_URL, {
+    maxRetriesPerRequest: null,
+    enableReadyCheck: false,
+    lazyConnect: true,
+  });
+
+  try {
+    const entries: QueueHealthEntry[] = await Promise.all(
+      ALL_QUEUE_NAMES.map(async (name): Promise<QueueHealthEntry> => {
+        const queue = new Queue(name, { connection: redis });
+        try {
+          const raw = await withTimeout(
+            queue.getJobCounts("waiting", "active", "completed", "failed", "delayed"),
+            HEALTH_TIMEOUT_MS,
+          );
+          const counts: QueueJobCounts = {
+            waiting: raw.waiting ?? 0,
+            active: raw.active ?? 0,
+            completed: raw.completed ?? 0,
+            failed: raw.failed ?? 0,
+            delayed: raw.delayed ?? 0,
+          };
+          const warnings: string[] = [];
+          if (counts.failed > QUEUE_FAILED_THRESHOLD) {
+            warnings.push(
+              `failed jobs (${counts.failed}) exceed threshold (${QUEUE_FAILED_THRESHOLD})`,
+            );
+          }
+          if (counts.delayed > QUEUE_DELAYED_THRESHOLD) {
+            warnings.push(
+              `delayed jobs (${counts.delayed}) exceed threshold (${QUEUE_DELAYED_THRESHOLD})`,
+            );
+          }
+          return {
+            name,
+            counts,
+            status: warnings.length > 0 ? "warning" : "healthy",
+            warnings,
+          };
+        } catch {
+          return {
+            name,
+            counts: { waiting: 0, active: 0, completed: 0, failed: 0, delayed: 0 },
+            status: "error",
+            warnings: ["failed to fetch job counts"],
+          };
+        } finally {
+          await queue.close();
+        }
+      }),
+    );
+
+    const overallStatus: QueueStatus = entries.some((e) => e.status === "error")
+      ? "error"
+      : entries.some((e) => e.status === "warning")
+        ? "warning"
+        : "healthy";
+
+    const body: QueueHealthSummary = { queues: entries, overallStatus, timestamp: new Date().toISOString() };
+    res.status(overallStatus === "error" ? 503 : 200).json(body);
+  } finally {
+    await redis.quit().catch(() => {});
+  }
 });
 
 export default router;

--- a/server/src/routes/simulator.ts
+++ b/server/src/routes/simulator.ts
@@ -9,6 +9,12 @@ import {
   type RebalanceParams,
   type RebalanceBacktestParams,
 } from "../services/simulationService";
+import {
+  simulateFailover,
+  DEFAULT_FAILOVER_THRESHOLDS,
+  type FailoverSimulationInput,
+  type ProtocolSimulationFixture,
+} from "../services/protocolFailoverService";
 
 const router = Router();
 
@@ -100,6 +106,100 @@ router.post("/rebalance-backtest", (req: Request, res: Response) => {
   } catch (e) {
     res.status(500).json({
       error: e instanceof Error ? e.message : "Rebalance backtest failed",
+    });
+  }
+});
+
+/**
+ * POST /api/simulator/failover
+ *
+ * Dry-run a failover pass against synthetic protocol health fixtures.
+ * Returns which protocols would be included or excluded, per-protocol
+ * evaluations, and the decision log — all clearly marked simulationOnly.
+ *
+ * This endpoint is read-only and never touches the live failoverRegistry,
+ * so it cannot affect production state under any circumstances.
+ *
+ * Request body:
+ *   fixtures    — array of protocol health snapshots to evaluate
+ *   thresholds  — (optional) override failover thresholds for this run
+ *
+ * Example fixture for a simulated outage:
+ *   { "id": "blend", "name": "Blend", "status": "down" }
+ *
+ * Example fixture for a stale-data scenario:
+ *   { "id": "blend", "name": "Blend", "status": "healthy",
+ *     "lastUpdatedAt": "2020-01-01T00:00:00.000Z" }
+ */
+router.post("/failover", (req: Request, res: Response) => {
+  const { fixtures, thresholds } = req.body as Partial<FailoverSimulationInput>;
+
+  if (!Array.isArray(fixtures) || fixtures.length === 0) {
+    res.status(400).json({
+      error: "fixtures must be a non-empty array of protocol health snapshots.",
+    });
+    return;
+  }
+
+  const VALID_STATUSES = new Set(["healthy", "degraded", "critical", "down", "unknown"]);
+
+  const validationErrors: string[] = [];
+  (fixtures as ProtocolSimulationFixture[]).forEach((f, i) => {
+    if (typeof f.id !== "string" || !f.id.trim()) {
+      validationErrors.push(`fixtures[${i}].id must be a non-empty string`);
+    }
+    if (typeof f.name !== "string" || !f.name.trim()) {
+      validationErrors.push(`fixtures[${i}].name must be a non-empty string`);
+    }
+    if (!VALID_STATUSES.has(f.status)) {
+      validationErrors.push(
+        `fixtures[${i}].status must be one of: ${[...VALID_STATUSES].join(", ")}`,
+      );
+    }
+    if (f.lastUpdatedAt !== undefined && isNaN(Date.parse(f.lastUpdatedAt))) {
+      validationErrors.push(`fixtures[${i}].lastUpdatedAt must be a valid ISO-8601 timestamp`);
+    }
+    if (f.providerUptime !== undefined) {
+      const u = Number(f.providerUptime);
+      if (!Number.isFinite(u) || u < 0 || u > 1) {
+        validationErrors.push(`fixtures[${i}].providerUptime must be a number in [0, 1]`);
+      }
+    }
+    if (f.recentErrorCount !== undefined) {
+      const e = Number(f.recentErrorCount);
+      if (!Number.isFinite(e) || e < 0 || !Number.isInteger(e)) {
+        validationErrors.push(`fixtures[${i}].recentErrorCount must be a non-negative integer`);
+      }
+    }
+  });
+
+  if (validationErrors.length > 0) {
+    res.status(400).json({ error: "Invalid simulation input", details: validationErrors });
+    return;
+  }
+
+  // Sanitise thresholds — only accept known numeric/array keys; ignore anything else.
+  let safeThresholds: Partial<typeof DEFAULT_FAILOVER_THRESHOLDS> | undefined;
+  if (thresholds && typeof thresholds === "object") {
+    safeThresholds = {};
+    if (typeof thresholds.maxDataAgeMs === "number" && thresholds.maxDataAgeMs > 0) {
+      safeThresholds.maxDataAgeMs = thresholds.maxDataAgeMs;
+    }
+    if (typeof thresholds.minUptimeRatio === "number" &&
+        thresholds.minUptimeRatio >= 0 && thresholds.minUptimeRatio <= 1) {
+      safeThresholds.minUptimeRatio = thresholds.minUptimeRatio;
+    }
+    if (typeof thresholds.maxRecentErrors === "number" && thresholds.maxRecentErrors >= 0) {
+      safeThresholds.maxRecentErrors = thresholds.maxRecentErrors;
+    }
+  }
+
+  try {
+    const result = simulateFailover({ fixtures, thresholds: safeThresholds });
+    res.json(result);
+  } catch (e) {
+    res.status(500).json({
+      error: e instanceof Error ? e.message : "Failover simulation failed",
     });
   }
 });

--- a/server/src/routes/strategies.ts
+++ b/server/src/routes/strategies.ts
@@ -13,6 +13,7 @@ import {
 } from "../services/protocolFailoverService";
 import { rotationRegistry } from "../services/strategyRotationService";
 import { exportService } from "../services/exportService";
+import { strategySnapshotVersioningService } from "../services/strategySnapshotVersioningService";
 
 const router = Router();
 
@@ -165,5 +166,47 @@ router.get("/export", async (req: Request, res: Response) => {
     res.status(500).json({ error: "Failed to generate export bundle" });
   }
 });
+
+/**
+ * GET /api/strategies/:strategyId/snapshots/:targetVersion/rollback-preview
+ *
+ * Returns a read-only diff between the current active snapshot and the
+ * requested target version. No rollback is executed.
+ *
+ * Response includes:
+ *   - changedFields: array of { field, current, target } for every field that differs
+ *   - targetSnapshot: full snapshot DTO that would become active
+ *   - safe: false when the target version is ARCHIVED (requires explicit override)
+ */
+router.get(
+  "/:strategyId/snapshots/:targetVersion/rollback-preview",
+  async (req: Request, res: Response) => {
+    const { strategyId, targetVersion } = req.params;
+    const version = Number(targetVersion);
+
+    if (!Number.isInteger(version) || version < 1) {
+      res.status(400).json({ error: "targetVersion must be a positive integer." });
+      return;
+    }
+
+    const rollbackReason = req.query.reason as string | undefined;
+
+    try {
+      const preview = await strategySnapshotVersioningService.previewRollback(
+        strategyId,
+        version,
+        rollbackReason,
+      );
+      res.json(preview);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to generate rollback preview.";
+      if (message.includes("not found") || message.includes("No active snapshot")) {
+        res.status(404).json({ error: message });
+      } else {
+        res.status(500).json({ error: message });
+      }
+    }
+  },
+);
 
 export default router;

--- a/server/src/services/protocolFailoverService.ts
+++ b/server/src/services/protocolFailoverService.ts
@@ -334,3 +334,103 @@ export class FailoverRegistry {
 
 /** Process-wide failover registry shared across routes/jobs. */
 export const failoverRegistry = new FailoverRegistry();
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Failover Simulation — safe, read-only, never touches failoverRegistry
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A synthetic health fixture for simulation. `lastUpdatedAt` defaults to the
+ * current time (fresh data) when omitted, so callers only need to supply it
+ * when they want to simulate stale-data scenarios.
+ */
+export interface ProtocolSimulationFixture {
+  id: string;
+  name: string;
+  status: ProtocolHealthStatus;
+  /** ISO-8601. Defaults to `now` when omitted (simulates fresh data). */
+  lastUpdatedAt?: string;
+  providerUptime?: number;
+  recentErrorCount?: number;
+}
+
+export interface FailoverSimulationInput {
+  fixtures: ProtocolSimulationFixture[];
+  /** Override individual thresholds for the simulation run. */
+  thresholds?: Partial<FailoverThresholds>;
+}
+
+/** A strategy stub derived from a simulation fixture. */
+export interface SimulatedStrategy {
+  id: string;
+  name: string;
+}
+
+export interface FailoverSimulationResult {
+  /** Explicitly marks the response as non-production data. */
+  simulationOnly: true;
+  timestamp: string;
+  included: SimulatedStrategy[];
+  excluded: SimulatedStrategy[];
+  evaluations: ProtocolEvaluation[];
+  decisions: FailoverDecision[];
+}
+
+/**
+ * Run a failover pass against synthetic health fixtures.
+ *
+ * This function is entirely pure — it constructs its own local health map and
+ * strategy list from the provided fixtures and calls `applyFailover` directly.
+ * It never reads from or writes to `failoverRegistry` or any other mutable
+ * module-level state, so it cannot interfere with production behaviour.
+ */
+export function simulateFailover(
+  input: FailoverSimulationInput,
+  now: number = Date.now(),
+): FailoverSimulationResult {
+  const thresholds: FailoverThresholds = {
+    ...DEFAULT_FAILOVER_THRESHOLDS,
+    ...input.thresholds,
+    // Arrays must be fully replaced, not spread-merged, to avoid accidental merges.
+    excludeStatuses:
+      input.thresholds?.excludeStatuses ?? DEFAULT_FAILOVER_THRESHOLDS.excludeStatuses,
+    warnStatuses:
+      input.thresholds?.warnStatuses ?? DEFAULT_FAILOVER_THRESHOLDS.warnStatuses,
+  };
+
+  const strategies: SimulatedStrategy[] = input.fixtures.map((f) => ({
+    id: f.id,
+    name: f.name,
+  }));
+
+  const health = new Map<string, ProtocolHealthInput>(
+    input.fixtures.map((f) => [
+      f.id,
+      {
+        id: f.id,
+        name: f.name,
+        status: f.status,
+        lastUpdatedAt: f.lastUpdatedAt ?? new Date(now).toISOString(),
+        providerUptime: f.providerUptime,
+        recentErrorCount: f.recentErrorCount,
+      },
+    ]),
+  );
+
+  const result = applyFailover(
+    strategies,
+    health,
+    new Set<string>(), // fresh previousState — simulation always starts clean
+    thresholds,
+    now,
+  );
+
+  return {
+    simulationOnly: true,
+    timestamp: new Date(now).toISOString(),
+    included: result.included,
+    excluded: result.excluded,
+    evaluations: result.evaluations,
+    decisions: result.decisions,
+  };
+}

--- a/server/src/services/strategySnapshotVersioningService.ts
+++ b/server/src/services/strategySnapshotVersioningService.ts
@@ -39,6 +39,32 @@ export interface VersionReferenceDTO {
 }
 
 /**
+ * A single field diff between two snapshots.
+ */
+export interface SnapshotFieldDiff {
+  field: string;
+  current: unknown;
+  target: unknown;
+}
+
+/**
+ * Read-only preview of what a rollback would change.
+ * No state is mutated when this is produced.
+ */
+export interface RollbackPreviewDTO {
+  strategyId: string;
+  currentVersion: number;
+  targetVersion: number;
+  /** Fields whose values differ between current and target. */
+  changedFields: SnapshotFieldDiff[];
+  /** Full snapshot that would become active after rollback. */
+  targetSnapshot: StrategySnapshotDTO;
+  rollbackReason?: string;
+  /** False when the target is ARCHIVED — rollback would need explicit override. */
+  safe: boolean;
+}
+
+/**
  * Strategy version change record for audit trail.
  */
 export interface VersionChangeRecordDTO {
@@ -427,9 +453,74 @@ export class StrategySnapshotVersioningService {
     };
   }
 
+  /**
+   * Preview what a rollback to `targetVersion` would change.
+   *
+   * Compares the current active snapshot against the target snapshot and
+   * returns a diff of all fields that would be affected. This method is
+   * purely read-only — it never writes to the database.
+   */
+  async previewRollback(
+    strategyId: string,
+    targetVersion: number,
+    rollbackReason?: string,
+  ): Promise<RollbackPreviewDTO> {
+    const [currentSnapshot, targetSnapshot] = await Promise.all([
+      prisma.strategySnapshot.findFirst({
+        where: { strategyId, status: 'ACTIVE' },
+      }),
+      prisma.strategySnapshot.findFirst({
+        where: { strategyId, version: targetVersion },
+      }),
+    ]);
+
+    if (!currentSnapshot) {
+      throw new Error(`No active snapshot found for strategy "${strategyId}".`);
+    }
+    if (!targetSnapshot) {
+      throw new Error(
+        `Snapshot version ${targetVersion} not found for strategy "${strategyId}".`,
+      );
+    }
+
+    const changedFields = this.diffSnapshots(currentSnapshot, targetSnapshot);
+
+    return {
+      strategyId,
+      currentVersion: currentSnapshot.version,
+      targetVersion: targetSnapshot.version,
+      changedFields,
+      targetSnapshot: this.mapToDTO(targetSnapshot),
+      rollbackReason,
+      safe: targetSnapshot.status !== 'ARCHIVED',
+    };
+  }
+
   // ─────────────────────────────────────────────────────────────
   // Private helpers
   // ─────────────────────────────────────────────────────────────
+
+  private diffSnapshots(current: any, target: any): SnapshotFieldDiff[] {
+    const diffs: SnapshotFieldDiff[] = [];
+
+    const scalarFields: Array<keyof typeof current> = ['name', 'description'];
+    for (const field of scalarFields) {
+      if (current[field] !== target[field]) {
+        diffs.push({ field, current: current[field], target: target[field] });
+      }
+    }
+
+    const objectFields = ['keyWeights', 'riskParameters', 'constraints'] as const;
+    for (const field of objectFields) {
+      const currentStr = JSON.stringify(current[field] ?? {});
+      const targetStr = JSON.stringify(target[field] ?? {});
+      if (currentStr !== targetStr) {
+        diffs.push({ field, current: current[field], target: target[field] });
+      }
+    }
+
+    return diffs;
+  }
 
   private async recordVersionChange(
     strategyId: string,


### PR DESCRIPTION
closes #547 - Adds GET /api/health/queues endpoint exposing waiting/active/completed/failed/delayed
counts for all BullMQ queues with threshold-based warnings; includes getQueueHealth() service in keepers.

closes #544 - Adds previewRollback() to StrategySnapshotVersioningService and GET
/:strategyId/snapshots/:targetVersion/rollback-preview route returning a field-level diff without executing any rollback.

closes #561 - Adds useLeaderboardFilters hook that persists timeWindow and strategyType to localStorage
with validation, restoration on page load, and a Reset button that only appears when filters differ from defaults.

closes #558 - Adds simulateFailover() pure function to protocolFailoverService and POST /api/simulator/failover
route for dry-running protocol outage/stale-data scenarios against synthetic fixtures without touching live registry state.
