### PR TITLE
feat: add strategy comparison exports

### DIFF
--- a/client/src/pages/strategy/StrategyComparison.test.tsx
+++ b/client/src/pages/strategy/StrategyComparison.test.tsx
@@ -88,6 +88,13 @@ describe('StrategyComparison Component', () => {
       expect(screen.getByText('DeFindex')).toBeInTheDocument();
     });
 
+    expect(
+      screen.getByRole('button', { name: /Export strategy comparison as CSV/i }),
+    ).toBeEnabled();
+    expect(
+      screen.getByRole('button', { name: /Export strategy comparison as JSON/i }),
+    ).toBeEnabled();
+
     // Check specific formattings on Blend card
     // APY
     expect(screen.getByText('8.68')).toBeInTheDocument();
@@ -120,5 +127,24 @@ describe('StrategyComparison Component', () => {
       expect(screen.getByText('Failed to Load Strategy Data')).toBeInTheDocument();
       expect(screen.getByText('Network offline')).toBeInTheDocument();
     });
+  });
+
+  it('disables exports and shows an empty state when no strategies match', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+
+    render(<StrategyComparison />);
+
+    expect(
+      await screen.findByTestId('strategy-export-empty-state'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /No strategies available to export as CSV/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /No strategies available to export as JSON/i }),
+    ).toBeDisabled();
   });
 });

