### PR TITLE
feat: keeper runbook, storage report, API pagination, and simulator OpenAPI schema

### DIFF
--- a/backend/keepers/README.md
+++ b/backend/keepers/README.md
@@ -1,0 +1,353 @@
+# StellarYield Keeper Bot Runbook
+
+This document covers day-to-day operation of the StellarYield keeper bots: configuration, local testing, monitoring, and failure recovery.
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Keeper Responsibilities](#keeper-responsibilities)
+3. [Architecture](#architecture)
+4. [Environment Variables](#environment-variables)
+5. [Running Locally](#running-locally)
+6. [Safe Local Test Commands](#safe-local-test-commands)
+7. [Monitoring](#monitoring)
+8. [Restarting a Keeper](#restarting-a-keeper)
+9. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Keeper bots are off-chain services that automate time-sensitive on-chain operations:
+
+- **Liquidation keeper** — scans CDPs for under-collateralised positions and submits liquidation transactions before they become insolvent.
+- **Compound keeper** — calls `harvest` on yield vaults on a schedule to auto-compound accrued rewards back into the vault (increasing the share price for all depositors without user action).
+
+Both keepers are built with [BullMQ](https://docs.bullmq.io/) job queues backed by Redis, and submit Soroban transactions via `@stellar/stellar-sdk`.
+
+---
+
+## Keeper Responsibilities
+
+### Liquidation Queue (`liquidation`)
+
+| Step | Actor | Action |
+|------|-------|--------|
+| 1 | `VaultMonitor` | Polls the `StablecoinManager` contract every `SCAN_INTERVAL_MS` ms for CDPs whose CR < MCR. |
+| 2 | `VaultMonitor` | Enqueues a `LiquidationJobData` job (deduplicated by `accountAddress`). |
+| 3 | `LiquidationWorker` | Pulls the job, re-verifies position is still undercollateralised, calls `liquidate(liquidator, user)` on-chain. |
+| 4 | `LiquidationWorker` | Logs `txHash` on success; failed jobs land in the BullMQ failed set for review. |
+
+**Retry policy:** exponential back-off, up to `JOB_MAX_ATTEMPTS` (default 5).
+
+### Compound Queue (`compound`)
+
+| Step | Actor | Action |
+|------|-------|--------|
+| 1 | `CompoundScheduler` | Registers a BullMQ repeatable job per vault at a cron interval (default: every 4 hours). |
+| 2 | `CompoundWorker` | Pulls the job, calls `harvest(keeper, min_amount)` on the `YieldVault` contract. |
+| 3 | `CompoundWorker` | On success, logs `txHash` and the harvested amount; failed jobs are retried. |
+
+Repeatable jobs survive worker restarts because they are stored in Redis.
+
+---
+
+## Architecture
+
+```
+VaultMonitor ──enqueue──▶ liquidation queue (Redis/BullMQ) ──consume──▶ LiquidationWorker
+                                                                               │
+                                                                               ▼
+CompoundScheduler ─enqueue─▶ compound queue (Redis/BullMQ) ──consume──▶ CompoundWorker
+                                                                               │
+                                                                               ▼
+                                                                    KeeperSigner (Stellar SDK)
+                                                                               │
+                                                                               ▼
+                                                                  Soroban RPC → On-chain tx
+```
+
+---
+
+## Environment Variables
+
+All variables are read at startup. Required variables cause the process to exit immediately if absent.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `VAULT_CONTRACT_ID` | **Yes** | — | Soroban contract ID of the `YieldVault` to compound. |
+| `STABLECOIN_MANAGER_CONTRACT_ID` | **Yes** | — | Soroban contract ID of the `StablecoinManager` for liquidation scanning. |
+| `KEEPER_SECRET_KEY` | **Yes** | — | Stellar secret key (`S...`) used to sign keeper transactions. **Never commit this value.** |
+| `REDIS_URL` | No | `redis://localhost:6379` | BullMQ connection string. |
+| `STELLAR_NETWORK` | No | `testnet` | `testnet` or `mainnet`. |
+| `STELLAR_HORIZON_URL` | No | `https://horizon-testnet.stellar.org` | Horizon REST endpoint. |
+| `STELLAR_SOROBAN_RPC_URL` | No | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint. |
+| `BASE_FEE` | No | `100` | Base transaction fee in stroops. |
+| `SCAN_INTERVAL_MS` | No | `30000` | How often `VaultMonitor` scans for liquidatable CDPs (ms). |
+| `MCR_BPS` | No | `11000` | Maintenance Collateralization Ratio in basis points (110% = 11000). |
+| `LIQUIDATION_CONCURRENCY` | No | `3` | Max simultaneous liquidation jobs per worker process. |
+| `COMPOUND_CONCURRENCY` | No | `5` | Max simultaneous compound jobs per worker process. |
+| `JOB_MAX_ATTEMPTS` | No | `5` | Max retries before a job lands in the failed set. |
+| `MONITORED_ADDRESSES` | No | `""` | Comma-separated list of Stellar addresses to monitor manually (useful when no indexer is available). |
+| `LOG_LEVEL` | No | `info` | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`. |
+
+### Example `.env` (testnet)
+
+```env
+VAULT_CONTRACT_ID=CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+STABLECOIN_MANAGER_CONTRACT_ID=CBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4
+KEEPER_SECRET_KEY=SBAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+REDIS_URL=redis://localhost:6379
+STELLAR_NETWORK=testnet
+SCAN_INTERVAL_MS=30000
+MCR_BPS=11000
+LOG_LEVEL=debug
+```
+
+> **Production note:** Replace `KEEPER_SECRET_KEY` with a KMS adapter that never exposes the raw private key in-process. See the `KeeperSigner` class in `src/signer/KeeperSigner.ts` for the integration point.
+
+---
+
+## Running Locally
+
+### Prerequisites
+
+- Node.js ≥ 18
+- Redis running on `localhost:6379` (or set `REDIS_URL`)
+- A funded testnet Stellar account whose secret key is set as `KEEPER_SECRET_KEY`
+- Deployed testnet contract IDs for `VAULT_CONTRACT_ID` and `STABLECOIN_MANAGER_CONTRACT_ID`
+
+### Install dependencies
+
+```bash
+cd backend/keepers
+npm install
+```
+
+### Start Redis (Docker)
+
+```bash
+docker run -d -p 6379:6379 --name redis-keeper redis:7-alpine
+```
+
+### Start the keeper
+
+```bash
+# Copy and fill in .env
+cp .env.example .env
+# edit .env with your testnet values
+
+npm run dev
+```
+
+You should see:
+
+```
+INFO  StellarYield Keeper Bot starting...
+INFO  { publicKey: "G..." } Keeper bot public key
+INFO  { intervalMs: 30000 } [VaultMonitor] Starting vault scan loop
+INFO  { vaultCount: 1 } [CompoundScheduler] All vaults scheduled
+INFO  Keeper Bot fully operational
+```
+
+---
+
+## Safe Local Test Commands
+
+> All commands below run against **testnet only**. Never point `STELLAR_NETWORK=mainnet` at a local test environment.
+
+### Run unit and integration tests
+
+```bash
+# From backend/keepers/
+npm test
+```
+
+Tests mock the Stellar SDK and Redis — no live network calls are made.
+
+### Manually trigger a compound job (testnet)
+
+```bash
+# Enqueues a one-off compound job for the configured vault
+VAULT_CONTRACT_ID=<your-testnet-vault-id> \
+KEEPER_SECRET_KEY=<your-testnet-key> \
+STELLAR_NETWORK=testnet \
+node -e "
+const { createCompoundQueue } = require('./dist/queues');
+const q = createCompoundQueue();
+q.add('manual-compound', { vaultContractId: process.env.VAULT_CONTRACT_ID, minHarvestAmount: '0' });
+console.log('Job enqueued');
+"
+```
+
+### Inspect queued and failed jobs
+
+```bash
+# Connect to Redis and list BullMQ keys
+redis-cli keys "bull:*"
+
+# Count jobs in each state
+redis-cli llen bull:liquidation:wait
+redis-cli llen bull:compound:wait
+redis-cli zcard bull:liquidation:failed
+redis-cli zcard bull:compound:failed
+```
+
+### Simulate a VaultMonitor scan (dry run)
+
+Set `SCAN_INTERVAL_MS=0` (disabled) and call the monitor once manually:
+
+```bash
+SCAN_INTERVAL_MS=9999999 npm run dev
+# In another terminal, send SIGUSR2 or add a one-shot scan path (see monitors/VaultMonitor.ts)
+```
+
+---
+
+## Monitoring
+
+The keeper emits structured JSON logs via [Pino](https://getpino.io/). In production, pipe stdout to your log aggregator (Datadog, Loki, CloudWatch, etc.).
+
+### Key log fields to alert on
+
+| Log event | Field | Alert condition |
+|---|---|---|
+| Liquidation job failed | `"Liquidation job failed"` | Any occurrence |
+| Compound job failed | `"Compound job failed"` | Any occurrence |
+| Signer error | `"err"` containing `"KeeperSigner"` | Any occurrence |
+| VaultMonitor scan failed | `"[VaultMonitor] Scan failed"` | Any occurrence |
+| High failed-job count | BullMQ `failed` set size | > 10 |
+
+### Health endpoint
+
+The keeper exposes a lightweight HTTP health endpoint on port `3002` (configurable):
+
+```bash
+curl http://localhost:3002/health
+# {"status":"ok","queues":{"liquidation":"running","compound":"running"}}
+```
+
+---
+
+## Restarting a Keeper
+
+Graceful restart (drains in-progress jobs before exit):
+
+```bash
+# Send SIGTERM — the keeper calls worker.close() and redis.disconnect()
+kill -SIGTERM <pid>
+```
+
+Hard restart (loses in-progress jobs — use only if the process is hung):
+
+```bash
+kill -9 <pid>
+# BullMQ will automatically re-queue stalled jobs on next startup
+```
+
+For systemd deployments:
+
+```bash
+systemctl restart stellar-yield-keeper
+```
+
+---
+
+## Troubleshooting
+
+### Redis connection failures
+
+**Symptom:** Keeper exits at startup with `ECONNREFUSED` or BullMQ throws `Redis connection failed`.
+
+**Checks:**
+1. Verify Redis is running: `redis-cli ping` should return `PONG`.
+2. Check `REDIS_URL` in `.env` matches the running Redis address and port.
+3. If Redis requires a password, include it in the URL: `redis://:password@host:6379`.
+4. For TLS Redis (Upstash, Redis Cloud), use `rediss://` scheme.
+
+**Fix:**
+```bash
+docker start redis-keeper         # if using Docker
+# or
+brew services start redis         # macOS Homebrew
+# or
+systemctl start redis             # Linux systemd
+```
+
+---
+
+### Signer / keypair failures
+
+**Symptom:** `KEEPER_SECRET_KEY is not set` at startup, or `TransactionSubmissionError` during job processing.
+
+**Checks:**
+1. Confirm `KEEPER_SECRET_KEY` is set and starts with `S` (Stellar secret key format).
+2. Verify the keeper account is funded: `stellar account balance --source <public-key> --network testnet`.
+3. Check the account has enough XLM for fees (`BASE_FEE` × concurrency × number of pending jobs).
+4. If using a KMS, confirm the KMS role/credentials are reachable from the keeper host.
+
+**Fix:**
+```bash
+# Fund testnet keeper account
+stellar keys fund <public-key> --network testnet
+
+# Verify key is valid
+stellar keys address <name>
+```
+
+---
+
+### Queue stalls / jobs not processing
+
+**Symptom:** Jobs accumulate in the `wait` list; workers are running but nothing processes.
+
+**Checks:**
+1. Confirm workers are connected: check logs for `[LiquidationWorker]` / `[CompoundWorker]` startup messages.
+2. Check for stalled jobs: BullMQ marks a job as stalled if a worker crashes mid-processing. Stalled jobs are automatically requeued on worker reconnect.
+3. Check concurrency: if `LIQUIDATION_CONCURRENCY` or `COMPOUND_CONCURRENCY` is set too low for your load, increase it.
+4. Check for a Redis memory limit (`maxmemory` setting) that is causing evictions.
+
+**Fix:**
+```bash
+# Manually retry all failed jobs
+redis-cli zrange bull:liquidation:failed 0 -1 WITHSCORES
+
+# Via BullMQ dashboard (if installed):
+# npx @bull-board/cli
+```
+
+---
+
+### Jobs failing repeatedly
+
+**Symptom:** The BullMQ failed set grows; logs show repeated `LiquidationWorker job failed` or `CompoundWorker job failed`.
+
+**Checks:**
+1. Read the `err` field in the failure log for root cause.
+2. Common causes:
+   - **`InsufficientBalance`** — keeper account is out of XLM. Top up the account.
+   - **`TransactionSubmissionError: tx_bad_seq`** — sequence number conflict from concurrent workers. Reduce `LIQUIDATION_CONCURRENCY` to `1` temporarily.
+   - **`ContractError`** — the on-chain call reverted. Check the contract logs; the position may have already been liquidated by another keeper.
+   - **`HostError`** — Soroban resource limit exceeded. Increase `BASE_FEE` or the resource budget in `KeeperSigner`.
+
+**Fix:**
+```bash
+# After fixing the root cause, move failed jobs back to the wait queue
+# (use BullMQ's retryJobs API or the Bull Board UI)
+```
+
+---
+
+### VaultMonitor not finding liquidatable positions
+
+**Symptom:** No liquidation jobs are being enqueued despite undercollateralised CDPs existing on-chain.
+
+**Checks:**
+1. Confirm `STABLECOIN_MANAGER_CONTRACT_ID` points to the correct contract on the correct network.
+2. Confirm `MCR_BPS` matches the contract's maintenance ratio. If the contract uses 120% (12000 bps) but `MCR_BPS=11000`, positions between 110%–120% are missed.
+3. Confirm `MONITORED_ADDRESSES` is set if the keeper is relying on a manual list rather than an indexer.
+4. Check Soroban RPC connectivity: `curl $STELLAR_SOROBAN_RPC_URL/health`.
+
+---
+
+*For general Stellar/Soroban questions see the [Stellar Developer Docs](https://developers.stellar.org/docs).*

--- a/docs/contracts/storage-report.md
+++ b/docs/contracts/storage-report.md
@@ -1,0 +1,155 @@
+# Soroban Contract Storage Usage Report
+
+This report lists every storage key used by each StellarYield Soroban contract, the Soroban storage class, the expected TTL/persistence behaviour, and the recommended cleanup strategy.
+
+## Background
+
+Soroban provides three storage classes with distinct TTL semantics:
+
+| Class | Default TTL | Typical use case |
+|---|---|---|
+| `instance` | Tied to the contract instance | Contract-wide config, global counters |
+| `persistent` | Set by the writer; must be bumped proactively | Per-user state, long-lived positions |
+| `temporary` | Short-lived; auto-deleted when TTL expires | Caches, nonces, ephemeral flags |
+
+Keys that are not bumped expire silently. Persistent state that has not been accessed for an extended period requires an `extend_ttl` call before it can be read again.
+
+---
+
+## Contracts
+
+### 1. `yield_vault`
+
+**Source:** `contracts/yield_vault/src/lib.rs`
+
+#### Storage class: `instance`
+
+| Key | Type | Description | Cleanup |
+|---|---|---|---|
+| `Admin` | `Address` | Current contract admin. | Never — persists for contract lifetime. |
+| `Token` | `Address` | The vault's deposit/withdraw token. | Never. |
+| `TotalShares` | `i128` | Sum of all outstanding vault shares. | Never — global counter updated on every deposit/withdrawal. |
+| `TotalAssets` | `i128` | Total tokens held by the vault (AUM). | Never. |
+| `Initialized` | `bool` | Prevents re-initialization. | Never. |
+| `RewardProtocol` | `String` | Identifier of the protocol supplying yield. | Admin-updatable; never auto-expired. |
+| `RewardToken` | `Address` | Token used for reward distribution. | Admin-updatable. |
+| `DexRouter` | `Address` | DEX router used during `harvest` swaps. | Admin-updatable. |
+| `TotalHarvested` | `i128` | Cumulative amount harvested across all compound cycles. | Never. |
+| `Keeper` | `Address` | Keeper bot address authorized to call `harvest`. | Admin-updatable. |
+| `Paused` | `bool` | Emergency pause flag. | Cleared on `unpause`. |
+| `PendingAdmin` | `Address` | Address pending admin transfer confirmation. | Cleared on `accept_admin`. |
+| `Oracle` | `Address` | Price oracle address. | Admin-updatable. |
+| `EmergencyPenaltyBps` | `u32` | Haircut in basis points applied to withdrawals during emergency mode. | Cleared when emergency mode ends. |
+
+#### Storage class: `persistent`
+
+| Key | Type | Description | TTL extension | Cleanup |
+|---|---|---|---|---|
+| `Shares(Address)` | `i128` | Share balance of a specific depositor. | Must be bumped on each deposit, withdrawal, and transfer involving the user. | Remove when user's share balance reaches 0 via full withdrawal. |
+| `Timelock(Symbol)` | `u64` (timestamp) | Expiry timestamp for a pending timelocked action identified by name. | N/A — expires naturally when the action is executed or cancelled. | Remove after action execution (`remove(key)`). |
+
+**Cleanup responsibility:** The contract itself clears `Timelock` keys on action execution. `Shares` cleanup requires calling `remove` when a user's balance reaches zero — verify this is done in the `withdraw` path.
+
+---
+
+### 2. `stablecoin_manager`
+
+**Source:** `contracts/stablecoin_manager/src/storage.rs`
+
+#### Storage class: `instance`
+
+| Key | Type | Description | Cleanup |
+|---|---|---|---|
+| `Admin` | `Address` | Contract admin. | Never. |
+| `SUSDToken` | `Address` | The synthetic USD token contract. | Never. |
+| `CollateralToken` | `Address` | The SAC (Stellar Asset Contract) used as collateral. | Never. |
+| `VaultMetrics` | `Address` | Contract address exposing `total_assets`/`total_shares`. | Never. |
+| `Oracle` | `Address` | Price oracle for collateral valuation. | Admin-updatable. |
+| `Icr` | `u32` (bps) | Initial Collateralization Ratio. | Admin-updatable. |
+| `Mcr` | `u32` (bps) | Maintenance Collateralization Ratio (liquidation threshold). | Admin-updatable. |
+| `InterestRate` | `i128` | Per-second interest rate scaled by 1e18. | Admin-updatable. |
+| `CumulativeIndex` | `i128` | Running compound interest index. | Updated on every interest accrual. Never removed. |
+| `LastUpdate` | `u64` | Ledger timestamp of last interest accrual. | Updated alongside `CumulativeIndex`. |
+| `Initialized` | `bool` | Prevents re-initialization. | Never. |
+
+#### Storage class: `persistent`
+
+| Key | Type | Description | TTL extension | Cleanup |
+|---|---|---|---|---|
+| `Cdp(Address)` | `Cdp { collateral, debt_shares, last_index }` | Per-user collateralised debt position. | Bump on every open, repay, deposit-collateral, and withdraw-collateral call. | Remove when `collateral == 0 && debt_shares == 0` (position fully closed). The liquidation path should also clear the key on full liquidation. |
+
+**Cleanup responsibility:** CDP keys that are fully liquidated or repaid must be removed with `env.storage().persistent().remove(&DataKey::Cdp(user))` to recover ledger rent. Without cleanup, the contract accumulates orphan entries proportional to total historical users.
+
+---
+
+### 3. `ve_tokenomics`
+
+**Source:** `contracts/ve_tokenomics/src/storage.rs`
+
+#### Storage class: `instance`
+
+| Key | Type | Description | Cleanup |
+|---|---|---|---|
+| `Admin` | `Address` | Contract admin. | Never. |
+| `YieldToken` | `Address` | The governance / yield token to lock. | Never. |
+| `TotalVotingPower` | `i128` | Global sum of all voting power (placeholder — may be computed dynamically). | Updated on lock/unlock. Never removed. |
+| `Initialized` | `bool` | Re-initialization guard. | Never. |
+
+#### Storage class: `persistent`
+
+| Key | Type | Description | TTL extension | Cleanup |
+|---|---|---|---|---|
+| `UserLock(Address)` | lock struct | A user's locked token amount and unlock timestamp. | Bump on `lock` and `extend_lock`. | Remove when the user calls `unlock` after the lock expires and their balance is withdrawn. |
+| `GaugeVote(Address)` | vote allocation map | The user's current gauge vote weights. | Bump on `vote`. | Remove when the user un-votes or when their lock expires. |
+| `PoolTotalWeight(Address)` | `i128` | Aggregate voting weight directed at a given pool/gauge. | Bump on `vote`. | Archivable once a pool is deprecated; do not remove while active. |
+
+**Cleanup responsibility:** Expired `UserLock` and `GaugeVote` entries should be removable by anyone after the lock epoch ends (consider a public `cleanup_expired_lock(user)` function to reclaim rent).
+
+---
+
+### 4. `options`
+
+**Source:** `contracts/options/src/storage.rs`
+
+#### Storage class: `instance`
+
+| Key | Type | Description | Cleanup |
+|---|---|---|---|
+| `Admin` | `Address` | Contract admin. | Never. |
+| `Oracle` | `Address` | Price oracle for option valuation. | Admin-updatable. |
+| `OptionCounter` | `u32` | Monotonically increasing ID for new options. | Never. |
+
+#### Storage class: `persistent`
+
+| Key | Type | Description | TTL extension | Cleanup |
+|---|---|---|---|---|
+| `Option(id)` | option struct | Individual option record (strike, expiry, writer, holder, settled). | Bump on write/exercise/settle. | Remove after settlement + a minimum audit retention period (suggested: 30 days in ledgers ≈ ~2.6M ledgers). |
+
+**Cleanup responsibility:** A `settle_and_cleanup(id)` admin function can be added to remove the key after on-chain settlement is confirmed and the audit window has passed.
+
+---
+
+## General TTL Policy
+
+| Storage class | Recommended bump ledger threshold | Bump target |
+|---|---|---|
+| `instance` | On every mutating call | `MAX_INSTANCE_TTL` (17,280,000 ledgers ≈ ~1 year) |
+| `persistent` (user state) | On every read/write involving the user | `MAX_PERSISTENT_TTL` (17,280,000 ledgers) |
+| `temporary` | N/A — let expire naturally; only bump if needed within the same tx | Depends on use case |
+
+> Soroban's current `MAX_TTL` is approximately 17,280,000 ledgers on mainnet. TTL constants should be defined as named constants in each contract rather than magic numbers.
+
+---
+
+## Archival & Cleanup Summary
+
+| Contract | Keys with cleanup responsibility | Recommended action |
+|---|---|---|
+| `yield_vault` | `Shares(Address)` on full withdrawal; `Timelock(Symbol)` after execution | Contract already clears `Timelock` on execution. Verify `Shares` removal on zero-balance withdrawal. |
+| `stablecoin_manager` | `Cdp(Address)` on full repay or full liquidation | Add `env.storage().persistent().remove(...)` to the full-repay and full-liquidation code paths. |
+| `ve_tokenomics` | `UserLock(Address)`, `GaugeVote(Address)` after lock expiry | Add a permissionless `cleanup_expired_lock(user)` function callable by anyone after the user's unlock timestamp. |
+| `options` | `Option(id)` after settlement + audit window | Add `settle_and_cleanup(id)` admin function with a minimum retention guard. |
+
+---
+
+*Last updated: 2026-05-27. Re-run this audit whenever a new contract or `DataKey` variant is added.*

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -43,6 +43,8 @@ tags:
     description: Prometheus-compatible metrics scrape endpoint
   - name: Liquidity
     description: Liquidity fragmentation metrics
+  - name: Simulator
+    description: Simulation endpoints for deposit, rebalance, and failover dry-runs (never executes on-chain)
 
 paths:
   /api/health:
@@ -1766,12 +1768,234 @@ paths:
           '500':
             description: Failed to stop monitoring
 
+  # ── Deposit Simulation ──────────────────────────────────────────────────────
+
+  /api/simulator/deposit:
+    post:
+      summary: Simulate a token deposit
+      description: |
+        Dry-run a deposit against a yield strategy and return projected allocations,
+        expected share count, fee breakdown, and any risk warnings. This endpoint is
+        simulation-only — it never executes a transaction or modifies on-chain state.
+        All responses include `"isSimulationOnly": true`.
+      tags:
+        - Simulator
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DepositSimulationRequest'
+            examples:
+              standard_deposit:
+                summary: 1000 USDC into strategy alpha-1
+                value:
+                  strategyId: "alpha-1"
+                  token: "USDC"
+                  amount: 1000
+              minimum_deposit:
+                summary: Smallest valid deposit
+                value:
+                  strategyId: "alpha-1"
+                  token: "XLM"
+                  amount: 0.0000001
+      responses:
+        '200':
+          description: Simulation completed successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DepositSimulationResponse'
+              examples:
+                success:
+                  summary: Typical successful simulation
+                  value:
+                    isSimulationOnly: true
+                    allocations:
+                      - protocol: "Blend"
+                        amount: 600
+                        percentage: 60
+                      - protocol: "Soroswap"
+                        amount: 400
+                        percentage: 40
+                    expectedShares: 987.5
+                    fees:
+                      - type: "entry"
+                        amount: 2.5
+                    postDepositExposure:
+                      expectedApy: 8.3
+                    warnings: []
+                with_warnings:
+                  summary: Simulation with risk warnings
+                  value:
+                    isSimulationOnly: true
+                    allocations:
+                      - protocol: "Blend"
+                        amount: 1000
+                        percentage: 100
+                    expectedShares: 990
+                    fees:
+                      - type: "entry"
+                        amount: 10
+                    postDepositExposure:
+                      expectedApy: 4.1
+                    warnings:
+                      - "Protocol liquidity is low — large deposits may experience slippage"
+        '400':
+          description: Invalid request parameters.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationError'
+              examples:
+                missing_fields:
+                  summary: Required field absent
+                  value:
+                    error: "Missing required fields: strategyId, amount, token"
+                negative_amount:
+                  summary: Negative amount
+                  value:
+                    error: "amount must be a positive number"
+        '500':
+          description: Unexpected simulation failure.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimulationError'
+              examples:
+                strategy_not_found:
+                  summary: Unknown strategy
+                  value:
+                    error: "Unknown strategy: no-such-strategy"
+
   # Intentionally excluded routes:
   # - Internal debugging and profiling endpoints under /internal/* are intentionally omitted from this public spec.
   # - Any admin-only endpoints that require interactive session tokens are documented above when needed; ephemeral or highly-sensitive debug routes are excluded.
 
 components:
   schemas:
+
+    # ── Simulator schemas ───────────────────────────────────────────────────
+
+    DepositSimulationRequest:
+      type: object
+      required:
+        - strategyId
+        - token
+        - amount
+      properties:
+        strategyId:
+          type: string
+          description: Identifier of the yield strategy to simulate the deposit against.
+          example: "alpha-1"
+        token:
+          type: string
+          description: Token symbol or contract address to deposit (e.g. "USDC", "XLM").
+          example: "USDC"
+        amount:
+          type: number
+          format: double
+          minimum: 0
+          exclusiveMinimum: true
+          description: Amount of `token` to deposit. Must be a positive number.
+          example: 1000
+
+    DepositSimulationResponse:
+      type: object
+      required:
+        - isSimulationOnly
+        - allocations
+        - expectedShares
+        - fees
+        - postDepositExposure
+      properties:
+        isSimulationOnly:
+          type: boolean
+          enum: [true]
+          description: Always `true`. Confirms this response is a simulation preview, not an executed transaction.
+        allocations:
+          type: array
+          description: How the deposited amount would be split across protocols.
+          items:
+            $ref: '#/components/schemas/SimulationAllocation'
+        expectedShares:
+          type: number
+          format: double
+          description: Estimated number of vault shares the depositor would receive.
+          example: 987.5
+        fees:
+          type: array
+          description: Itemised fee breakdown.
+          items:
+            $ref: '#/components/schemas/SimulationFee'
+        postDepositExposure:
+          type: object
+          description: Projected portfolio metrics after the deposit.
+          properties:
+            expectedApy:
+              type: number
+              format: double
+              description: Blended expected APY (%) after allocation.
+              example: 8.3
+        warnings:
+          type: array
+          description: Non-fatal warnings about liquidity, stale data, or risk concentration. Empty array when none.
+          items:
+            type: string
+          example: ["Protocol liquidity is low — large deposits may experience slippage"]
+
+    SimulationAllocation:
+      type: object
+      required:
+        - protocol
+        - amount
+        - percentage
+      properties:
+        protocol:
+          type: string
+          description: Protocol name receiving this portion of the deposit.
+          example: "Blend"
+        amount:
+          type: number
+          format: double
+          description: Token amount allocated to this protocol.
+          example: 600
+        percentage:
+          type: number
+          format: double
+          minimum: 0
+          maximum: 100
+          description: Percentage of total deposit allocated to this protocol.
+          example: 60
+
+    SimulationFee:
+      type: object
+      required:
+        - type
+        - amount
+      properties:
+        type:
+          type: string
+          description: Fee category (e.g. "entry", "protocol", "performance").
+          example: "entry"
+        amount:
+          type: number
+          format: double
+          description: Fee amount in the deposit token's units.
+          example: 2.5
+
+    SimulationError:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: string
+          description: Human-readable error message.
+          example: "Missing required fields: strategyId, amount, token"
+
+    # ── Platform schemas ─────────────────────────────────────────────────────
+
     HealthStatus:
       type: object
       properties:

--- a/server/src/__tests__/incidentsPagination.test.ts
+++ b/server/src/__tests__/incidentsPagination.test.ts
@@ -1,0 +1,138 @@
+import request from "supertest";
+import express from "express";
+import incidentsRouter from "../routes/incidents";
+
+// ---------------------------------------------------------------------------
+// Prisma mock — keyed by UUID so we can simulate multi-page results.
+// ---------------------------------------------------------------------------
+const makeIncident = (id: string, startedAt: Date) => ({
+  id,
+  protocol: "TestProtocol",
+  severity: "HIGH",
+  type: "PAUSE",
+  title: `Incident ${id}`,
+  description: "Test description",
+  affectedVaults: [],
+  resolved: false,
+  startedAt,
+  resolvedAt: null,
+  createdAt: startedAt,
+  updatedAt: startedAt,
+});
+
+// 25 incidents ordered newest-first (ids "id-01" … "id-25", dates descending)
+const ALL_INCIDENTS = Array.from({ length: 25 }, (_, i) => {
+  const n = 25 - i; // n goes 25, 24, … 1
+  const id = `id-${String(n).padStart(2, "0")}`;
+  const startedAt = new Date(2024, 0, n); // Jan n, 2024
+  return makeIncident(id, startedAt);
+});
+
+jest.mock("@prisma/client", () => {
+  const mockFindMany = jest.fn().mockImplementation(
+    (args?: {
+      where?: { id?: { lt?: string }; resolved?: boolean };
+      take?: number;
+      orderBy?: unknown;
+    }) => {
+      let pool = [...ALL_INCIDENTS];
+
+      if (args?.where?.resolved !== undefined) {
+        pool = pool.filter((i) => i.resolved === args.where!.resolved);
+      }
+      if (args?.where?.id?.lt) {
+        const cursor = args.where.id.lt;
+        const idx = pool.findIndex((i) => i.id === cursor);
+        pool = idx >= 0 ? pool.slice(idx + 1) : [];
+      }
+
+      return Promise.resolve(args?.take ? pool.slice(0, args.take) : pool);
+    },
+  );
+
+  return {
+    PrismaClient: jest.fn(() => ({
+      incident: { findMany: mockFindMany, findUnique: jest.fn(), create: jest.fn(), update: jest.fn() },
+      $disconnect: jest.fn(),
+    })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// App setup
+// ---------------------------------------------------------------------------
+const app = express();
+app.use(express.json());
+app.use("/api/incidents", incidentsRouter);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("GET /api/incidents — cursor pagination", () => {
+  it("returns first page with default limit (20) and hasMore=true", async () => {
+    const res = await request(app).get("/api/incidents");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(20);
+    expect(res.body.pagination.hasMore).toBe(true);
+    expect(res.body.pagination.limit).toBe(20);
+    expect(typeof res.body.pagination.nextCursor).toBe("string");
+  });
+
+  it("returns correct second page using nextCursor", async () => {
+    const firstPage = await request(app).get("/api/incidents");
+    const { nextCursor } = firstPage.body.pagination;
+
+    const secondPage = await request(app).get(`/api/incidents?cursor=${nextCursor}`);
+
+    expect(secondPage.status).toBe(200);
+    // 25 total - 20 first page = 5 remaining
+    expect(secondPage.body.data).toHaveLength(5);
+    expect(secondPage.body.pagination.hasMore).toBe(false);
+    expect(secondPage.body.pagination.nextCursor).toBeNull();
+  });
+
+  it("returns empty data array when cursor points past the last item", async () => {
+    // Use a cursor that does not match any id → pool becomes empty after cursor filter
+    const res = await request(app).get("/api/incidents?cursor=id-nonexistent");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(0);
+    expect(res.body.pagination.hasMore).toBe(false);
+    expect(res.body.pagination.nextCursor).toBeNull();
+  });
+
+  it("respects a custom limit", async () => {
+    const res = await request(app).get("/api/incidents?limit=5");
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toHaveLength(5);
+    expect(res.body.pagination.limit).toBe(5);
+    expect(res.body.pagination.hasMore).toBe(true);
+  });
+
+  it("clamps limit to maximum of 100", async () => {
+    const res = await request(app).get("/api/incidents?limit=999");
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.limit).toBe(100);
+  });
+
+  it("uses default limit when limit param is invalid", async () => {
+    const res = await request(app).get("/api/incidents?limit=abc");
+
+    expect(res.status).toBe(200);
+    expect(res.body.pagination.limit).toBe(20);
+  });
+
+  it("returns pagination shape on every response (data + pagination fields present)", async () => {
+    const res = await request(app).get("/api/incidents?limit=3");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("data");
+    expect(res.body).toHaveProperty("pagination");
+    expect(res.body.pagination).toHaveProperty("nextCursor");
+    expect(res.body.pagination).toHaveProperty("hasMore");
+    expect(res.body.pagination).toHaveProperty("limit");
+  });
+});

--- a/server/src/routes/incidents.ts
+++ b/server/src/routes/incidents.ts
@@ -1,18 +1,41 @@
 import { Router, Request, Response } from "express";
 import { incidentService, IncidentFilter } from "../services/incidentService";
+import { parsePaginationLimit } from "../types/pagination";
 
 const router = Router();
 
+/**
+ * GET /api/incidents
+ *
+ * Returns a paginated list of incidents ordered by `startedAt` descending.
+ *
+ * Query parameters:
+ *   protocol  — filter by protocol name (optional)
+ *   severity  — filter by severity (optional)
+ *   type      — filter by incident type (optional)
+ *   resolved  — "true" | "false" (optional)
+ *   cursor    — opaque cursor from a previous response's `pagination.nextCursor` (optional)
+ *   limit     — items per page, 1–100 (default 20)
+ *
+ * Response:
+ *   {
+ *     "data": [...incidents],
+ *     "pagination": { "nextCursor": string|null, "hasMore": boolean, "limit": number }
+ *   }
+ */
 router.get("/", async (req: Request, res: Response) => {
     try {
         const filter: IncidentFilter = {
-            protocol: req.query.protocol as string,
-            severity: req.query.severity as string,
-            type: req.query.type as string,
+            protocol: req.query.protocol as string | undefined,
+            severity: req.query.severity as string | undefined,
+            type: req.query.type as string | undefined,
             resolved: req.query.resolved === "true" ? true : req.query.resolved === "false" ? false : undefined,
         };
-        const incidents = await incidentService.getIncidents(filter);
-        res.json(incidents);
+        const page = await incidentService.getIncidentsPaginated(filter, {
+            cursor: req.query.cursor as string | undefined,
+            limit: parsePaginationLimit(req.query.limit),
+        });
+        res.json(page);
     } catch {
         res.status(500).json({ error: "Failed to fetch incidents" });
     }

--- a/server/src/services/incidentService.ts
+++ b/server/src/services/incidentService.ts
@@ -1,5 +1,6 @@
 import { PrismaClient, Incident } from "@prisma/client"; // Type verified via tsc
 import { recoveryRecommendationService, RecoveryRecommendation, ShockEvent, ShockEventType } from "./recoveryRecommendationService";
+import { PaginatedResponse, PAGINATION_DEFAULT_LIMIT, PAGINATION_MAX_LIMIT } from "../types/pagination";
 
 const prisma = new PrismaClient();
 
@@ -8,6 +9,11 @@ export interface IncidentFilter {
     severity?: string;
     type?: string;
     resolved?: boolean;
+}
+
+export interface IncidentPageOptions {
+    cursor?: string;
+    limit?: number;
 }
 
 export interface IncidentWithRecommendations extends Incident {
@@ -51,6 +57,35 @@ export class IncidentService {
                 startedAt: "desc",
             },
         });
+    }
+
+    async getIncidentsPaginated(
+        filter: IncidentFilter,
+        options: IncidentPageOptions,
+    ): Promise<PaginatedResponse<Incident>> {
+        const limit = Math.min(
+            Math.max(1, options.limit ?? PAGINATION_DEFAULT_LIMIT),
+            PAGINATION_MAX_LIMIT,
+        );
+
+        const rows = await prisma.incident.findMany({
+            where: {
+                protocol: filter.protocol || undefined,
+                severity: filter.severity || undefined,
+                type: filter.type || undefined,
+                resolved: filter.resolved,
+                ...(options.cursor ? { id: { lt: options.cursor } } : {}),
+            },
+            orderBy: { startedAt: "desc" },
+            // Fetch one extra to determine whether a next page exists.
+            take: limit + 1,
+        });
+
+        const hasMore = rows.length > limit;
+        const data = hasMore ? rows.slice(0, limit) : rows;
+        const nextCursor = hasMore ? data[data.length - 1].id : null;
+
+        return { data, pagination: { nextCursor, hasMore, limit } };
     }
 
     async getIncidentById(id: string): Promise<Incident | null> {

--- a/server/src/types/pagination.ts
+++ b/server/src/types/pagination.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared cursor-based pagination contract for StellarYield list endpoints.
+ *
+ * ## Query parameters
+ * - `cursor`  — opaque string token returned in a previous response's `nextCursor`.
+ *              Pass `cursor=<value>` to fetch the next page.
+ *              Omit (or pass an empty string) for the first page.
+ * - `limit`   — number of items to return per page (default: 20, max: 100).
+ *
+ * ## Response shape
+ * Every paginated endpoint returns `PaginatedResponse<T>`:
+ *   {
+ *     "data": [...],
+ *     "pagination": {
+ *       "nextCursor": "some-opaque-string" | null,
+ *       "hasMore": true | false,
+ *       "limit": 20
+ *     }
+ *   }
+ *
+ * A `nextCursor` of `null` means there are no more pages.
+ * Clients should stop paginating when `hasMore === false`.
+ */
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: {
+    /** Cursor to pass as `?cursor=` on the next request. `null` when no more pages. */
+    nextCursor: string | null;
+    /** `true` if another page exists after this one. */
+    hasMore: boolean;
+    /** Effective limit used for this page. */
+    limit: number;
+  };
+}
+
+export const PAGINATION_DEFAULT_LIMIT = 20;
+export const PAGINATION_MAX_LIMIT = 100;
+
+/**
+ * Parse and clamp `limit` from a query string value.
+ * Returns `PAGINATION_DEFAULT_LIMIT` when the value is absent or invalid.
+ */
+export function parsePaginationLimit(raw: unknown): number {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 1) return PAGINATION_DEFAULT_LIMIT;
+  return Math.min(Math.floor(n), PAGINATION_MAX_LIMIT);
+}


### PR DESCRIPTION
Closes #546
Closes #550
Closes #556
Closes #560

## What changed

- **#546 — Keeper Bot Runbook** (`backend/keepers/README.md`): Full operational runbook covering keeper responsibilities (liquidation queue, compound queue), all environment variables with types and defaults, safe local test commands, monitoring log-field reference, restart instructions, and a troubleshooting section for Redis, signer/keypair, queue stalls, repeated job failures, and VaultMonitor scan issues.

- **#550 — Storage Usage Report** (`docs/contracts/storage-report.md`): Per-contract audit of every `DataKey`, storage class (`instance` / `persistent` / `temporary`), intended lifetime, TTL extension requirements, and cleanup responsibilities for `yield_vault`, `stablecoin_manager`, `ve_tokenomics`, and `options`. Includes a general TTL policy table and a cleanup summary.

- **#556 — API Pagination Contract** (`server/src/types/pagination.ts`, `server/src/routes/incidents.ts`, `server/src/services/incidentService.ts`, `server/src/__tests__/incidentsPagination.test.ts`): Defines a shared cursor-based `PaginatedResponse<T>` type with `nextCursor`, `hasMore`, and `limit` fields. Applied to `GET /api/incidents` (now accepts `?cursor=&limit=` and returns the paginated shape). Added `getIncidentsPaginated` to `IncidentService`. Includes 7 passing tests covering first page, second page, empty page, custom limit, limit clamping, invalid limit fallback, and response shape validation.

- **#560 — Deposit Simulation OpenAPI Schema** (`server/openapi.yaml`): Documents `POST /api/simulator/deposit` with full request schema (`strategyId`, `token`, `amount`), response schema (`isSimulationOnly`, `allocations`, `expectedShares`, `fees`, `postDepositExposure`, `warnings`), named component schemas (`DepositSimulationRequest`, `DepositSimulationResponse`, `SimulationAllocation`, `SimulationFee`, `SimulationError`), error response examples for 400 and 500, and a `Simulator` tag. YAML formatting validated.

## How to test

- **Keeper runbook**: Review `backend/keepers/README.md` — all env var names match `backend/keepers/src/config/index.ts`.
- **Storage report**: Review `docs/contracts/storage-report.md` — `DataKey` variants verified against source files.
- **Pagination**: `cd server && npm test -- --testPathPatterns=incidentsPagination` — all 7 tests pass.
- **OpenAPI**: YAML parses without errors; review the new `Simulator` section in `server/openapi.yaml`.