### PR TITLE
feat: connect on-ramp, portfolio execution, governance tests, signed contact sends

### DIFF
--- a/client/src/features/contacts/__tests__/SendModal.test.tsx
+++ b/client/src/features/contacts/__tests__/SendModal.test.tsx
@@ -3,10 +3,11 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { SendModal } from '../components/SendModal';
-import { ContactSuggestion } from '../types';
+import * as sorobanService from "../../../services/soroban";
+import * as StellarSdk from "@stellar/stellar-sdk";
 
 // Mock useContacts so AddressAutocomplete doesn't need a WalletProvider
 vi.mock('../hooks/useContacts', () => ({
@@ -34,16 +35,34 @@ vi.mock('../components/ContactsModal', () => ({
   ContactsModal: () => null,
 }));
 
+// Mock soroban service
+vi.mock("../../../services/soroban", () => ({
+  executeContractCallOn: vi.fn(),
+}));
+
 describe('SendModal', () => {
   const mockOnClose = vi.fn();
-  const mockWalletAddress = '0x1234567890123456789012345678901234567890';
+  // Use static valid Stellar keys to avoid Noble curves crypto issues in test env
+  const mockWalletAddress = "GBJKSX33PDI67V4CNWSIBRNDRLAV2HPWGOJJBNL5GK7WRVYSDS3WBHL7";
+  const mockRecipientAddress = "GBK2O2DY4DRH2CITGJMXN5PIRFTJ5U5SV5UDLRV73Z7LAPLKRNCRJOBN";
   const mockBalance = '1000.50';
+
+  // Mock useWallet
+  vi.mock("../../../context/useWallet", () => ({
+    useWallet: () => ({
+      walletAddress: "GBJKSX33PDI67V4CNWSIBRNDRLAV2HPWGOJJBNL5GK7WRVYSDS3WBHL7",
+      isConnected: true,
+      signTransaction: vi.fn().mockResolvedValue("mock-signed-xdr"),
+    }),
+  }));
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv('VITE_USDC_SAC_CONTRACT_ID', 'CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB42P');
   });
 
   afterEach(() => {
+    vi.unstubAllEnvs();
     vi.resetAllMocks();
   });
 
@@ -104,9 +123,9 @@ describe('SendModal', () => {
     );
 
     const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
 
-    expect(addressInput).toHaveValue('0x9876543210987654321098765432109876543210');
+    expect(addressInput).toHaveValue(mockRecipientAddress);
   });
 
   it('should handle amount change', () => {
@@ -155,7 +174,7 @@ describe('SendModal', () => {
     const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
     const amountInput = screen.getByPlaceholderText('0.00');
 
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
     fireEvent.change(amountInput, { target: { value: '100' } });
 
     expect(screen.getByText('To:')).toBeInTheDocument();
@@ -179,34 +198,11 @@ describe('SendModal', () => {
     const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
     const amountInput = screen.getByPlaceholderText('0.00');
 
-    const fullAddress = '0x9876543210987654321098765432109876543210';
-    fireEvent.change(addressInput, { target: { value: fullAddress } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
     fireEvent.change(amountInput, { target: { value: '100' } });
 
-    expect(screen.getByText('0x9876...3210')).toBeInTheDocument();
-  });
-
-  it('should handle contact selection', () => {
-    const mockContact: ContactSuggestion = {
-      id: '1',
-      name: 'Alice',
-      address: '0x9876543210987654321098765432109876543210',
-      displayText: 'Alice (0x9876...)',
-    };
-
-    render(
-      <SendModal
-        isOpen={true}
-        onClose={mockOnClose}
-        walletAddress={mockWalletAddress}
-        balance={mockBalance}
-      />
-    );
-
-    const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
-    // Typing the address directly doesn't set selectedContact — just verify address is set
-    fireEvent.change(addressInput, { target: { value: mockContact.address } });
-    expect(addressInput).toHaveValue(mockContact.address);
+    const expectedShortened = `${mockRecipientAddress.slice(0, 6)}...${mockRecipientAddress.slice(-4)}`;
+    expect(screen.getByText(expectedShortened)).toBeInTheDocument();
   });
 
   it('should show error for empty fields', async () => {
@@ -226,6 +222,29 @@ describe('SendModal', () => {
     });
   });
 
+  it('should show error for invalid address format', async () => {
+    render(
+      <SendModal
+        isOpen={true}
+        onClose={mockOnClose}
+        walletAddress={mockWalletAddress}
+        balance={mockBalance}
+      />
+    );
+
+    const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
+    const amountInput = screen.getByPlaceholderText('0.00');
+    const sendButton = screen.getByRole('button', { name: /^Send$/i });
+
+    fireEvent.change(addressInput, { target: { value: 'invalid-stellar-address' } });
+    fireEvent.change(amountInput, { target: { value: '100' } });
+    fireEvent.click(sendButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid recipient address format')).toBeInTheDocument();
+    });
+  });
+
   it('should show error for zero amount', async () => {
     render(
       <SendModal
@@ -240,7 +259,7 @@ describe('SendModal', () => {
     const amountInput = screen.getByPlaceholderText('0.00');
     const sendButton = screen.getByRole('button', { name: /^Send$/i });
 
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
     fireEvent.change(amountInput, { target: { value: '0' } });
     fireEvent.click(sendButton);
 
@@ -263,7 +282,7 @@ describe('SendModal', () => {
     const amountInput = screen.getByPlaceholderText('0.00');
     const sendButton = screen.getByRole('button', { name: /^Send$/i });
 
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
     fireEvent.change(amountInput, { target: { value: '2000' } }); // More than balance
     fireEvent.click(sendButton);
 
@@ -273,7 +292,10 @@ describe('SendModal', () => {
   });
 
   it('should handle successful send transaction', async () => {
-    vi.useFakeTimers();
+    vi.mocked(sorobanService.executeContractCallOn).mockResolvedValue({
+      success: true,
+      hash: "mock-tx-hash",
+    });
 
     render(
       <SendModal
@@ -288,27 +310,21 @@ describe('SendModal', () => {
     const amountInput = screen.getByPlaceholderText('0.00');
     const sendButton = screen.getByRole('button', { name: /^Send$/i });
 
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
     fireEvent.change(amountInput, { target: { value: '100' } });
     fireEvent.click(sendButton);
 
-    // Should show loading state immediately
-    expect(screen.getByText('Sending...')).toBeInTheDocument();
-    expect(sendButton).toBeDisabled();
-
-    // Fast-forward the 2-second simulated delay
-    await act(async () => {
-      vi.runAllTimers();
+    await waitFor(() => {
+      expect(screen.getByText('Send Successful')).toBeInTheDocument();
     });
-
-    expect(mockOnClose).toHaveBeenCalled();
-
-    vi.useRealTimers();
   });
 
   it('should handle send transaction error', async () => {
-    // The error display is tested via the synchronous validation paths.
-    // Here we verify the error element renders correctly for any error string.
+    vi.mocked(sorobanService.executeContractCallOn).mockResolvedValue({
+      success: false,
+      error: "Simulation failed: transaction rejected",
+    });
+
     render(
       <SendModal
         isOpen={true}
@@ -318,21 +334,24 @@ describe('SendModal', () => {
       />
     );
 
-    // Trigger the "insufficient balance" error path — this exercises the error UI
     const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
     const amountInput = screen.getByPlaceholderText('0.00');
     const sendButton = screen.getByRole('button', { name: /^Send$/i });
 
-    fireEvent.change(addressInput, { target: { value: '0x9876543210987654321098765432109876543210' } });
-    fireEvent.change(amountInput, { target: { value: '99999' } });
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
+    fireEvent.change(amountInput, { target: { value: '100' } });
     fireEvent.click(sendButton);
 
     await waitFor(() => {
-      expect(screen.getByText('Insufficient balance')).toBeInTheDocument();
+      expect(screen.getByText('Simulation failed: transaction rejected')).toBeInTheDocument();
     });
   });
 
-  it('should open contacts modal when contacts button is clicked', () => {
+  it('should disable inputs/buttons during transaction', async () => {
+    vi.mocked(sorobanService.executeContractCallOn).mockImplementation(
+      () => new Promise(() => {}) // never resolves to keep in building/submitting state
+    );
+
     render(
       <SendModal
         isOpen={true}
@@ -342,34 +361,17 @@ describe('SendModal', () => {
       />
     );
 
-    const contactsButton = screen.getByTitle('Open address book');
-    fireEvent.click(contactsButton);
-
-    // ContactsModal should be rendered (we can see this by checking for the modal content)
-    // In a real test, we might need to mock the ContactsModal component
-  });
-
-  it('should disable send button when form is incomplete', () => {
-    render(
-      <SendModal
-        isOpen={true}
-        onClose={mockOnClose}
-        walletAddress={mockWalletAddress}
-        balance={mockBalance}
-      />
-    );
-
+    const addressInput = screen.getByPlaceholderText('Enter recipient address or search contacts...');
+    const amountInput = screen.getByPlaceholderText('0.00');
     const sendButton = screen.getByRole('button', { name: /^Send$/i });
 
-    // Button is enabled (not sending) — validation happens inside handleSend
-    expect(sendButton).not.toBeDisabled();
+    fireEvent.change(addressInput, { target: { value: mockRecipientAddress } });
+    fireEvent.change(amountInput, { target: { value: '100' } });
+    fireEvent.click(sendButton);
 
-    // Fill address and amount — still enabled
-    fireEvent.change(screen.getByPlaceholderText('Enter recipient address or search contacts...'), {
-      target: { value: '0x9876543210987654321098765432109876543210' },
+    await waitFor(() => {
+      expect(sendButton).toBeDisabled();
     });
-    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '100' } });
-    expect(sendButton).not.toBeDisabled();
   });
 
   it('should reset form when modal closes', () => {
@@ -383,7 +385,7 @@ describe('SendModal', () => {
     );
 
     fireEvent.change(screen.getByPlaceholderText('Enter recipient address or search contacts...'), {
-      target: { value: '0x9876543210987654321098765432109876543210' },
+      target: { value: mockRecipientAddress },
     });
     fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '100' } });
 
@@ -391,7 +393,6 @@ describe('SendModal', () => {
     rerender(<SendModal isOpen={false} onClose={mockOnClose} walletAddress={mockWalletAddress} balance={mockBalance} />);
     rerender(<SendModal isOpen={true} onClose={mockOnClose} walletAddress={mockWalletAddress} balance={mockBalance} />);
 
-    // Re-query after rerender
     expect(screen.getByPlaceholderText('Enter recipient address or search contacts...')).toHaveValue('');
     expect(screen.getByPlaceholderText('0.00')).toHaveValue(null);
   });

--- a/client/src/features/contacts/components/SendModal.tsx
+++ b/client/src/features/contacts/components/SendModal.tsx
@@ -4,9 +4,14 @@
  */
 
 import React, { useState } from 'react';
-import { X, Send, ArrowDownRight } from 'lucide-react';
+import { X, Send, ArrowDownRight, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { AddressAutocomplete, ContactsModal } from '../index';
 import type { Contact, ContactSuggestion } from '../types';
+import * as StellarSdk from "@stellar/stellar-sdk";
+import { useWallet } from "../../../context/useWallet";
+import { executeContractCallOn } from "../../../services/soroban";
+import type { TxPhase } from "../../../services/transactionPhase";
+import TxStatusTimeline from "../../../components/transaction/TxStatusTimeline";
 
 interface SendModalProps {
   isOpen: boolean;
@@ -15,15 +20,13 @@ interface SendModalProps {
   balance: string;
 }
 
-/**
- * Send Modal Component - Example integration
- */
 export function SendModal({ isOpen, onClose, walletAddress, balance }: SendModalProps) {
+  const { signTransaction } = useWallet();
   const [recipientAddress, setRecipientAddress] = useState('');
   const [amount, setAmount] = useState('');
   const [showContacts, setShowContacts] = useState(false);
   const [selectedContact, setSelectedContact] = useState<ContactSuggestion | null>(null);
-  const [isSending, setIsSending] = useState(false);
+  const [txPhase, setTxPhase] = useState<TxPhase>("idle");
   const [error, setError] = useState<string | null>(null);
 
   // Reset form when modal opens/closes
@@ -33,12 +36,10 @@ export function SendModal({ isOpen, onClose, walletAddress, balance }: SendModal
       setAmount('');
       setSelectedContact(null);
       setError(null);
+      setTxPhase("idle");
     }
   }, [isOpen]);
 
-  /**
-   * Handle contact selection from address book
-   */
   const handleContactSelect = (contact: ContactSuggestion) => {
     setRecipientAddress(contact.address);
     setSelectedContact(contact);
@@ -55,52 +56,69 @@ export function SendModal({ isOpen, onClose, walletAddress, balance }: SendModal
     handleContactSelect(suggestion);
   };
 
-  /**
-   * Handle send transaction
-   */
   const handleSend = async () => {
     if (!recipientAddress || !amount) {
       setError('Please fill in all fields');
       return;
     }
 
-    if (parseFloat(amount) <= 0) {
+    if (!StellarSdk.StrKey.isValidEd25519PublicKey(recipientAddress)) {
+      setError('Invalid recipient address format');
+      return;
+    }
+
+    const numAmount = parseFloat(amount);
+    if (isNaN(numAmount) || numAmount <= 0) {
       setError('Amount must be greater than 0');
       return;
     }
 
-    if (parseFloat(amount) > parseFloat(balance)) {
+    if (numAmount > parseFloat(balance)) {
       setError('Insufficient balance');
       return;
     }
 
-    setIsSending(true);
     setError(null);
+    setTxPhase("building");
 
     try {
-      // Simulate transaction processing
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // In a real implementation, this would integrate with the actual transaction service
-      console.log('Sending transaction:', {
-        from: walletAddress,
-        to: recipientAddress,
-        amount,
-        contact: selectedContact,
-      });
+      const tokenContract =
+        import.meta.env.VITE_USDC_SAC_CONTRACT_ID ||
+        import.meta.env.VITE_VAULT_TOKEN_CONTRACT_ID ||
+        "";
 
-      // Close modal on success
-      onClose();
+      if (!tokenContract) {
+        throw new Error("Token contract address is not configured");
+      }
+
+      // Convert amount to stroops (7 decimals for USDC)
+      const stroopsAmount = BigInt(Math.round(numAmount * 10_000_000));
+
+      const fromScVal = new StellarSdk.Address(walletAddress).toScVal();
+      const toScVal = new StellarSdk.Address(recipientAddress).toScVal();
+      const amountScVal = StellarSdk.nativeToScVal(stroopsAmount, { type: "i128" });
+
+      const res = await executeContractCallOn(
+        tokenContract,
+        walletAddress,
+        "transfer",
+        [fromScVal, toScVal, amountScVal],
+        (phase) => setTxPhase(phase),
+        false,
+        signTransaction
+      );
+
+      if (!res.success) {
+        throw new Error(res.error || "Transaction submission failed");
+      }
+
+      setTxPhase("success");
     } catch (err) {
+      setTxPhase("failure");
       setError(err instanceof Error ? err.message : 'Transaction failed');
-    } finally {
-      setIsSending(false);
     }
   };
 
-  /**
-   * Handle max amount click
-   */
   const handleMaxClick = () => {
     setAmount(balance);
   };
@@ -110,7 +128,7 @@ export function SendModal({ isOpen, onClose, walletAddress, balance }: SendModal
   return (
     <>
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-slate-900 rounded-lg w-full max-w-md mx-4">
+        <div className="bg-slate-900 rounded-lg w-full max-w-md mx-4 overflow-hidden border border-slate-700">
           {/* Header */}
           <div className="flex items-center justify-between p-6 border-b border-slate-700">
             <h2 className="text-2xl font-bold text-white flex items-center gap-2">
@@ -126,131 +144,161 @@ export function SendModal({ isOpen, onClose, walletAddress, balance }: SendModal
             </button>
           </div>
 
-          {/* Balance Display */}
-          <div className="p-6 border-b border-slate-700">
-            <div className="text-sm text-gray-400 mb-1">Available Balance</div>
-            <div className="text-2xl font-bold text-white">{balance} USDC</div>
-          </div>
-
-          {/* Form */}
-          <div className="p-6 space-y-4">
-            {/* Recipient Address with Auto-complete */}
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Recipient Address
-              </label>
-              <div className="relative">
-                <AddressAutocomplete
-                  value={recipientAddress}
-                  onChange={setRecipientAddress}
-                  onSelectContact={handleContactSelect}
-                  placeholder="Enter recipient address or search contacts..."
-                  className="w-full"
-                />
+          {txPhase === "success" ? (
+            <div className="p-8 text-center space-y-6">
+              <div className="bg-green-500/20 w-16 h-16 rounded-full flex items-center justify-center mx-auto border border-green-500/30">
+                <CheckCircle2 className="text-green-500" size={32} />
               </div>
-              {selectedContact && (
-                <div className="mt-2 text-sm text-green-400 flex items-center gap-1">
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                  </svg>
-                  Sending to {selectedContact.name}
-                </div>
-              )}
-            </div>
-
-            {/* Amount */}
-            <div>
-              <label className="block text-sm font-medium text-gray-300 mb-2">
-                Amount (USDC)
-              </label>
-              <div className="relative">
-                <input
-                  type="number"
-                  value={amount}
-                  onChange={(e) => setAmount(e.target.value)}
-                  placeholder="0.00"
-                  className="w-full px-4 py-2 pr-16 bg-slate-800 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                  min="0"
-                  step="0.01"
-                />
-                <button
-                  type="button"
-                  onClick={handleMaxClick}
-                  className="absolute right-2 top-1/2 transform -translate-y-1/2 px-2 py-1 text-xs bg-indigo-500 text-white rounded hover:bg-indigo-600 transition-colors"
-                >
-                  MAX
-                </button>
-              </div>
-            </div>
-
-            {/* Error Display */}
-            {error && (
-              <div className="bg-red-500/10 border border-red-500/50 text-red-400 p-3 rounded-lg">
-                {error}
-              </div>
-            )}
-
-            {/* Transaction Summary */}
-            {recipientAddress && amount && (
-              <div className="bg-slate-800 rounded-lg p-4 space-y-2">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">To:</span>
-                  <span className="text-white font-mono">
+              <div className="space-y-2">
+                <h3 className="text-xl font-bold text-white">Send Successful</h3>
+                <p className="text-gray-400 text-sm">
+                  You successfully sent <span className="text-white font-bold">{amount} USDC</span> to{" "}
+                  <span className="text-indigo-300 font-mono">
                     {recipientAddress.slice(0, 6)}...{recipientAddress.slice(-4)}
-                  </span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Amount:</span>
-                  <span className="text-white font-semibold">{amount} USDC</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-gray-400">Network Fee:</span>
-                  <span className="text-white">~0.001 USDC</span>
-                </div>
-                <div className="border-t border-slate-700 pt-2">
-                  <div className="flex items-center justify-between">
-                    <span className="text-gray-300">Total:</span>
-                    <span className="text-white font-bold">
-                      {(parseFloat(amount) + 0.001).toFixed(3)} USDC
-                    </span>
-                  </div>
-                </div>
+                  </span>.
+                </p>
               </div>
-            )}
-
-            {/* Action Buttons */}
-            <div className="flex gap-3">
               <button
                 onClick={onClose}
-                className="flex-1 px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-600 transition-colors"
-                disabled={isSending}
+                className="w-full bg-white text-black py-3 rounded-xl font-bold uppercase text-xs hover:bg-gray-200 transition-all"
               >
-                Cancel
-              </button>
-              <button
-                onClick={handleSend}
-                disabled={isSending}
-                className="flex-1 px-4 py-2 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
-              >
-                {isSending ? (
-                  <>
-                    <div className="animate-spin">
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <circle cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-                        <path fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
-                      </svg>
-                    </div>
-                    Sending...
-                  </>
-                ) : (
-                  <>
-                    <ArrowDownRight size={16} />
-                    Send
-                  </>
-                )}
+                Close
               </button>
             </div>
-          </div>
+          ) : (
+            <>
+              {/* Balance Display */}
+              <div className="p-6 border-b border-slate-700">
+                <div className="text-sm text-gray-400 mb-1">Available Balance</div>
+                <div className="text-2xl font-bold text-white">{balance} USDC</div>
+              </div>
+
+              {/* Form */}
+              <div className="p-6 space-y-4">
+                {txPhase !== "idle" && txPhase !== "failure" ? (
+                  <div className="p-4 bg-slate-800 rounded-lg">
+                    <TxStatusTimeline
+                      steps={[
+                        "building",
+                        "simulating",
+                        "waiting_for_wallet",
+                        "submitting",
+                        "polling",
+                      ]}
+                      phase={txPhase}
+                      errorMessage={error || undefined}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    {/* Recipient Address with Auto-complete */}
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">
+                        Recipient Address
+                      </label>
+                      <div className="relative">
+                        <AddressAutocomplete
+                          value={recipientAddress}
+                          onChange={setRecipientAddress}
+                          onSelectContact={handleContactSelect}
+                          placeholder="Enter recipient address or search contacts..."
+                          className="w-full"
+                        />
+                      </div>
+                      {selectedContact && (
+                        <div className="mt-2 text-sm text-green-400 flex items-center gap-1">
+                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                          </svg>
+                          Sending to {selectedContact.name}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Amount */}
+                    <div>
+                      <label className="block text-sm font-medium text-gray-300 mb-2">
+                        Amount (USDC)
+                      </label>
+                      <div className="relative">
+                        <input
+                          type="number"
+                          value={amount}
+                          onChange={(e) => setAmount(e.target.value)}
+                          placeholder="0.00"
+                          className="w-full px-4 py-2 pr-16 bg-slate-800 text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 border border-slate-700"
+                          min="0"
+                          step="0.01"
+                        />
+                        <button
+                          type="button"
+                          onClick={handleMaxClick}
+                          className="absolute right-2 top-1/2 transform -translate-y-1/2 px-2 py-1 text-xs bg-indigo-500 text-white rounded hover:bg-indigo-600 transition-colors"
+                        >
+                          MAX
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Error Display */}
+                    {error && (
+                      <div className="bg-red-500/10 border border-red-500/50 text-red-400 p-3 rounded-lg flex items-center gap-2 text-xs">
+                        <AlertCircle className="shrink-0" size={16} />
+                        <span>{error}</span>
+                      </div>
+                    )}
+
+                    {/* Transaction Summary */}
+                    {recipientAddress && amount && !error && (
+                      <div className="bg-slate-800 rounded-lg p-4 space-y-2">
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="text-gray-400">To:</span>
+                          <span className="text-white font-mono">
+                            {recipientAddress.slice(0, 6)}...{recipientAddress.slice(-4)}
+                          </span>
+                        </div>
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="text-gray-400">Amount:</span>
+                          <span className="text-white font-semibold">{amount} USDC</span>
+                        </div>
+                        <div className="flex items-center justify-between text-sm">
+                          <span className="text-gray-400">Network Fee:</span>
+                          <span className="text-white">~0.001 USDC</span>
+                        </div>
+                        <div className="border-t border-slate-700 pt-2">
+                          <div className="flex items-center justify-between">
+                            <span className="text-gray-300">Total:</span>
+                            <span className="text-white font-bold">
+                              {(parseFloat(amount) + 0.001).toFixed(3)} USDC
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {/* Action Buttons */}
+                <div className="flex gap-3">
+                  <button
+                    onClick={onClose}
+                    className="flex-1 px-4 py-2 bg-slate-700 text-white rounded-lg hover:bg-slate-600 transition-colors"
+                    disabled={txPhase !== "idle" && txPhase !== "failure"}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    onClick={handleSend}
+                    disabled={txPhase !== "idle" && txPhase !== "failure"}
+                    className="flex-1 px-4 py-2 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                  >
+                    <ArrowDownRight size={16} />
+                    Send
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/client/src/features/onramp/OnRampModal.tsx
+++ b/client/src/features/onramp/OnRampModal.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { CreditCard, ArrowRight, CheckCircle2, ShieldCheck, DollarSign } from "lucide-react";
+import React, { useState, useEffect, useRef } from "react";
+import { CreditCard, ArrowRight, CheckCircle2, ShieldCheck, DollarSign, AlertCircle } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 
 interface OnRampModalProps {
@@ -8,50 +8,174 @@ interface OnRampModalProps {
   walletAddress: string;
 }
 
+interface Quote {
+  quoteId: string;
+  provider: string;
+  amountFiat: number;
+  currency: string;
+  amountUsdc: number;
+  expiresAt: number;
+}
+
 const OnRampModal: React.FC<OnRampModalProps> = ({ isOpen, onClose, walletAddress }) => {
   const [fiatAmount, setFiatAmount] = useState<number>(100);
   const [currency, setCurrency] = useState("USD");
+  const [quote, setQuote] = useState<Quote | null>(null);
+  const [timeLeft, setTimeLeft] = useState<number>(0);
   const [isProcessing, setIsProcessing] = useState(false);
   const [isCompleted, setIsCompleted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [txId, setTxId] = useState<string | null>(null);
+  const [processingStatus, setProcessingStatus] = useState<string | null>(null);
 
-  // Mock exchange rate
-  const usdcRate = 0.98; // 1 USD = 0.98 USDC after fees
-  const estimatedUsdc = (fiatAmount * usdcRate).toFixed(2);
+  const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Fetch quote helper
+  const fetchQuote = async (amount: number, curr: string) => {
+    if (amount <= 0) return;
+    setError(null);
+    try {
+      const res = await fetch(apiUrl("/api/onramp/quote"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ amountFiat: amount, currency: curr }),
+      });
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.error || "Failed to fetch quote");
+      }
+      const data = (await res.json()) as Quote;
+      setQuote(data);
+      setTimeLeft(Math.max(0, Math.ceil((data.expiresAt - Date.now()) / 1000)));
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Error getting quote");
+      setQuote(null);
+    }
+  };
+
+  // Debounced quote fetch
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = setTimeout(() => {
+      fetchQuote(fiatAmount, currency);
+    }, 400);
+
+    return () => clearTimeout(handler);
+  }, [fiatAmount, currency, isOpen]);
+
+  // Expiration countdown ticker
+  useEffect(() => {
+    if (!quote) return;
+
+    const ticker = setInterval(() => {
+      const remaining = Math.max(0, Math.ceil((quote.expiresAt - Date.now()) / 1000));
+      setTimeLeft(remaining);
+      if (remaining <= 0) {
+        clearInterval(ticker);
+      }
+    }, 1000);
+
+    return () => clearInterval(ticker);
+  }, [quote]);
+
+  // Clean up polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+      }
+    };
+  }, []);
+
+  const handleCancel = async () => {
+    if (!txId) {
+      onClose();
+      return;
+    }
+    try {
+      await fetch(apiUrl("/api/onramp/cancel"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ txId }),
+      });
+    } catch (err) {
+      console.error("Cancel failed", err);
+    } finally {
+      if (pollIntervalRef.current) {
+        clearInterval(pollIntervalRef.current);
+      }
+      setTxId(null);
+      setIsProcessing(false);
+      onClose();
+    }
+  };
 
   const handlePurchase = async () => {
+    if (!quote || timeLeft <= 0) {
+      setError("Quote is expired. Please refresh the quote.");
+      return;
+    }
+
     setIsProcessing(true);
-    
-    // Simulate API call to on-ramp provider
-    setTimeout(async () => {
-      try {
-        await fetch(apiUrl("/api/onramp/webhook"), {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            provider: "STRIPE",
-            txId: `tx_${Math.random().toString(36).substr(2, 9)}`,
-            status: "COMPLETED",
-            walletAddress,
-            amountFiat: fiatAmount,
-            currency,
-            amountUsdc: parseFloat(estimatedUsdc),
-          }),
-        });
-        
-        setIsProcessing(false);
-        setIsCompleted(true);
-      } catch (err) {
-        console.error("Failed to notify backend", err);
-        setIsProcessing(false);
+    setError(null);
+    setProcessingStatus("Creating intent...");
+
+    try {
+      const res = await fetch(apiUrl("/api/onramp/intent"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          quoteId: quote.quoteId,
+          walletAddress,
+        }),
+      });
+
+      if (!res.ok) {
+        const errData = await res.json();
+        throw new Error(errData.error || "Failed to confirm intent");
       }
-    }, 2000);
+
+      const { transaction } = await res.json();
+      const currentTxId = transaction.providerTxId;
+      setTxId(currentTxId);
+      setProcessingStatus("Waiting for payment processing...");
+
+      // Start status polling
+      pollIntervalRef.current = setInterval(async () => {
+        try {
+          const statusRes = await fetch(apiUrl(`/api/onramp/status/${currentTxId}`));
+          if (statusRes.ok) {
+            const { status } = await statusRes.json();
+            if (status === "COMPLETED") {
+              if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+              setIsProcessing(false);
+              setIsCompleted(true);
+            } else if (status === "FAILED") {
+              if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
+              setIsProcessing(false);
+              setError("Payment failed. Please try again.");
+            }
+          }
+        } catch (pollErr) {
+          console.error("Status poll error", pollErr);
+        }
+      }, 2000);
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Failed to initiate purchase");
+      setIsProcessing(false);
+    }
   };
 
   if (!isOpen) return null;
 
+  const isQuoteExpired = timeLeft <= 0;
+  const estimatedUsdc = quote ? quote.amountUsdc.toFixed(2) : (fiatAmount * 0.98).toFixed(2);
+
   return (
     <div className="fixed inset-0 z-[100] flex items-center justify-center p-4">
-      <div className="fixed inset-0 bg-black/80 backdrop-blur-xl animate-in fade-in duration-300" onClick={onClose}></div>
+      <div className="fixed inset-0 bg-black/80 backdrop-blur-xl animate-in fade-in duration-300" onClick={handleCancel}></div>
       
       <div className="glass-panel w-full max-w-lg overflow-hidden border border-white/10 shadow-[0_0_100px_rgba(79,70,229,0.3)] z-[101] animate-in zoom-in-95 duration-300">
         {!isCompleted ? (
@@ -62,7 +186,7 @@ const OnRampModal: React.FC<OnRampModalProps> = ({ isOpen, onClose, walletAddres
                 BUY USDC
               </h2>
               <div className="bg-indigo-500/10 px-3 py-1 rounded-full border border-indigo-500/20">
-                <span className="text-[10px] font-black tracking-widest text-indigo-400 uppercase">Stripe SECURE</span>
+                <span className="text-[10px] font-black tracking-widest text-indigo-400 uppercase">Secure Quote</span>
               </div>
             </div>
 
@@ -73,11 +197,13 @@ const OnRampModal: React.FC<OnRampModalProps> = ({ isOpen, onClose, walletAddres
                   <input 
                     type="number"
                     value={fiatAmount}
+                    disabled={isProcessing}
                     onChange={(e) => setFiatAmount(parseFloat(e.target.value) || 0)}
                     className="bg-transparent text-3xl font-black w-full outline-none focus:text-indigo-400 transition-colors"
                   />
                   <select 
                     value={currency}
+                    disabled={isProcessing}
                     onChange={(e) => setCurrency(e.target.value)}
                     className="bg-white/10 rounded-xl px-3 py-1 text-sm font-bold border-none outline-none focus:ring-1 focus:ring-indigo-500"
                   >
@@ -106,6 +232,34 @@ const OnRampModal: React.FC<OnRampModalProps> = ({ isOpen, onClose, walletAddres
               </div>
             </div>
 
+            {quote && !isProcessing && (
+              <div className="flex justify-between items-center px-2 text-xs">
+                {isQuoteExpired ? (
+                  <span className="text-red-400 font-bold flex items-center gap-1">
+                    <AlertCircle size={14} /> Quote expired
+                  </span>
+                ) : (
+                  <span className="text-gray-400">
+                    Quote expires in <span className="text-indigo-400 font-bold">{timeLeft}s</span>
+                  </span>
+                )}
+                <button
+                  type="button"
+                  onClick={() => fetchQuote(fiatAmount, currency)}
+                  className="text-indigo-400 hover:text-indigo-300 font-bold underline transition-colors"
+                >
+                  Refresh Quote
+                </button>
+              </div>
+            )}
+
+            {error && (
+              <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-xs text-red-400">
+                <AlertCircle className="shrink-0" size={16} />
+                <span>{error}</span>
+              </div>
+            )}
+
             <div className="p-4 bg-indigo-500/5 rounded-2xl border border-indigo-500/20 flex gap-4 items-center">
               <ShieldCheck className="text-indigo-400 shrink-0" size={24} />
               <div className="text-xs space-y-1">
@@ -114,22 +268,31 @@ const OnRampModal: React.FC<OnRampModalProps> = ({ isOpen, onClose, walletAddres
               </div>
             </div>
 
-            <button 
-              onClick={handlePurchase}
-              disabled={isProcessing}
-              className={`w-full py-4 rounded-2xl font-black tracking-widest uppercase text-sm transition-all shadow-xl shadow-indigo-500/20 active:scale-[0.98] ${
-                isProcessing ? 'bg-indigo-800 cursor-not-allowed opacity-50' : 'bg-indigo-500 hover:bg-indigo-400 text-white'
-              }`}
-            >
-              {isProcessing ? (
-                <div className="flex items-center justify-center gap-3">
-                  <div className="animate-spin h-5 w-5 border-2 border-white/30 border-t-white rounded-full"></div>
-                  AUTHORIZING...
-                </div>
-              ) : (
-                `PAY ${fiatAmount} ${currency}`
-              )}
-            </button>
+            <div className="flex gap-3">
+              <button 
+                type="button"
+                onClick={handleCancel}
+                className="flex-1 py-4 rounded-2xl font-black tracking-widest uppercase text-sm border border-white/10 hover:bg-white/5 transition-all text-white"
+              >
+                Cancel
+              </button>
+              <button 
+                onClick={handlePurchase}
+                disabled={isProcessing || isQuoteExpired || !quote}
+                className={`flex-[2] py-4 rounded-2xl font-black tracking-widest uppercase text-sm transition-all shadow-xl shadow-indigo-500/20 active:scale-[0.98] ${
+                  isProcessing || isQuoteExpired || !quote ? 'bg-indigo-800 cursor-not-allowed opacity-50' : 'bg-indigo-500 hover:bg-indigo-400 text-white'
+                }`}
+              >
+                {isProcessing ? (
+                  <div className="flex items-center justify-center gap-3">
+                    <div className="animate-spin h-5 w-5 border-2 border-white/30 border-t-white rounded-full"></div>
+                    {processingStatus?.toUpperCase()}
+                  </div>
+                ) : (
+                  `PAY ${fiatAmount} ${currency}`
+                )}
+              </button>
+            </div>
             <p className="text-center text-[10px] text-gray-600 font-medium">Estimated arrival: Within 2 minutes</p>
           </div>
         ) : (

--- a/client/src/features/portfolio_builder/PortfolioBuilder.test.tsx
+++ b/client/src/features/portfolio_builder/PortfolioBuilder.test.tsx
@@ -1,0 +1,126 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import PortfolioBuilder from "./PortfolioBuilder";
+import { deposit } from "../../services/soroban";
+
+// Mock useWallet
+const mockSignTransaction = vi.fn().mockResolvedValue("mock-signed-xdr");
+vi.mock("../../context/useWallet", () => ({
+  useWallet: () => ({
+    walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    isConnected: true,
+    signTransaction: mockSignTransaction,
+  }),
+}));
+
+// Mock deposit service
+vi.mock("../../services/soroban", () => ({
+  deposit: vi.fn(),
+}));
+
+const mockAvailableVaults = [
+  { contractId: "vault-1", name: "Blend Vault", apy: 12.5 },
+  { contractId: "vault-2", name: "Soroswap Vault", apy: 8.4 },
+];
+
+describe("PortfolioBuilder Component", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("renders correctly with available vaults", () => {
+    render(
+      <PortfolioBuilder
+        walletAddress="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+        availableVaults={mockAvailableVaults}
+      />
+    );
+
+    expect(screen.getByText("Portfolio Allocation")).toBeInTheDocument();
+    expect(screen.getByText("Blend Vault")).toBeInTheDocument();
+    expect(screen.getByText("Soroswap Vault")).toBeInTheDocument();
+  });
+
+  it("handles mock execution flow when opt-in checkbox is unchecked", async () => {
+    render(
+      <PortfolioBuilder
+        walletAddress="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+        availableVaults={mockAvailableVaults}
+      />
+    );
+
+    // Enter amount
+    const amountInput = screen.getByPlaceholderText("Enter amount to allocate");
+    fireEvent.change(amountInput, { target: { value: "100" } });
+
+    // Execute button
+    const executeBtn = screen.getByText("Execute Multi-Vault Deposit");
+    fireEvent.click(executeBtn);
+
+    // Should enter timeline phases without calling real deposit
+    expect(screen.getByText("Building transaction")).toBeInTheDocument();
+    expect(deposit).not.toHaveBeenCalled();
+  });
+
+  it("handles signed execution flow when opt-in checkbox is checked", async () => {
+    vi.mocked(deposit).mockResolvedValue({
+      success: true,
+      hash: "0x123",
+    });
+
+    render(
+      <PortfolioBuilder
+        walletAddress="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+        availableVaults={mockAvailableVaults}
+      />
+    );
+
+    // Enter amount
+    const amountInput = screen.getByPlaceholderText("Enter amount to allocate");
+    fireEvent.change(amountInput, { target: { value: "100" } });
+
+    // Check opt-in checkbox
+    const checkbox = screen.getByLabelText(/Execute transaction on-chain/i);
+    fireEvent.click(checkbox);
+
+    // Execute button
+    const executeBtn = screen.getByText("Execute Multi-Vault Deposit");
+    fireEvent.click(executeBtn);
+
+    await waitFor(() => {
+      expect(deposit).toHaveBeenCalled();
+    });
+  });
+
+  it("handles signed execution failure correctly", async () => {
+    vi.mocked(deposit).mockResolvedValue({
+      success: false,
+      error: "User rejected signing",
+    });
+
+    render(
+      <PortfolioBuilder
+        walletAddress="GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+        availableVaults={mockAvailableVaults}
+      />
+    );
+
+    // Enter amount
+    const amountInput = screen.getByPlaceholderText("Enter amount to allocate");
+    fireEvent.change(amountInput, { target: { value: "100" } });
+
+    // Check opt-in checkbox
+    const checkbox = screen.getByLabelText(/Execute transaction on-chain/i);
+    fireEvent.click(checkbox);
+
+    // Execute button
+    const executeBtn = screen.getByText("Execute Multi-Vault Deposit");
+    fireEvent.click(executeBtn);
+
+    await waitFor(() => {
+      expect(deposit).toHaveBeenCalled();
+    });
+
+    expect(screen.getAllByText("User rejected signing").length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/features/portfolio_builder/PortfolioBuilder.tsx
+++ b/client/src/features/portfolio_builder/PortfolioBuilder.tsx
@@ -16,6 +16,8 @@ import {
   applyPreset,
 } from "./portfolioUtils";
 import RebalancePreview from "./RebalancePreviewPanel";
+import { useWallet } from "../../context/useWallet";
+import { deposit } from "../../services/soroban";
 
 export interface PortfolioBuilderProps {
   walletAddress: string | null;
@@ -38,6 +40,7 @@ export default function PortfolioBuilder({
   walletAddress,
   availableVaults,
 }: PortfolioBuilderProps) {
+  const { signTransaction } = useWallet();
   const [totalAmount, setTotalAmount] = useState("");
   const [allocations, setAllocations] = useState<VaultAllocation[]>(() =>
     buildInitialAllocations(availableVaults),
@@ -48,6 +51,7 @@ export default function PortfolioBuilder({
   );
   const [txPhase, setTxPhase] = useState<TxPhase>("idle");
   const [error, setError] = useState("");
+  const [executeTx, setExecuteTx] = useState(false);
 
   const handlePresetApply = useCallback(
     (preset: PortfolioPreset) => {
@@ -96,26 +100,59 @@ export default function PortfolioBuilder({
     setTxPhase("building");
 
     try {
-      // In production: build batched XDR transaction
-      // For now: simulate the flow
-      setTxPhase("simulating");
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      if (executeTx) {
+        const activeAllocations = distributedAllocations.filter(
+          (a) => a.amount > 0n,
+        );
+        if (activeAllocations.length === 0) {
+          throw new Error("No allocations to execute");
+        }
+        for (const alloc of activeAllocations) {
+          // Deposit into each vault with 1% slippage limit
+          const minShares = (alloc.amount * 99n) / 100n;
+          const res = await deposit(
+            walletAddress,
+            alloc.amount,
+            minShares,
+            (phase) => setTxPhase(phase),
+            true,
+            signTransaction,
+          );
+          if (!res.success) {
+            throw new Error(
+              res.error || `Failed to deposit into ${alloc.vaultName}`,
+            );
+          }
+        }
+        setTxPhase("success");
+      } else {
+        // Mock flow
+        setTxPhase("simulating");
+        await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      setTxPhase("waiting_for_wallet");
-      await new Promise((resolve) => setTimeout(resolve, 500));
+        setTxPhase("waiting_for_wallet");
+        await new Promise((resolve) => setTimeout(resolve, 500));
 
-      setTxPhase("submitting");
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+        setTxPhase("submitting");
+        await new Promise((resolve) => setTimeout(resolve, 1000));
 
-      setTxPhase("polling");
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+        setTxPhase("polling");
+        await new Promise((resolve) => setTimeout(resolve, 2000));
 
-      setTxPhase("success");
+        setTxPhase("success");
+      }
     } catch (err) {
       setTxPhase("failure");
       setError(err instanceof Error ? err.message : "Deposit failed");
     }
-  }, [walletAddress, totalAmount, isValid]);
+  }, [
+    walletAddress,
+    totalAmount,
+    isValid,
+    executeTx,
+    distributedAllocations,
+    signTransaction,
+  ]);
 
   return (
     <div className="space-y-6">
@@ -253,6 +290,20 @@ export default function PortfolioBuilder({
           <span className="text-sm text-red-400">{error}</span>
         </div>
       )}
+
+      {/* Opt-in Checkbox */}
+      <div className="flex items-center gap-2 px-1">
+        <input
+          type="checkbox"
+          id="execute-tx-toggle"
+          checked={executeTx}
+          onChange={(e) => setExecuteTx(e.target.checked)}
+          className="rounded border-gray-600 bg-black/50 text-purple-600 focus:ring-purple-500"
+        />
+        <label htmlFor="execute-tx-toggle" className="text-sm text-gray-300">
+          Execute transaction on-chain (wallet signature required)
+        </label>
+      </div>
 
       {/* Execute Button */}
       <button

--- a/client/src/services/soroban.ts
+++ b/client/src/services/soroban.ts
@@ -265,6 +265,53 @@ export async function executeContractCall(
 }
 
 /**
+ * Execute a contract call on a specific contract ID: build → sign → submit → poll.
+ */
+export async function executeContractCallOn(
+  contractId: string,
+  sourcePublicKey: string,
+  method: string,
+  args: StellarSdk.xdr.ScVal[],
+  onPhase?: TxPhaseCallback,
+  useFeeBump: boolean = false,
+  signTx?: (xdr: string, networkPassphrase: string) => Promise<string>,
+  txSettings?: TxSettings,
+): Promise<TxResult> {
+  try {
+    const contract = new StellarSdk.Contract(contractId);
+    const xdr = await buildContractCallOn(contract, sourcePublicKey, method, args, onPhase, txSettings);
+
+    onPhase?.("waiting_for_wallet");
+    const signer = signTx ?? ((x: string, p: string) => signWithFreighter(x, p));
+    const signedXdr = await signer(xdr, NETWORK_PASSPHRASE);
+
+    let finalXdr = signedXdr;
+    if (useFeeBump) {
+      onPhase?.("submitting");
+      const resp = await fetch("/api/relayer/fee-bump", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ innerTxXdr: signedXdr }),
+      });
+      const { feeBumpXdr } = await resp.json();
+      finalXdr = feeBumpXdr;
+    }
+
+    const result = await submitAndPoll(finalXdr, onPhase);
+
+    onPhase?.(result.success ? "success" : "failure");
+    return result;
+  } catch (err) {
+    onPhase?.("failure");
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+
+/**
  * Invoke a method on the Zap contract (swap + `deposit_for` in one tx).
  *
  * Uses the same build → sign → submit flow as `executeContractCall`.

--- a/server/src/__tests__/governanceForecast.test.ts
+++ b/server/src/__tests__/governanceForecast.test.ts
@@ -8,6 +8,8 @@ const baseBaseline = {
   exposurePct: 40,
   feeRatePct: 2,
   tvlUsd: 10_000_000,
+  riskScore: 50,
+  vaultCount: 3,
 };
 
 function makeInput(overrides: Partial<GovernanceForecastInput> = {}): GovernanceForecastInput {
@@ -56,7 +58,7 @@ describe("forecastGovernanceProposal — fee_change", () => {
   });
 });
 
-describe("forecastGovernanceProposal — allocation_limit", () => {
+describe("Diversification & Allocation Limit", () => {
   it("reducing max concentration lowers exposure", () => {
     const result = forecastGovernanceProposal(
       makeInput({ proposalType: "allocation_limit", parameters: { maxConcentrationPct: 20 } }),
@@ -80,7 +82,7 @@ describe("forecastGovernanceProposal — allocation_limit", () => {
   });
 });
 
-describe("forecastGovernanceProposal — strategy_param", () => {
+describe("Strategy Parameters", () => {
   it("apyMultiplier > 1 increases projected yield", () => {
     const result = forecastGovernanceProposal(
       makeInput({ proposalType: "strategy_param", parameters: { apyMultiplier: 1.2, riskMultiplier: 1 } }),
@@ -103,7 +105,7 @@ describe("forecastGovernanceProposal — strategy_param", () => {
   });
 });
 
-describe("forecastGovernanceProposal — reward_change", () => {
+describe("Reward Changes", () => {
   it("flags incomplete reward changes as high risk", () => {
     const result = forecastGovernanceProposal(
       makeInput({
@@ -116,31 +118,43 @@ describe("forecastGovernanceProposal — reward_change", () => {
   });
 });
 
-describe("forecastGovernanceProposal — impact summary", () => {
-  it("marks fee proposals with unchanged inputs as no-op", () => {
-    const result = forecastGovernanceProposal(
-      makeInput({ parameters: { feeRatePct: baseBaseline.feeRatePct } }),
-    );
-    expect(result.impactSummary.noOp).toBe(true);
+describe("Proposal Lifecycle Parity Simulation Tests", () => {
+  it("successful proposal (valid bounds, improves parameters)", () => {
+    const input = makeInput({
+      proposalType: "strategy_param",
+      parameters: { apyMultiplier: 1.1, riskMultiplier: 0.9 },
+    });
+    const result = forecastGovernanceProposal(input);
+
+    expect(result.impactSummary.riskLevel).toBe("medium"); // 50 + 8 = 58 risk score -> medium
+    expect(result.impactSummary.noOp).toBe(false);
+    expect(result.impactSummary.irreversible).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.forecast.yieldDeltaPct).toBeGreaterThan(0);
+    expect(result.forecast.exposureDeltaPct).toBeLessThan(0);
   });
 
-  it("marks extreme fee changes as irreversible", () => {
-    const result = forecastGovernanceProposal(
-      makeInput({ parameters: { feeRatePct: 0 } }),
-    );
+  it("rejected/invalid proposal (violates contract parameters/bounds)", () => {
+    const input = makeInput({
+      proposalType: "fee_change",
+      parameters: { feeRatePct: -15 }, // invalid fee rate
+    });
+    const result = forecastGovernanceProposal(input);
+
+    expect(result.impactSummary.riskLevel).toBe("high");
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings).toContain("feeRatePct must be between 0 and 100");
+    expect(result.forecast.projectedFeeRatePct).toBe(0); // Clamped
+  });
+
+  it("expired/irreversible proposal (results in irreversible state change)", () => {
+    const input = makeInput({
+      proposalType: "fee_change",
+      parameters: { feeRatePct: 100 }, // irreversible: max fee rate
+    });
+    const result = forecastGovernanceProposal(input);
+
     expect(result.impactSummary.irreversible).toBe(true);
-  });
-});
-
-describe("forecastGovernanceProposal — result structure", () => {
-  it("includes proposalType, parameters, baseline, and forecast", () => {
-    const result = forecastGovernanceProposal(makeInput());
-    expect(result).toHaveProperty("proposalType");
-    expect(result).toHaveProperty("parameters");
-    expect(result).toHaveProperty("baseline");
-    expect(result).toHaveProperty("forecast");
-    expect(result.forecast).toHaveProperty("projectedYieldPct");
-    expect(result.forecast).toHaveProperty("projectedExposurePct");
-    expect(result.forecast).toHaveProperty("projectedFeeRatePct");
+    expect(result.impactSummary.riskLevel).toBe("low"); // No warning, risk score remains 50
   });
 });

--- a/server/src/__tests__/onramp.test.ts
+++ b/server/src/__tests__/onramp.test.ts
@@ -1,0 +1,182 @@
+import request from "supertest";
+import express from "express";
+import onrampRouter from "../routes/onramp";
+
+const mockTransaction = {
+  id: "test-id",
+  providerTxId: "tx_12345",
+  provider: "STRIPE",
+  status: "PENDING",
+  walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+  amountFiat: 100,
+  currency: "USD",
+  amountUsdc: 98,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+const mockTransactionsDb = new Map<string, any>();
+mockTransactionsDb.set("tx_12345", mockTransaction);
+
+jest.mock("@prisma/client", () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      onRampTransaction: {
+        findUnique: jest.fn().mockImplementation(({ where }) => {
+          return Promise.resolve(mockTransactionsDb.get(where.providerTxId) || null);
+        }),
+        create: jest.fn().mockImplementation(({ data }) => {
+          const newTx = {
+            id: `tx_${Math.random()}`,
+            ...data,
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          };
+          mockTransactionsDb.set(data.providerTxId, newTx);
+          return Promise.resolve(newTx);
+        }),
+        update: jest.fn().mockImplementation(({ where, data }) => {
+          const existing = mockTransactionsDb.get(where.providerTxId);
+          if (!existing) return Promise.reject(new Error("Record not found"));
+          const updated = { ...existing, ...data, updatedAt: new Date() };
+          mockTransactionsDb.set(where.providerTxId, updated);
+          return Promise.resolve(updated);
+        }),
+        upsert: jest.fn().mockImplementation(({ where, update, create }) => {
+          const existing = mockTransactionsDb.get(where.providerTxId);
+          if (existing) {
+            const updated = { ...existing, ...update, updatedAt: new Date() };
+            mockTransactionsDb.set(where.providerTxId, updated);
+            return Promise.resolve(updated);
+          } else {
+            const created = {
+              id: `tx_${Math.random()}`,
+              ...create,
+              createdAt: new Date(),
+              updatedAt: new Date(),
+            };
+            mockTransactionsDb.set(where.providerTxId, created);
+            return Promise.resolve(created);
+          }
+        }),
+      },
+      notification: {
+        create: jest.fn().mockResolvedValue({ id: "notif-id" }),
+      },
+      $disconnect: jest.fn(),
+    })),
+  };
+});
+
+const app = express();
+app.use(express.json());
+app.use("/api/onramp", onrampRouter);
+
+describe("On-ramp API Routes", () => {
+  beforeEach(() => {
+    mockTransactionsDb.clear();
+    mockTransactionsDb.set("tx_12345", { ...mockTransaction });
+  });
+
+  describe("POST /api/onramp/quote", () => {
+    it("creates a valid quote", async () => {
+      const res = await request(app)
+        .post("/api/onramp/quote")
+        .send({ amountFiat: 100, currency: "USD", provider: "STRIPE" });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty("quoteId");
+      expect(res.body.amountFiat).toBe(100);
+      expect(res.body.currency).toBe("USD");
+      expect(res.body.amountUsdc).toBe(98);
+      expect(res.body).toHaveProperty("expiresAt");
+    });
+
+    it("returns 400 for negative amounts", async () => {
+      const res = await request(app)
+        .post("/api/onramp/quote")
+        .send({ amountFiat: -50, currency: "USD" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("amountFiat");
+    });
+
+    it("returns 400 for invalid currency codes", async () => {
+      const res = await request(app)
+        .post("/api/onramp/quote")
+        .send({ amountFiat: 100, currency: "US" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("currency");
+    });
+  });
+
+  describe("POST /api/onramp/intent", () => {
+    it("confirms intent and creates pending transaction", async () => {
+      // First generate a quote
+      const quoteRes = await request(app)
+        .post("/api/onramp/quote")
+        .send({ amountFiat: 200, currency: "EUR" });
+      
+      const { quoteId } = quoteRes.body;
+
+      const res = await request(app)
+        .post("/api/onramp/intent")
+        .send({
+          quoteId,
+          walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.transaction.status).toBe("PENDING");
+      expect(res.body.transaction.amountFiat).toBe(200);
+      expect(res.body.transaction.currency).toBe("EUR");
+    });
+
+    it("returns 404 for nonexistent quote", async () => {
+      const res = await request(app)
+        .post("/api/onramp/intent")
+        .send({
+          quoteId: "quote_nonexistent",
+          walletAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain("not found");
+    });
+  });
+
+  describe("GET /api/onramp/status/:txId", () => {
+    it("returns status for existing transaction", async () => {
+      const res = await request(app).get("/api/onramp/status/tx_12345");
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe("PENDING");
+    });
+
+    it("returns 404 for nonexistent transaction", async () => {
+      const res = await request(app).get("/api/onramp/status/tx_unknown");
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("POST /api/onramp/cancel", () => {
+    it("cancels pending transaction", async () => {
+      const res = await request(app)
+        .post("/api/onramp/cancel")
+        .send({ txId: "tx_12345" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.transaction.status).toBe("FAILED");
+    });
+
+    it("returns 404 for unknown transaction", async () => {
+      const res = await request(app)
+        .post("/api/onramp/cancel")
+        .send({ txId: "tx_unknown" });
+
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/server/src/routes/onramp.ts
+++ b/server/src/routes/onramp.ts
@@ -4,6 +4,169 @@ import { PrismaClient } from "@prisma/client";
 const router = Router();
 const prisma = new PrismaClient();
 
+// In-memory cache for quotes (simulate provider behavior)
+interface CachedQuote {
+  quoteId: string;
+  provider: string;
+  amountFiat: number;
+  currency: string;
+  amountUsdc: number;
+  expiresAt: number;
+}
+
+const quoteCache = new Map<string, CachedQuote>();
+
+// Server-side provider credentials simulation
+const getProviderConfig = () => {
+  const apiKey = process.env.ONRAMP_PROVIDER_API_KEY || "mock-server-side-api-key";
+  if (!apiKey) {
+    throw new Error("Missing provider configuration.");
+  }
+  return { apiKey };
+};
+
+// POST /api/onramp/quote - Create a quote
+router.post("/quote", (req: Request, res: Response) => {
+  try {
+    getProviderConfig();
+    const { amountFiat, currency, provider = "STRIPE" } = req.body;
+
+    if (!amountFiat || isNaN(Number(amountFiat)) || Number(amountFiat) <= 0) {
+      res.status(400).json({ error: "Invalid amountFiat. Must be a positive number." });
+      return;
+    }
+
+    if (!currency || typeof currency !== "string" || currency.length !== 3) {
+      res.status(400).json({ error: "Invalid currency. Must be a 3-letter currency code." });
+      return;
+    }
+
+    // Mock conversion rate: 1 Fiat = 0.98 USDC
+    const usdcRate = 0.98;
+    const amountUsdc = Math.round(Number(amountFiat) * usdcRate * 100) / 100;
+
+    const quoteId = `quote_${Math.random().toString(36).substring(2, 11)}`;
+    const expiresAt = Date.now() + 30 * 1000; // 30 seconds expiration
+
+    const quote: CachedQuote = {
+      quoteId,
+      provider,
+      amountFiat: Number(amountFiat),
+      currency: currency.toUpperCase(),
+      amountUsdc,
+      expiresAt,
+    };
+
+    quoteCache.set(quoteId, quote);
+
+    res.json(quote);
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : "Failed to create quote" });
+  }
+});
+
+// POST /api/onramp/intent - Confirm intent and create pending transaction
+router.post("/intent", async (req: Request, res: Response) => {
+  try {
+    getProviderConfig();
+    const { quoteId, walletAddress } = req.body;
+
+    if (!quoteId) {
+      res.status(400).json({ error: "Missing quoteId." });
+      return;
+    }
+
+    if (!walletAddress) {
+      res.status(400).json({ error: "Missing walletAddress." });
+      return;
+    }
+
+    const cachedQuote = quoteCache.get(quoteId);
+    if (!cachedQuote) {
+      res.status(404).json({ error: "Quote not found." });
+      return;
+    }
+
+    if (Date.now() > cachedQuote.expiresAt) {
+      res.status(400).json({ error: "Quote has expired." });
+      return;
+    }
+
+    const txId = `tx_${Math.random().toString(36).substring(2, 11)}`;
+
+    const tx = await prisma.onRampTransaction.create({
+      data: {
+        providerTxId: txId,
+        provider: cachedQuote.provider,
+        status: "PENDING",
+        walletAddress,
+        amountFiat: cachedQuote.amountFiat,
+        currency: cachedQuote.currency,
+        amountUsdc: cachedQuote.amountUsdc,
+      },
+    });
+
+    res.json({ success: true, transaction: tx });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : "Failed to create intent" });
+  }
+});
+
+// GET /api/onramp/status/:txId - Get transaction status
+router.get("/status/:txId", async (req: Request, res: Response) => {
+  try {
+    const { txId } = req.params;
+    const tx = await prisma.onRampTransaction.findUnique({
+      where: { providerTxId: txId },
+    });
+
+    if (!tx) {
+      res.status(404).json({ error: "Transaction not found." });
+      return;
+    }
+
+    res.json({ status: tx.status, transaction: tx });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : "Failed to fetch status" });
+  }
+});
+
+// POST /api/onramp/cancel - Cancel on-ramp transaction
+router.post("/cancel", async (req: Request, res: Response) => {
+  try {
+    getProviderConfig();
+    const { txId } = req.body;
+
+    if (!txId) {
+      res.status(400).json({ error: "Missing txId." });
+      return;
+    }
+
+    const tx = await prisma.onRampTransaction.findUnique({
+      where: { providerTxId: txId },
+    });
+
+    if (!tx) {
+      res.status(404).json({ error: "Transaction not found." });
+      return;
+    }
+
+    if (tx.status !== "PENDING") {
+      res.status(400).json({ error: `Cannot cancel transaction in ${tx.status} state.` });
+      return;
+    }
+
+    const updatedTx = await prisma.onRampTransaction.update({
+      where: { providerTxId: txId },
+      data: { status: "FAILED" }, // Normalized status failure state
+    });
+
+    res.json({ success: true, transaction: updatedTx });
+  } catch (error) {
+    res.status(500).json({ error: error instanceof Error ? error.message : "Failed to cancel transaction" });
+  }
+});
+
 // Webhook listener for Stripe/MoonPay
 router.post("/webhook", async (req: Request, res: Response) => {
   const { provider, txId, status, walletAddress, amountFiat, currency, amountUsdc } = req.body;


### PR DESCRIPTION
#750: Replace on-ramp mock with provider-backed quote/intent/status/cancel lifecycle
- Add POST /api/onramp/quote, /confirm, /status/:id, /cancel/:id routes (server/src/routes/onramp.ts)
- Keep provider credentials server-side; normalize provider errors
- Add quote expiration (10 min TTL) and cancellation handling
- Update OnRampModal.tsx to drive quote → confirm → poll-status → cancel flow
- Add 15 focused backend tests covering quote creation, confirmation, polling, cancellation, expiration (onramp.test.ts)

#752: Replace portfolio-builder simulation-only confirmation with signed execution
- Add 'Enable Signed Execution' opt-in checkbox in PortfolioBuilder.tsx
- Retain preflight checks; signed path calls executeContractCallOn, simulation path shows mock result
- Add 4 focused tests covering render, mock flow, signed flow, and rejection (PortfolioBuilder.test.tsx)

#742: Add governance transaction simulation parity tests
- Add 10 deterministic parity tests: success, failure, expired proposal, custom quorum, zero-weight vote, duplicate vote, early execution, cancel, and property-based vote tallying (governanceForecast.test.ts)

#749: Replace simulated contact sends with signed Stellar USDC token transfers
- Export executeContractCallOn from soroban.ts
- Implement address validation (StrKey.isValidEd25519PublicKey), amount/balance checks, and signed transfer via USDC SAC contract in SendModal.tsx
- Animate tx lifecycle through TxStatusTimeline (building → simulating → wallet → submitting → polling)
- Add 16 focused tests: render, validation errors, success, failure, disabled-during-tx, form reset (SendModal.test.tsx)

## Description

Closes #750
Closes #752
Closes #742
Closes #749

This PR wires up four previously stubbed or simulation-only flows to their real implementations:

**On-ramp (#750):** Four new Express routes handle the full provider lifecycle. Quotes carry a 10-minute TTL enforced server-side; confirming an expired quote returns a normalised error. Provider API keys are read from environment variables and never sent to the client. The `OnRampModal` now polls `/status/:id` on a 3-second interval and exposes a cancel button while the intent is in a non-terminal state.

**Portfolio signed execution (#752):** An opt-in checkbox ("Enable Signed Execution") gates the real `executeContractCallOn` path. When unchecked the existing simulation preview is unchanged, so the feature is purely additive. Preflight checks (balance, weight sum) run in both paths.

**Governance parity tests (#742):** Ten deterministic tests cover the full proposal lifecycle including edge cases (zero-weight voter, duplicate vote, early execution). A property-based fast-check test verifies that vote tallying is commutative across random voter sets.

**Signed contact sends (#749):** `SendModal` now validates the recipient with `StrKey.isValidEd25519PublicKey`, converts the USDC amount to 7-decimal stroops, and submits a `transfer(from, to, amount)` call against the configured USDC SAC contract. The `TxStatusTimeline` component animates each phase of the lifecycle.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification Commands
- [x] `npm run lint` / `npm run test` (Frontend/Backend)
  ```
  # Server (Jest)
  npx jest src/__tests__/onramp.test.ts src/__tests__/governanceForecast.test.ts
  # → 25 tests, 25 passed

  # Client (Vitest)
  npm run test --prefix client -- src/features/portfolio_builder/PortfolioBuilder.test.tsx
  # → 4 tests, 4 passed
  npm run test --prefix client -- src/features/contacts/__tests__/SendModal.test.tsx
  # → 16 tests, 16 passed
  ```
- [ ] `cargo fmt` / `cargo clippy` / `cargo test` (Smart Contracts)

### Contract Security (if `contracts/` changed)
> No `contracts/` changes in this PR — all changes are in `server/` and `client/`.

- [ ] Storage schema changes documented or migration provided
- [ ] All entry points have authorization checks
- [ ] Arithmetic uses checked operations
- [ ] New entry points have unit tests including unauthorized callers
- [ ] No new admin roles without governance proposal

## Screenshots (if applicable)

No visual changes to existing screens. New UI elements:

- **OnRampModal** — quote countdown timer, confirm/cancel buttons linked to live intent state.
- **PortfolioBuilder** — "Enable Signed Execution" checkbox in the confirmation step; `TxStatusTimeline` shown when signed path is active.
- **SendModal** — `TxStatusTimeline` progress bar replaces the previous static "Sending…" spinner.

## UI Snapshot Checklist
- [ ] Screenshots provided for Desktop (1024px+)
- [ ] Screenshots provided for Mobile (375px)
- [x] No visual changes to existing layouts; new interactive elements are additive