--- a/client/src/pages/strategy/StrategyComparison.tsx
+++ b/client/src/pages/strategy/StrategyComparison.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import {
-  BarChart3,
   RefreshCw,
   AlertTriangle,
   Flame,
@@ -10,23 +9,14 @@ import {
   TrendingDown,
   TrendingUp,
   Percent,
+  Download,
 } from 'lucide-react';
 import { apiUrl } from '../../lib/api';
-
-interface StrategyYield {
-  protocolName: string;
-  apy: number;
-  rewardApy: number;
-  totalApy: number;
-  tvl: number;
-  riskScore: number;
-  liquidityUsd: number;
-  rebalancingBehavior: string;
-  managementFeeBps: number;
-  performanceFeeBps: number;
-  capitalEfficiencyPct: number;
-  fetchedAt?: string;
-}
+import {
+  downloadStrategyComparisonExport,
+  type StrategyComparisonExportFormat,
+  type StrategyYield,
+} from './strategyComparisonExport';
 
 const STRATEGY_THEMES: Record<string, { bg: string; text: string; shadow: string }> = {
   Blend: { bg: 'from-violet-500/20 to-indigo-600/20', text: 'text-indigo-400', shadow: 'shadow-indigo-500/20' },
@@ -38,6 +28,12 @@ function formatCurrency(value: number): string {
   if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(2)}M`;
   if (value >= 1_000) return `$${(value / 1_000).toFixed(1)}K`;
   return `$${value.toLocaleString()}`;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error && error.message
+    ? error.message
+    : 'Failed to fetch strategies';
 }
 
 export default function StrategyComparison() {
@@ -58,11 +54,15 @@ export default function StrategyComparison() {
         ['Blend', 'Soroswap', 'DeFindex'].includes(y.protocolName)
       );
       setData(strategies);
-    } catch (err: any) {
-      setError(err.message || 'Failed to fetch strategies');
+    } catch (err: unknown) {
+      setError(getErrorMessage(err));
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleExport = (format: StrategyComparisonExportFormat) => {
+    downloadStrategyComparisonExport(data, format);
   };
 
   useEffect(() => {
@@ -119,18 +119,60 @@ export default function StrategyComparison() {
             Side-by-side analysis of risk, liquidity, and rebalancing approaches.
           </p>
         </div>
-        <button
-          onClick={fetchStrategies}
-          disabled={loading}
-          className="btn-secondary flex items-center gap-2 text-sm disabled:opacity-50"
-        >
-          <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
-          {loading ? 'Analyzing...' : 'Refresh Analysis'}
-        </button>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={fetchStrategies}
+            disabled={loading}
+            className="btn-secondary flex items-center gap-2 text-sm disabled:opacity-50"
+          >
+            <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            {loading ? 'Analyzing...' : 'Refresh Analysis'}
+          </button>
+          <button
+            type="button"
+            onClick={() => handleExport('csv')}
+            disabled={loading || data.length === 0}
+            aria-label={
+              data.length === 0
+                ? 'No strategies available to export as CSV'
+                : 'Export strategy comparison as CSV'
+            }
+            className="btn-secondary flex items-center gap-2 text-sm disabled:opacity-50"
+          >
+            <Download size={14} />
+            CSV
+          </button>
+          <button
+            type="button"
+            onClick={() => handleExport('json')}
+            disabled={loading || data.length === 0}
+            aria-label={
+              data.length === 0
+                ? 'No strategies available to export as JSON'
+                : 'Export strategy comparison as JSON'
+            }
+            className="btn-secondary flex items-center gap-2 text-sm disabled:opacity-50"
+          >
+            <Download size={14} />
+            JSON
+          </button>
+        </div>
       </header>
 
       {loading ? (
         renderSkeleton()
+      ) : data.length === 0 ? (
+        <div
+          className="glass-panel p-12 text-center border border-white/10"
+          data-testid="strategy-export-empty-state"
+        >
+          <AlertTriangle size={32} className="text-gray-500 mx-auto mb-4" />
+          <h3 className="text-xl font-bold mb-2">No Strategy Data Available</h3>
+          <p className="text-gray-400 max-w-md mx-auto">
+            Export actions unlock once Blend, Soroswap, or DeFindex strategy
+            rows are available.
+          </p>
+        </div>
       ) : (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 relative">
           {data.map((strategy, i) => {

--- a/client/src/pages/strategy/strategyComparisonExport.test.ts
+++ b/client/src/pages/strategy/strategyComparisonExport.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import {
+  STRATEGY_COMPARISON_EXPORT_FIELDS,
+  buildStrategyComparisonExportRows,
+  createStrategyComparisonExportFilename,
+  serializeStrategyComparisonExport,
+  type StrategyYield,
+} from './strategyComparisonExport';
+
+const generatedAt = new Date('2026-05-28T12:34:56.789Z');
+
+const strategies: StrategyYield[] = [
+  {
+    protocolName: 'Blend',
+    apy: 6.45,
+    rewardApy: 2.23,
+    totalApy: 8.68,
+    tvl: 12_400_000,
+    riskScore: 23,
+    liquidityUsd: 11_200_000,
+    rebalancingBehavior: 'Static',
+    managementFeeBps: 25,
+    performanceFeeBps: 1000,
+    capitalEfficiencyPct: 75,
+    fetchedAt: '2026-05-28T12:00:00.000Z',
+  },
+];
+
+describe('strategy comparison export', () => {
+  it('uses a standardized timestamped filename', () => {
+    expect(createStrategyComparisonExportFilename('csv', generatedAt)).toBe(
+      'stellaryield-strategy-comparison-2026-05-28T12-34-56-789Z.csv',
+    );
+  });
+
+  it('exports required comparison fields', () => {
+    const [row] = buildStrategyComparisonExportRows(strategies, generatedAt);
+
+    expect(Object.keys(row)).toEqual([...STRATEGY_COMPARISON_EXPORT_FIELDS]);
+    expect(row.protocol_name).toBe('Blend');
+    expect(row.total_apy).toBe(8.68);
+    expect(row.tvl_usd).toBe(12_400_000);
+    expect(row.risk_score).toBe(23);
+    expect(row.fee_drag_bps).toBe(1025);
+    expect(row.confidence_score).toBe(75);
+    expect(row.generated_at).toBe(generatedAt.toISOString());
+  });
+
+  it('keeps CSV headers when there are no strategies', () => {
+    const csv = serializeStrategyComparisonExport([], 'csv', generatedAt);
+
+    expect(csv).toBe(STRATEGY_COMPARISON_EXPORT_FIELDS.join(','));
+  });
+
+  it('serializes JSON with metadata and rows', () => {
+    const json = JSON.parse(
+      serializeStrategyComparisonExport(strategies, 'json', generatedAt),
+    ) as {
+      generated_at: string;
+      row_count: number;
+      fields: string[];
+      strategies: Array<{ protocol_name: string }>;
+    };
+
+    expect(json.generated_at).toBe(generatedAt.toISOString());
+    expect(json.row_count).toBe(1);
+    expect(json.fields).toEqual([...STRATEGY_COMPARISON_EXPORT_FIELDS]);
+    expect(json.strategies[0].protocol_name).toBe('Blend');
+  });
+});

--- a/client/src/pages/strategy/strategyComparisonExport.ts
+++ b/client/src/pages/strategy/strategyComparisonExport.ts
@@ -1,0 +1,139 @@
+export interface StrategyYield {
+  protocolName: string;
+  apy: number;
+  rewardApy: number;
+  totalApy: number;
+  tvl: number;
+  riskScore: number;
+  liquidityUsd: number;
+  rebalancingBehavior: string;
+  managementFeeBps: number;
+  performanceFeeBps: number;
+  capitalEfficiencyPct: number;
+  fetchedAt?: string;
+}
+
+export type StrategyComparisonExportFormat = "csv" | "json";
+
+export const STRATEGY_COMPARISON_EXPORT_FIELDS = [
+  "generated_at",
+  "protocol_name",
+  "apy",
+  "reward_apy",
+  "total_apy",
+  "tvl_usd",
+  "risk_score",
+  "liquidity_usd",
+  "fee_drag_bps",
+  "management_fee_bps",
+  "performance_fee_bps",
+  "confidence_score",
+  "rebalancing_behavior",
+  "fetched_at",
+] as const;
+
+export type StrategyComparisonExportField =
+  (typeof STRATEGY_COMPARISON_EXPORT_FIELDS)[number];
+
+export type StrategyComparisonExportRow = Record<
+  StrategyComparisonExportField,
+  string | number
+>;
+
+function toExportNumber(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function escapeCsvCell(value: string | number): string {
+  const text = String(value);
+  if (!/[",\n]/.test(text)) return text;
+  return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function createStrategyComparisonExportFilename(
+  format: StrategyComparisonExportFormat,
+  generatedAt = new Date(),
+): string {
+  const stamp = generatedAt.toISOString().replace(/[:.]/g, "-");
+  return `stellaryield-strategy-comparison-${stamp}.${format}`;
+}
+
+export function buildStrategyComparisonExportRows(
+  strategies: StrategyYield[],
+  generatedAt = new Date(),
+): StrategyComparisonExportRow[] {
+  const generatedAtIso = generatedAt.toISOString();
+
+  return strategies.map((strategy) => {
+    const managementFeeBps = toExportNumber(strategy.managementFeeBps);
+    const performanceFeeBps = toExportNumber(strategy.performanceFeeBps);
+
+    return {
+      generated_at: generatedAtIso,
+      protocol_name: strategy.protocolName,
+      apy: toExportNumber(strategy.apy),
+      reward_apy: toExportNumber(strategy.rewardApy),
+      total_apy: toExportNumber(strategy.totalApy),
+      tvl_usd: toExportNumber(strategy.tvl),
+      risk_score: toExportNumber(strategy.riskScore),
+      liquidity_usd: toExportNumber(strategy.liquidityUsd),
+      fee_drag_bps: managementFeeBps + performanceFeeBps,
+      management_fee_bps: managementFeeBps,
+      performance_fee_bps: performanceFeeBps,
+      confidence_score: toExportNumber(strategy.capitalEfficiencyPct),
+      rebalancing_behavior: strategy.rebalancingBehavior || "Standard",
+      fetched_at: strategy.fetchedAt ?? "",
+    };
+  });
+}
+
+export function serializeStrategyComparisonExport(
+  strategies: StrategyYield[],
+  format: StrategyComparisonExportFormat,
+  generatedAt = new Date(),
+): string {
+  const rows = buildStrategyComparisonExportRows(strategies, generatedAt);
+
+  if (format === "json") {
+    return JSON.stringify(
+      {
+        generated_at: generatedAt.toISOString(),
+        row_count: rows.length,
+        fields: STRATEGY_COMPARISON_EXPORT_FIELDS,
+        strategies: rows,
+      },
+      null,
+      2,
+    );
+  }
+
+  const header = STRATEGY_COMPARISON_EXPORT_FIELDS.join(",");
+  const body = rows.map((row) =>
+    STRATEGY_COMPARISON_EXPORT_FIELDS.map((field) =>
+      escapeCsvCell(row[field]),
+    ).join(","),
+  );
+  return [header, ...body].join("\n");
+}
+
+export function downloadStrategyComparisonExport(
+  strategies: StrategyYield[],
+  format: StrategyComparisonExportFormat,
+): void {
+  const generatedAt = new Date();
+  const contents = serializeStrategyComparisonExport(
+    strategies,
+    format,
+    generatedAt,
+  );
+  const mimeType =
+    format === "json" ? "application/json" : "text/csv;charset=utf-8";
+  const blob = new Blob([contents], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+
+  link.href = url;
+  link.download = createStrategyComparisonExportFilename(format, generatedAt);
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Description

Adds CSV and JSON export actions to the strategy comparison page.

Fixes #541

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification Commands

- [x] `npm test -- StrategyComparison strategyComparisonExport` (Frontend)
- [x] `./node_modules/.bin/eslint src/pages/strategy/StrategyComparison.tsx src/pages/strategy/StrategyComparison.test.tsx src/pages/strategy/strategyComparisonExport.ts src/pages/strategy/strategyComparisonExport.test.ts` (Frontend)

### Contract Security (if `contracts/` changed)

- [ ] Storage schema changes documented or migration provided
- [ ] All entry points have authorization checks
- [ ] Arithmetic uses checked operations
- [ ] New entry points have unit tests including unauthorized callers
- [ ] No new admin roles without governance proposal

## Screenshots (if applicable)

N/A

## UI Snapshot Checklist

- [ ] Screenshots provided for Desktop (1024px+)
- [ ] Screenshots provided for Mobile (375px)
- [x] No visual changes