### PR TITLE
feat: resolve issues #715, #724, and #725

### DIFF
--- a/backend/matching_engine/src/settlement/mod.rs
+++ b/backend/matching_engine/src/settlement/mod.rs
@@ -30,6 +30,8 @@ pub struct SettlementData {
     pub price: u128,
     /// Timestamp
     pub timestamp: u64,
+    /// Per-settlement nonce for replay prevention beyond trade_id
+    pub nonce: String,
     /// Maker signature
     pub maker_signature: String,
     /// Taker signature
@@ -79,6 +81,7 @@ impl SettlementPayload {
             amount1,
             price: trade.price,
             timestamp: trade.timestamp,
+            nonce: uuid::Uuid::new_v4().to_string(),
             maker_signature: String::new(),
             taker_signature: String::new(),
             engine_signature: String::new(),
@@ -121,6 +124,7 @@ impl SettlementPayload {
         hasher.update(data.amount1.to_be_bytes());
         hasher.update(data.price.to_be_bytes());
         hasher.update(data.timestamp.to_be_bytes());
+        hasher.update(data.nonce.as_bytes());
         hex::encode(hasher.finalize())
     }
 
@@ -374,5 +378,56 @@ mod tests {
         let hash2 = SettlementPayload::hash_settlement_data(&settlement.data);
 
         assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_tampered_data_hash_mismatch() {
+        let mut csprng = OsRng;
+        let maker_key = SigningKey::generate(&mut csprng);
+        let taker_key = SigningKey::generate(&mut csprng);
+        let engine_key = SigningKey::generate(&mut csprng);
+
+        let trade = create_test_trade();
+        let mut settlement =
+            SettlementPayload::from_trade(&trade, &maker_key, &taker_key, &engine_key).unwrap();
+
+        let original_hash = settlement.data_hash.clone();
+
+        // Tamper with the settlement amount after signing
+        settlement.data.amount0 += 1;
+        let tampered_hash = SettlementPayload::hash_settlement_data(&settlement.data);
+
+        // A tampered amount must produce a different hash, making the
+        // stored data_hash a detectable mismatch
+        assert_ne!(
+            tampered_hash, original_hash,
+            "tampered settlement must produce a different hash"
+        );
+    }
+
+    #[test]
+    fn test_nonce_uniqueness() {
+        let mut csprng = OsRng;
+        let maker_key = SigningKey::generate(&mut csprng);
+        let taker_key = SigningKey::generate(&mut csprng);
+        let engine_key = SigningKey::generate(&mut csprng);
+
+        let trade = create_test_trade();
+
+        let s1 = SettlementPayload::from_trade(&trade, &maker_key, &taker_key, &engine_key)
+            .unwrap();
+        let s2 = SettlementPayload::from_trade(&trade, &maker_key, &taker_key, &engine_key)
+            .unwrap();
+
+        // Same trade_id but each settlement gets a distinct nonce, so hashes differ
+        assert_eq!(s1.data.trade_id, s2.data.trade_id);
+        assert_ne!(
+            s1.data.nonce, s2.data.nonce,
+            "each settlement from the same trade must have a unique nonce"
+        );
+        assert_ne!(
+            s1.data_hash, s2.data_hash,
+            "different nonces must produce different settlement hashes"
+        );
     }
 }

--- a/contracts/settlement/src/lib.rs
+++ b/contracts/settlement/src/lib.rs
@@ -855,6 +855,109 @@ mod tests {
         client.settle_batch(&batch, &signatures);
     }
 
+    /// Verifies that submitting a batch whose trade_id was already settled
+    /// fails deterministically with TradeAlreadySettled (error #5).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #5)")]
+    fn test_duplicate_trade_id_rejected() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let contract_id = env.register(SettlementContract, ());
+        let client = SettlementContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let engine = Address::generate(&env);
+        let fee_recipient = Address::generate(&env);
+        // fee_bps = 0 so collect_fees is a no-op and transfers succeed cleanly
+        client.initialize(&admin, &Some(engine), &fee_recipient, &0);
+
+        let maker = Address::generate(&env);
+        let taker = Address::generate(&env);
+        let token_admin = Address::generate(&env);
+        let token0 = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+        let token1 = env.register_stellar_asset_contract_v2(token_admin.clone()).address();
+
+        token::StellarAssetClient::new(&env, &token0).mint(&maker, &2000);
+        token::StellarAssetClient::new(&env, &token1).mint(&taker, &2000);
+
+        let data = SettlementData {
+            trade_id: String::from_str(&env, "dup_trade_1"),
+            maker: maker.clone(),
+            taker: taker.clone(),
+            token0: token0.clone(),
+            token1: token1.clone(),
+            amount0: 100,
+            amount1: 100,
+            price: 100,
+            timestamp: 100,
+        };
+
+        let sig = Bytes::from_slice(&env, &[1u8; 64]);
+        let signatures = soroban_sdk::vec![&env, (sig.clone(), sig.clone(), sig.clone())];
+
+        let batch1 = SettlementBatch {
+            batch_id: String::from_str(&env, "batch_first"),
+            settlements: soroban_sdk::vec![&env, data.clone()],
+            total_amount0: 100,
+            total_amount1: 100,
+            timestamp: 100,
+        };
+
+        // First submission must succeed and mark trade as settled
+        client.settle_batch(&batch1, &signatures);
+
+        let batch2 = SettlementBatch {
+            batch_id: String::from_str(&env, "batch_replay"),
+            settlements: soroban_sdk::vec![&env, data],
+            total_amount0: 100,
+            total_amount1: 100,
+            timestamp: 101,
+        };
+
+        // Replay of the same trade_id must panic with TradeAlreadySettled (#5)
+        client.settle_batch(&batch2, &signatures);
+    }
+
+    /// Verifies that a batch with empty signatures fails with InvalidSignature (error #4).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #4)")]
+    fn test_empty_signature_rejected() {
+        let env = Env::default();
+        let (client, _, _) = setup_contract(&env);
+
+        let maker = Address::generate(&env);
+        let taker = Address::generate(&env);
+        let token0 = Address::generate(&env);
+        let token1 = Address::generate(&env);
+
+        let data = SettlementData {
+            trade_id: String::from_str(&env, "trade_sig_test"),
+            maker: maker.clone(),
+            taker: taker.clone(),
+            token0: token0.clone(),
+            token1: token1.clone(),
+            amount0: 100,
+            amount1: 200,
+            price: 200,
+            timestamp: 100,
+        };
+
+        let batch = SettlementBatch {
+            batch_id: String::from_str(&env, "batch_sig"),
+            settlements: soroban_sdk::vec![&env, data],
+            total_amount0: 100,
+            total_amount1: 200,
+            timestamp: 100,
+        };
+
+        // Zero-length signatures must trigger InvalidSignature (#4)
+        let empty = Bytes::new(&env);
+        let signatures = soroban_sdk::vec![&env, (empty.clone(), empty.clone(), empty.clone())];
+
+        client.settle_batch(&batch, &signatures);
+    }
+
     #[test]
     #[should_panic(expected = "Error(Contract, #10)")]
     fn test_settle_batch_negative_amount_panics() {

--- a/server/jest.config.ts
+++ b/server/jest.config.ts
@@ -3,4 +3,9 @@ export default {
   testEnvironment: "node",
   roots: ["<rootDir>/src"],
   testMatch: ["**/__tests__/**/*.test.ts"],
+  globals: {
+    "ts-jest": {
+      isolatedModules: true,
+    },
+  },
 };

--- a/server/openapi.yaml
+++ b/server/openapi.yaml
@@ -45,6 +45,14 @@ tags:
     description: Liquidity fragmentation metrics
   - name: Simulator
     description: Simulation endpoints for deposit, rebalance, and failover dry-runs (never executes on-chain)
+  - name: Contacts
+    description: Encrypted contact management (client-side encryption, server stores opaque blobs)
+  - name: Incidents
+    description: Protocol incident tracking and resolution
+  - name: Onramp
+    description: Fiat onramp provider webhook integration
+  - name: Deposits
+    description: Multi-asset deposit routing recommendations
 
 paths:
   /api/health:
@@ -1868,12 +1876,741 @@ paths:
                   value:
                     error: "Unknown strategy: no-such-strategy"
 
+  # ── Contacts ─────────────────────────────────────────────────────────────────
+
+  /api/contacts:
+    get:
+      summary: List all contacts
+      description: |
+        Returns all encrypted contacts for the authenticated wallet.
+        Data is encrypted on the client side; the server stores and returns
+        opaque base64 blobs without inspecting their contents.
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+          description: Stellar wallet address of the authenticated user
+      responses:
+        '200':
+          description: Contact list returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contacts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Contact'
+                  total:
+                    type: integer
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+    post:
+      summary: Create a new contact
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - encryptedName
+                - encryptedAddress
+              properties:
+                encryptedName:
+                  type: string
+                  description: Client-encrypted contact name (opaque base64 blob)
+                encryptedAddress:
+                  type: string
+                  description: Client-encrypted Stellar address (opaque base64 blob)
+      responses:
+        '201':
+          description: Contact created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contact:
+                    $ref: '#/components/schemas/Contact'
+        '400':
+          description: Missing or invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '409':
+          description: Contact with this encrypted address already exists
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+
+  /api/contacts/search:
+    get:
+      summary: Search contacts
+      description: |
+        Returns all contacts for the wallet. Because data is encrypted,
+        the server cannot filter by content; the client performs post-decryption
+        filtering using the `q` query parameter as a hint.
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+          description: Search query (filtering happens client-side after decryption)
+      responses:
+        '200':
+          description: Contacts returned for client-side filtering
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contacts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Contact'
+                  total:
+                    type: integer
+        '400':
+          description: Search query missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+
+  /api/contacts/export:
+    get:
+      summary: Export contacts as encrypted backup
+      description: Returns all contacts serialised into an encrypted backup blob for client-side storage or migration.
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Encrypted backup blob
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  encryptedBackup:
+                    type: string
+                    description: JSON-stringified backup envelope containing encrypted contact data
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+
+  /api/contacts/import:
+    post:
+      summary: Import contacts from encrypted backup
+      description: |
+        Accepts a previously-exported encrypted backup and imports contacts,
+        skipping any that already exist (duplicate encrypted address).
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - encryptedBackup
+              properties:
+                encryptedBackup:
+                  type: string
+                  description: JSON-stringified backup envelope produced by GET /api/contacts/export
+      responses:
+        '200':
+          description: Import completed; includes only newly created contacts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contacts:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Contact'
+                  total:
+                    type: integer
+        '400':
+          description: Missing or malformed backup payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+
+  /api/contacts/{id}:
+    get:
+      summary: Get a single contact
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Contact found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contact:
+                    $ref: '#/components/schemas/Contact'
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '404':
+          description: Contact not found or belongs to a different wallet
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+    put:
+      summary: Update a contact
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                encryptedName:
+                  type: string
+                encryptedAddress:
+                  type: string
+      responses:
+        '200':
+          description: Contact updated
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contact:
+                    $ref: '#/components/schemas/Contact'
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '404':
+          description: Contact not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '409':
+          description: Duplicate encrypted address
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+    delete:
+      summary: Delete a contact
+      tags:
+        - Contacts
+      parameters:
+        - name: x-wallet-address
+          in: header
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Contact deleted
+        '401':
+          description: Wallet address header missing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+        '404':
+          description: Contact not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactError'
+
+  # ── Incidents ─────────────────────────────────────────────────────────────
+
+  /api/incidents:
+    get:
+      summary: List incidents
+      description: Returns a paginated list of incidents ordered by start time descending.
+      tags:
+        - Incidents
+      parameters:
+        - name: protocol
+          in: query
+          schema:
+            type: string
+          description: Filter by protocol name
+        - name: severity
+          in: query
+          schema:
+            type: string
+          description: Filter by severity level
+        - name: type
+          in: query
+          schema:
+            type: string
+          description: Filter by incident type
+        - name: resolved
+          in: query
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: Filter by resolution status
+        - name: cursor
+          in: query
+          schema:
+            type: string
+          description: Pagination cursor from a previous response
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Paginated incident list
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Incident'
+                  pagination:
+                    type: object
+                    properties:
+                      nextCursor:
+                        type: string
+                        nullable: true
+                      hasMore:
+                        type: boolean
+                      limit:
+                        type: integer
+        '500':
+          description: Failed to fetch incidents
+    post:
+      summary: Create an incident
+      tags:
+        - Incidents
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - protocol
+                - severity
+                - type
+                - title
+                - description
+                - startedAt
+              properties:
+                protocol:
+                  type: string
+                severity:
+                  type: string
+                type:
+                  type: string
+                title:
+                  type: string
+                description:
+                  type: string
+                affectedVaults:
+                  type: array
+                  items:
+                    type: string
+                startedAt:
+                  type: string
+                  format: date-time
+      responses:
+        '201':
+          description: Incident created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '400':
+          description: Missing required fields
+        '500':
+          description: Failed to create incident
+
+  /api/incidents/{id}:
+    get:
+      summary: Get a single incident
+      tags:
+        - Incidents
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Incident found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '404':
+          description: Incident not found
+        '500':
+          description: Failed to fetch incident
+
+  /api/incidents/{id}/resolve:
+    patch:
+      summary: Resolve an incident
+      tags:
+        - Incidents
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Incident resolved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Incident'
+        '500':
+          description: Failed to resolve incident
+
+  /api/incidents/{id}/recommendations:
+    get:
+      summary: Get recommendations for an incident
+      tags:
+        - Incidents
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Recommendations for the incident
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '500':
+          description: Failed to fetch recommendations
+
+  # ── Onramp ───────────────────────────────────────────────────────────────
+
+  /api/onramp/webhook:
+    post:
+      summary: Onramp provider webhook
+      description: |
+        Receives payment status callbacks from fiat onramp providers (e.g. Stripe,
+        MoonPay). Upserts the transaction record and triggers a DEPOSIT notification
+        when the status transitions to COMPLETED.
+      tags:
+        - Onramp
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - provider
+                - txId
+                - status
+                - walletAddress
+                - amountFiat
+                - currency
+                - amountUsdc
+              properties:
+                provider:
+                  type: string
+                  description: Onramp provider identifier (e.g. "stripe", "moonpay")
+                txId:
+                  type: string
+                  description: Provider-assigned transaction ID
+                status:
+                  type: string
+                  enum: [PENDING, COMPLETED, FAILED]
+                walletAddress:
+                  type: string
+                amountFiat:
+                  type: number
+                currency:
+                  type: string
+                amountUsdc:
+                  type: number
+      responses:
+        '200':
+          description: Webhook processed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  transaction:
+                    type: object
+        '500':
+          description: Failed to process webhook
+
+  # ── Deposits ─────────────────────────────────────────────────────────────
+
+  /api/deposits/supported-assets:
+    get:
+      summary: List supported deposit assets
+      description: Returns the set of assets accepted for multi-asset deposit routing.
+      tags:
+        - Deposits
+      responses:
+        '200':
+          description: Supported assets configuration
+          content:
+            application/json:
+              schema:
+                type: object
+        '503':
+          description: Supported assets configuration unavailable
+
+  /api/deposits/recommend:
+    post:
+      summary: Get deposit routing recommendation
+      description: |
+        Returns a routing recommendation for a multi-asset deposit: per-asset
+        conversion/allocation path, expected vault-token output, estimated
+        network fees, and warnings for unsupported assets.
+      tags:
+        - Deposits
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - assets
+              properties:
+                assets:
+                  type: array
+                  minItems: 1
+                  items:
+                    type: object
+                    required:
+                      - symbol
+                      - amountInStroops
+                    properties:
+                      symbol:
+                        type: string
+                        description: Asset symbol (e.g. "USDC", "XLM")
+                      amountInStroops:
+                        type: string
+                        description: Positive integer amount in stroops as a decimal string
+      responses:
+        '200':
+          description: Routing recommendation
+          content:
+            application/json:
+              schema:
+                type: object
+        '400':
+          description: Invalid request body or asset parameters
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  code:
+                    type: string
+        '500':
+          description: Failed to compute recommendation
+
   # Intentionally excluded routes:
   # - Internal debugging and profiling endpoints under /internal/* are intentionally omitted from this public spec.
   # - Any admin-only endpoints that require interactive session tokens are documented above when needed; ephemeral or highly-sensitive debug routes are excluded.
 
 components:
   schemas:
+
+    # ── Contacts schemas ────────────────────────────────────────────────────
+
+    Contact:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        encrypted_name:
+          type: string
+          description: Client-encrypted contact name (opaque base64 blob)
+        encrypted_address:
+          type: string
+          description: Client-encrypted Stellar address (opaque base64 blob)
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
+      required:
+        - id
+        - encrypted_name
+        - encrypted_address
+        - created_at
+        - updated_at
+
+    ContactError:
+      type: object
+      properties:
+        error:
+          type: string
+        code:
+          type: string
+      required:
+        - error
+        - code
+
+    # ── Incidents schemas ───────────────────────────────────────────────────
+
+    Incident:
+      type: object
+      properties:
+        id:
+          type: string
+        protocol:
+          type: string
+        severity:
+          type: string
+        type:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        affectedVaults:
+          type: array
+          items:
+            type: string
+        startedAt:
+          type: string
+          format: date-time
+        resolvedAt:
+          type: string
+          format: date-time
+          nullable: true
+        resolved:
+          type: boolean
 
     # ── Simulator schemas ───────────────────────────────────────────────────
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -75,6 +75,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -592,29 +593,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2440,6 +2418,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
       "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2626,6 +2605,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3315,6 +3295,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3794,6 +3775,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4736,6 +4718,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5653,6 +5636,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.0.tgz",
       "integrity": "sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -6220,6 +6204,7 @@
       "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.4.2",
         "@jest/types": "30.4.1",
@@ -8195,6 +8180,7 @@
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -9486,6 +9472,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9727,6 +9714,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9901,6 +9889,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/server/package.json
+++ b/server/package.json
@@ -10,7 +10,8 @@
     "lint": "npx eslint \"src/**/*.ts\"",
     "test": "jest",
     "check:metrics-token": "node scripts/check-metrics-token.js",
-    "seed": "ts-node scripts/seed.ts"
+    "seed": "ts-node scripts/seed.ts",
+    "check:openapi": "ts-node scripts/check-openapi-drift.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/server/scripts/check-openapi-drift.ts
+++ b/server/scripts/check-openapi-drift.ts
@@ -1,0 +1,93 @@
+/**
+ * check-openapi-drift.ts
+ *
+ * Compares the Express route mounts in src/app.ts with the paths documented
+ * in openapi.yaml and reports any mounts that have no matching documented path.
+ *
+ * Usage:
+ *   npx ts-node scripts/check-openapi-drift.ts
+ *
+ * Exits with code 1 if drift is detected (CI-friendly).
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+const ROOT = path.resolve(__dirname, "..");
+
+// ── 1. Collect documented path prefixes from openapi.yaml ─────────────────
+
+const specPath = path.join(ROOT, "openapi.yaml");
+const specText = fs.readFileSync(specPath, "utf8");
+
+// Match top-level path entries: lines starting with "  /api/..."
+const documentedPaths = new Set<string>();
+const pathLineRe = /^\s{2}(\/api\/[^\s:]+):/gm;
+let m: RegExpExecArray | null;
+while ((m = pathLineRe.exec(specText)) !== null) {
+  // Normalise path params: /api/foo/{id} → /api/foo
+  const base = m[1].replace(/\{[^}]+\}.*$/, "").replace(/\/$/, "");
+  documentedPaths.add(base);
+}
+
+// ── 2. Collect mounted prefixes from src/app.ts ───────────────────────────
+
+const appPath = path.join(ROOT, "src", "app.ts");
+const appText = fs.readFileSync(appPath, "utf8");
+
+// Match: app.use("/api/...", ...)  and  app.post("/api/...", ...)  etc.
+const mountRe = /app\.(?:use|get|post|put|patch|delete)\(\s*["'](\/?api\/[^"']+)["']/g;
+const mountedPaths = new Set<string>();
+while ((m = mountRe.exec(appText)) !== null) {
+  // Strip trailing wildcard or path variables for comparison
+  const prefix = m[1].replace(/\/:[^/]+.*$/, "").replace(/\/$/, "");
+  mountedPaths.add(prefix);
+}
+
+// ── 3. Compare and report ─────────────────────────────────────────────────
+
+const undocumented: string[] = [];
+
+for (const mount of Array.from(mountedPaths).sort()) {
+  // A mount is covered if at least one documented path starts with it
+  const covered = Array.from(documentedPaths).some(
+    (doc) => doc === mount || doc.startsWith(mount + "/")
+  );
+  if (!covered) {
+    undocumented.push(mount);
+  }
+}
+
+const documented: string[] = [];
+for (const mount of Array.from(mountedPaths).sort()) {
+  const covered = Array.from(documentedPaths).some(
+    (doc) => doc === mount || doc.startsWith(mount + "/")
+  );
+  if (covered) {
+    documented.push(mount);
+  }
+}
+
+console.log(`\nOpenAPI Drift Check`);
+console.log(`===================`);
+console.log(`Documented path prefixes : ${documentedPaths.size}`);
+console.log(`Mounted route prefixes   : ${mountedPaths.size}`);
+
+if (documented.length > 0) {
+  console.log(`\n✓ Documented mounts (${documented.length}):`);
+  for (const p of documented) {
+    console.log(`  ${p}`);
+  }
+}
+
+if (undocumented.length === 0) {
+  console.log(`\n✓ No drift detected — all mounted routes are documented.\n`);
+  process.exit(0);
+} else {
+  console.log(`\n✗ Undocumented mounts (${undocumented.length}) — add these to openapi.yaml:`);
+  for (const p of undocumented) {
+    console.log(`  ${p}`);
+  }
+  console.log();
+  process.exit(1);
+}

--- a/server/src/__tests__/contacts.test.ts
+++ b/server/src/__tests__/contacts.test.ts
@@ -1,0 +1,348 @@
+import request from "supertest";
+import { createApp } from "../app";
+
+// jest.mock is hoisted above variable declarations, so we cannot reference
+// external `const` variables inside the factory (temporal dead zone).
+// Instead, we create the mock contact operations object inside the factory
+// as a closure variable, then retrieve it via jest.requireMock below.
+jest.mock("@prisma/client", () => {
+  const contact = {
+    findMany: jest.fn(),
+    findFirst: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+  };
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({ contact })),
+  };
+});
+
+// All PrismaClient instances share the same `contact` closure object, so we
+// retrieve it once here for use in test assertions.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const { PrismaClient: MockPrismaClient } = jest.requireMock("@prisma/client") as any;
+const mockContact = new MockPrismaClient().contact as {
+  findMany: jest.Mock;
+  findFirst: jest.Mock;
+  create: jest.Mock;
+  update: jest.Mock;
+  delete: jest.Mock;
+};
+
+const WALLET = "GTEST_WALLET_ADDRESS_12345";
+
+const SAMPLE_CONTACT = {
+  id: "contact-uuid-1",
+  encryptedName: "enc_name_base64_blob",
+  encryptedAddress: "enc_addr_base64_blob",
+  createdAt: new Date("2024-01-15T10:00:00Z"),
+  updatedAt: new Date("2024-01-15T10:00:00Z"),
+};
+
+describe("Contacts API", () => {
+  const app = createApp();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── GET /api/contacts ────────────────────────────────────────────────────
+
+  describe("GET /api/contacts", () => {
+    it("returns 401 when x-wallet-address header is missing", async () => {
+      const res = await request(app).get("/api/contacts");
+      expect(res.status).toBe(401);
+      expect(res.body.code).toBe("WALLET_ADDRESS_REQUIRED");
+    });
+
+    it("returns 200 with contacts list for authenticated wallet", async () => {
+      mockContact.findMany.mockResolvedValue([SAMPLE_CONTACT]);
+
+      const res = await request(app)
+        .get("/api/contacts")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.contacts[0].id).toBe("contact-uuid-1");
+      // Encrypted blobs must pass through unmodified (encryption boundary)
+      expect(res.body.contacts[0].encrypted_name).toBe("enc_name_base64_blob");
+      expect(res.body.contacts[0].encrypted_address).toBe("enc_addr_base64_blob");
+      expect(mockContact.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { walletAddress: WALLET } })
+      );
+    });
+
+    it("returns 200 with empty list when wallet has no contacts", async () => {
+      mockContact.findMany.mockResolvedValue([]);
+
+      const res = await request(app)
+        .get("/api/contacts")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(0);
+      expect(res.body.contacts).toEqual([]);
+    });
+  });
+
+  // ── GET /api/contacts/search ─────────────────────────────────────────────
+  // Route is defined before /:id so Express resolves it as a static path.
+
+  describe("GET /api/contacts/search", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app).get("/api/contacts/search?q=alice");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when query param is missing", async () => {
+      const res = await request(app)
+        .get("/api/contacts/search")
+        .set("x-wallet-address", WALLET);
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_QUERY");
+    });
+
+    it("returns all contacts so the client can filter after decryption", async () => {
+      mockContact.findMany.mockResolvedValue([SAMPLE_CONTACT]);
+
+      const res = await request(app)
+        .get("/api/contacts/search?q=alice")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.contacts[0].encrypted_name).toBe("enc_name_base64_blob");
+    });
+  });
+
+  // ── GET /api/contacts/export ─────────────────────────────────────────────
+
+  describe("GET /api/contacts/export", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app).get("/api/contacts/export");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns encrypted backup blob when authenticated", async () => {
+      mockContact.findMany.mockResolvedValue([SAMPLE_CONTACT]);
+
+      const res = await request(app)
+        .get("/api/contacts/export")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(200);
+      expect(typeof res.body.encryptedBackup).toBe("string");
+
+      const parsed = JSON.parse(res.body.encryptedBackup);
+      expect(parsed.version).toBe("1.0");
+      expect(Array.isArray(parsed.contacts)).toBe(true);
+      // Encrypted fields passed through unchanged
+      expect(parsed.contacts[0].encryptedName).toBe("enc_name_base64_blob");
+      expect(parsed.contacts[0].encryptedAddress).toBe("enc_addr_base64_blob");
+    });
+  });
+
+  // ── GET /api/contacts/:id ────────────────────────────────────────────────
+
+  describe("GET /api/contacts/:id", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app).get("/api/contacts/contact-uuid-1");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 200 with contact when found", async () => {
+      mockContact.findFirst.mockResolvedValue(SAMPLE_CONTACT);
+
+      const res = await request(app)
+        .get("/api/contacts/contact-uuid-1")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(200);
+      expect(res.body.contact.id).toBe("contact-uuid-1");
+      expect(res.body.contact.encrypted_name).toBe("enc_name_base64_blob");
+      expect(mockContact.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "contact-uuid-1", walletAddress: WALLET } })
+      );
+    });
+
+    it("returns 404 when contact does not exist or belongs to another wallet", async () => {
+      mockContact.findFirst.mockResolvedValue(null);
+
+      const res = await request(app)
+        .get("/api/contacts/non-existent")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe("CONTACT_NOT_FOUND");
+    });
+  });
+
+  // ── POST /api/contacts ───────────────────────────────────────────────────
+
+  describe("POST /api/contacts", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app)
+        .post("/api/contacts")
+        .send({ encryptedName: "enc", encryptedAddress: "addr" });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when required fields are missing", async () => {
+      const res = await request(app)
+        .post("/api/contacts")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedName: "enc" }); // missing encryptedAddress
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_REQUEST");
+    });
+
+    it("returns 201 with created contact on success", async () => {
+      mockContact.findFirst.mockResolvedValue(null); // no duplicate
+      mockContact.create.mockResolvedValue(SAMPLE_CONTACT);
+
+      const res = await request(app)
+        .post("/api/contacts")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedName: "enc_name_base64_blob", encryptedAddress: "enc_addr_base64_blob" });
+
+      expect(res.status).toBe(201);
+      expect(res.body.contact.id).toBe("contact-uuid-1");
+      expect(res.body.contact.encrypted_name).toBe("enc_name_base64_blob");
+    });
+
+    it("returns 409 when a contact with the same encrypted address already exists", async () => {
+      mockContact.findFirst.mockResolvedValue(SAMPLE_CONTACT); // duplicate
+
+      const res = await request(app)
+        .post("/api/contacts")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedName: "enc_name_base64_blob", encryptedAddress: "enc_addr_base64_blob" });
+
+      expect(res.status).toBe(409);
+      expect(res.body.code).toBe("DUPLICATE_CONTACT");
+    });
+  });
+
+  // ── PUT /api/contacts/:id ────────────────────────────────────────────────
+
+  describe("PUT /api/contacts/:id", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app)
+        .put("/api/contacts/contact-uuid-1")
+        .send({ encryptedName: "new_name" });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when contact does not exist", async () => {
+      mockContact.findFirst.mockResolvedValue(null);
+
+      const res = await request(app)
+        .put("/api/contacts/non-existent")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedName: "new_name" });
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe("CONTACT_NOT_FOUND");
+    });
+
+    it("returns 200 with updated contact on success", async () => {
+      mockContact.findFirst.mockResolvedValue(SAMPLE_CONTACT);
+      mockContact.update.mockResolvedValue({
+        ...SAMPLE_CONTACT,
+        encryptedName: "updated_name",
+      });
+
+      const res = await request(app)
+        .put("/api/contacts/contact-uuid-1")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedName: "updated_name" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.contact.encrypted_name).toBe("updated_name");
+    });
+  });
+
+  // ── DELETE /api/contacts/:id ─────────────────────────────────────────────
+
+  describe("DELETE /api/contacts/:id", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app).delete("/api/contacts/contact-uuid-1");
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 404 when contact does not exist", async () => {
+      mockContact.findFirst.mockResolvedValue(null);
+
+      const res = await request(app)
+        .delete("/api/contacts/non-existent")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(404);
+      expect(res.body.code).toBe("CONTACT_NOT_FOUND");
+    });
+
+    it("returns 204 on successful deletion", async () => {
+      mockContact.findFirst.mockResolvedValue(SAMPLE_CONTACT);
+      mockContact.delete.mockResolvedValue(SAMPLE_CONTACT);
+
+      const res = await request(app)
+        .delete("/api/contacts/contact-uuid-1")
+        .set("x-wallet-address", WALLET);
+
+      expect(res.status).toBe(204);
+      expect(mockContact.delete).toHaveBeenCalledWith({ where: { id: "contact-uuid-1" } });
+    });
+  });
+
+  // ── POST /api/contacts/import ────────────────────────────────────────────
+
+  describe("POST /api/contacts/import", () => {
+    it("returns 401 when header is missing", async () => {
+      const res = await request(app)
+        .post("/api/contacts/import")
+        .send({ encryptedBackup: JSON.stringify({ contacts: [] }) });
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 400 when encryptedBackup is missing", async () => {
+      const res = await request(app)
+        .post("/api/contacts/import")
+        .set("x-wallet-address", WALLET)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_BACKUP");
+    });
+
+    it("returns 400 when backup format is invalid (no contacts array)", async () => {
+      const res = await request(app)
+        .post("/api/contacts/import")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedBackup: JSON.stringify({ version: "1.0" }) });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe("INVALID_FORMAT");
+    });
+
+    it("imports new contacts and returns 200 with the created list", async () => {
+      mockContact.findFirst.mockResolvedValue(null); // no duplicate
+      mockContact.create.mockResolvedValue(SAMPLE_CONTACT);
+
+      const backup = JSON.stringify({
+        version: "1.0",
+        contacts: [
+          { encryptedName: "enc_name_base64_blob", encryptedAddress: "enc_addr_base64_blob" },
+        ],
+      });
+
+      const res = await request(app)
+        .post("/api/contacts/import")
+        .set("x-wallet-address", WALLET)
+        .send({ encryptedBackup: backup });
+
+      expect(res.status).toBe(200);
+      expect(res.body.total).toBe(1);
+      expect(res.body.contacts[0].encrypted_name).toBe("enc_name_base64_blob");
+    });
+  });
+});

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -41,6 +41,7 @@ import activityTimelineRouter from "./routes/activityTimeline";
 import presetsRouter from "./routes/presets";
 import analyticsRouter from "./routes/analytics";
 import offrampRouter from "./routes/offramp";
+import contactsRouter from "./routes/contacts";
 
 import { createAuthChallenge, verifyAuthChallenge } from "./utils/stellarAuth";
 import {
@@ -129,6 +130,7 @@ export function createApp() {
   app.use("/api/presets", presetsRouter);
   app.use("/api/analytics", analyticsRouter);
   app.use("/api/offramp", offrampRouter);
+  app.use("/api/contacts", contactsRouter);
 
 
   // Legacy JSON metrics (internal tooling)

--- a/server/src/routes/analyticsUtils.ts
+++ b/server/src/routes/analyticsUtils.ts
@@ -1,56 +1,15 @@
-import { AttributionReport } from '../services/portfolioAttributionService';
-import { CompatibilityReport } from '../services/protocolCompatibilityService';
-import { StrategyHealthScore } from '../services/strategyHealthService';
-import { DataSourceReliability } from '../services/yieldReliabilityService';
-
-// Analytics Helper Functions
 import type { AttributionReport } from '../services/portfolioAttributionService';
 import type { CompatibilityReport, CompatibilityIssue } from '../services/protocolCompatibilityService';
 import type { StrategyHealthScore } from '../services/strategyHealthService';
 import type { DataSourceReliability } from '../services/yieldReliabilityService';
 
-export function validateAttributionRequest(walletAddress: string, startTime: string, endTime: string): { valid: boolean; error?: string } {
-  // Basic validation
-  if (!walletAddress || !startTime || !endTime) return { valid: false, error: 'Missing required parameters' };
-  
-  // Validate timestamp format and range
-  const start = new Date(startTime);
-  const end = new Date(endTime);
-  
-  if (isNaN(start.getTime()) || isNaN(end.getTime())) return { valid: false, error: 'Invalid timestamp format' };
-  if (start >= end) return { valid: false, error: 'Start time must be before end time' };
-  
-  // Check if time window is reasonable (max 1 year)
-  const maxWindow = 365 * 24 * 60 * 60 * 1000; // 1 year in ms
-  if (end.getTime() - start.getTime() > maxWindow) return { valid: false, error: 'Time window too large (max 1 year)' };
-  
-  return { valid: true };
-}
+// ── Interfaces ──────────────────────────────────────────────────────────────
 
 interface ProtocolReport {
   protocols?: Array<{ protocolName: string; status: string; criticalIssues?: number }>;
   issues?: Array<{ severity: string }>;
 }
 
-export function formatAttributionReport(report: AttributionReport): any {
-  return {
-    ...report,
-    formattedDate: new Date().toISOString(),
-    totalAttribution: (report as any).breakdown?.reduce((sum: number, item: { contribution: number }) => sum + item.contribution, 0) || 0,
-  };
-}
-
-export function formatCompatibilityReport(report: CompatibilityReport): any {
-  return {
-    ...report,
-    formattedDate: new Date().toISOString(),
-    criticalIssues: (report as any).issues?.filter((issue: { severity: string }) => issue.severity === 'critical') || [],
-  };
-}
-
-export function formatHealthScore(score: StrategyHealthScore): any {
-  const overallScore = score.overallScore;
-// Extended interfaces for utility functions
 interface ExtendedAttributionReport extends AttributionReport {
   formattedDate?: string;
   totalAttribution?: number;
@@ -75,6 +34,23 @@ interface WeightedProvider extends DataSourceReliability {
   weight: number;
 }
 
+// ── Utility functions ───────────────────────────────────────────────────────
+
+export function validateAttributionRequest(walletAddress: string, startTime: string, endTime: string): { valid: boolean; error?: string } {
+  if (!walletAddress || !startTime || !endTime) return { valid: false, error: 'Missing required parameters' };
+
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+
+  if (isNaN(start.getTime()) || isNaN(end.getTime())) return { valid: false, error: 'Invalid timestamp format' };
+  if (start >= end) return { valid: false, error: 'Start time must be before end time' };
+
+  const maxWindow = 365 * 24 * 60 * 60 * 1000;
+  if (end.getTime() - start.getTime() > maxWindow) return { valid: false, error: 'Time window too large (max 1 year)' };
+
+  return { valid: true };
+}
+
 export function formatAttributionReport(report: AttributionReport): ExtendedAttributionReport {
   return {
     ...report,
@@ -92,6 +68,7 @@ export function formatCompatibilityReport(report: CompatibilityReport): Extended
 }
 
 export function formatHealthScore(score: StrategyHealthScore): ExtendedHealthScore {
+  const overallScore = score.overallScore;
   return {
     ...score,
     status: overallScore >= 80 ? 'healthy' : overallScore >= 60 ? 'degraded' : 'critical',
@@ -127,12 +104,12 @@ export function getWeightedProviderSelection(providers: DataSourceReliability[])
   return providers
     .map(provider => ({
       ...provider,
-      weight: provider.reliabilityScore / 100, // Simple weighting based on score
+      weight: provider.reliabilityScore / 100,
     }))
     .sort((a, b) => b.weight - a.weight);
 }
 
 export function isProtocolSafeForExecution(protocolName: string, report: CompatibilityReport): boolean {
-  const protocolStatus = report.protocols?.find(p => p.protocolName === protocolName);
-  return protocolStatus?.status === 'compatible' && (protocolStatus?.issues?.length ?? 0) === 0;
+  const protocolStatus = (report as ProtocolReport).protocols?.find(p => p.protocolName === protocolName);
+  return protocolStatus?.status === 'compatible' && (protocolStatus?.criticalIssues ?? 0) === 0;
 }

--- a/server/src/routes/contacts.ts
+++ b/server/src/routes/contacts.ts
@@ -1,7 +1,7 @@
 /**
  * Contacts API Routes
  * Provides CRUD operations for encrypted contacts
- * 
+ *
  * Security Note: All contact data is encrypted on the client side.
  * The server only stores encrypted blobs and cannot access plaintext data.
  */
@@ -28,8 +28,8 @@ const updateContactSchema = z.object({
 const getWalletAddress = (req: Request): string => {
   // In a real implementation, this would extract from JWT token or session
   // For now, we'll use a header or param
-  return (req.headers['x-wallet-address'] as string) || 
-         (req.params.walletAddress as string) || 
+  return (req.headers['x-wallet-address'] as string) ||
+         (req.params.walletAddress as string) ||
          req.body?.walletAddress;
 };
 
@@ -40,9 +40,9 @@ const getWalletAddress = (req: Request): string => {
 router.get("/", async (req: Request, res: Response) => {
   try {
     const walletAddress = getWalletAddress(req);
-    
+
     if (!walletAddress) {
-      return res.status(401).json({ 
+      return res.status(401).json({
         error: "Wallet address required",
         code: "WALLET_ADDRESS_REQUIRED"
       });
@@ -72,9 +72,114 @@ router.get("/", async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error("Failed to fetch contacts:", error);
-    res.status(500).json({ 
+    res.status(500).json({
       error: "Failed to fetch contacts",
       code: "FETCH_FAILED"
+    });
+  }
+});
+
+/**
+ * GET /api/contacts/search
+ * Search contacts (limited implementation since data is encrypted)
+ *
+ * Defined before /:id so Express matches this static path first.
+ */
+router.get("/search", async (req: Request, res: Response) => {
+  try {
+    const walletAddress = getWalletAddress(req);
+    const { q } = req.query;
+
+    if (!walletAddress) {
+      return res.status(401).json({
+        error: "Wallet address required",
+        code: "WALLET_ADDRESS_REQUIRED"
+      });
+    }
+
+    if (!q || typeof q !== 'string') {
+      return res.status(400).json({
+        error: "Search query is required",
+        code: "INVALID_QUERY"
+      });
+    }
+
+    // Since data is encrypted, we can't search by content.
+    // Return all contacts and let the client filter after decryption.
+    const contacts = await prisma.contact.findMany({
+      where: { walletAddress },
+      orderBy: { createdAt: "desc" },
+      select: {
+        id: true,
+        encryptedName: true,
+        encryptedAddress: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    res.json({
+      contacts: contacts.map(contact => ({
+        id: contact.id,
+        encrypted_name: contact.encryptedName,
+        encrypted_address: contact.encryptedAddress,
+        created_at: contact.createdAt.toISOString(),
+        updated_at: contact.updatedAt.toISOString(),
+      })),
+      total: contacts.length,
+    });
+  } catch (error) {
+    console.error("Failed to search contacts:", error);
+    res.status(500).json({
+      error: "Failed to search contacts",
+      code: "SEARCH_FAILED"
+    });
+  }
+});
+
+/**
+ * GET /api/contacts/export
+ * Export all contacts as encrypted backup
+ *
+ * Defined before /:id so Express matches this static path first.
+ */
+router.get("/export", async (req: Request, res: Response) => {
+  try {
+    const walletAddress = getWalletAddress(req);
+
+    if (!walletAddress) {
+      return res.status(401).json({
+        error: "Wallet address required",
+        code: "WALLET_ADDRESS_REQUIRED"
+      });
+    }
+
+    const contacts = await prisma.contact.findMany({
+      where: { walletAddress },
+      orderBy: { createdAt: "desc" },
+    });
+
+    // Create encrypted backup (client will handle the actual encryption)
+    const backupData = {
+      version: "1.0",
+      exportedAt: new Date().toISOString(),
+      contacts: contacts.map(contact => ({
+        id: contact.id,
+        encryptedName: contact.encryptedName,
+        encryptedAddress: contact.encryptedAddress,
+        createdAt: contact.createdAt.toISOString(),
+        updatedAt: contact.updatedAt.toISOString(),
+      })),
+    };
+
+    res.json({
+      encryptedBackup: JSON.stringify(backupData),
+    });
+  } catch (error) {
+    console.error("Failed to export contacts:", error);
+    res.status(500).json({
+      error: "Failed to export contacts",
+      code: "EXPORT_FAILED"
     });
   }
 });
@@ -87,16 +192,16 @@ router.get("/:id", async (req: Request, res: Response) => {
   try {
     const { id } = req.params;
     const walletAddress = getWalletAddress(req);
-    
+
     if (!walletAddress) {
-      return res.status(401).json({ 
+      return res.status(401).json({
         error: "Wallet address required",
         code: "WALLET_ADDRESS_REQUIRED"
       });
     }
 
     const contact = await prisma.contact.findFirst({
-      where: { 
+      where: {
         id,
         walletAddress, // Ensure user can only access their own contacts
       },
@@ -110,7 +215,7 @@ router.get("/:id", async (req: Request, res: Response) => {
     });
 
     if (!contact) {
-      return res.status(404).json({ 
+      return res.status(404).json({
         error: "Contact not found",
         code: "CONTACT_NOT_FOUND"
       });
@@ -127,7 +232,7 @@ router.get("/:id", async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error("Failed to fetch contact:", error);
-    res.status(500).json({ 
+    res.status(500).json({
       error: "Failed to fetch contact",
       code: "FETCH_FAILED"
     });
@@ -141,9 +246,9 @@ router.get("/:id", async (req: Request, res: Response) => {
 router.post("/", async (req: Request, res: Response) => {
   try {
     const walletAddress = getWalletAddress(req);
-    
+
     if (!walletAddress) {
-      return res.status(401).json({ 
+      return res.status(401).json({
         error: "Wallet address required",
         code: "WALLET_ADDRESS_REQUIRED"
       });
@@ -151,7 +256,7 @@ router.post("/", async (req: Request, res: Response) => {
 
     const validation = createContactSchema.safeParse(req.body);
     if (!validation.success) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: "Invalid request body",
         code: "INVALID_REQUEST",
         details: validation.error.issues
@@ -169,7 +274,7 @@ router.post("/", async (req: Request, res: Response) => {
     });
 
     if (existingContact) {
-      return res.status(409).json({ 
+      return res.status(409).json({
         error: "Contact with this address already exists",
         code: "DUPLICATE_CONTACT"
       });
@@ -201,263 +306,18 @@ router.post("/", async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error("Failed to create contact:", error);
-    
+
     // Handle unique constraint violation
     if (error instanceof Error && error.message.includes('Unique constraint')) {
-      return res.status(409).json({ 
+      return res.status(409).json({
         error: "Contact with this address already exists",
         code: "DUPLICATE_CONTACT"
       });
     }
 
-    res.status(500).json({ 
+    res.status(500).json({
       error: "Failed to create contact",
       code: "CREATE_FAILED"
-    });
-  }
-});
-
-/**
- * PUT /api/contacts/:id
- * Update an existing contact
- */
-router.put("/:id", async (req: Request, res: Response) => {
-  try {
-    const { id } = req.params;
-    const walletAddress = getWalletAddress(req);
-    
-    if (!walletAddress) {
-      return res.status(401).json({ 
-        error: "Wallet address required",
-        code: "WALLET_ADDRESS_REQUIRED"
-      });
-    }
-
-    const validation = updateContactSchema.safeParse(req.body);
-    if (!validation.success) {
-      return res.status(400).json({ 
-        error: "Invalid request body",
-        code: "INVALID_REQUEST",
-        details: validation.error.issues
-      });
-    }
-
-    // Check if contact exists and belongs to user
-    const existingContact = await prisma.contact.findFirst({
-      where: { id, walletAddress },
-    });
-
-    if (!existingContact) {
-      return res.status(404).json({ 
-        error: "Contact not found",
-        code: "CONTACT_NOT_FOUND"
-      });
-    }
-
-    const { encryptedName, encryptedAddress } = validation.data;
-
-    // If updating address, check for duplicates
-    if (encryptedAddress && encryptedAddress !== existingContact.encryptedAddress) {
-      const duplicateContact = await prisma.contact.findFirst({
-        where: {
-          walletAddress,
-          encryptedAddress,
-          id: { not: id }, // Exclude current contact
-        },
-      });
-
-      if (duplicateContact) {
-        return res.status(409).json({ 
-          error: "Contact with this address already exists",
-          code: "DUPLICATE_CONTACT"
-        });
-      }
-    }
-
-    const updateData: { encryptedName?: string; encryptedAddress?: string } = {};
-    if (encryptedName) updateData.encryptedName = encryptedName;
-    if (encryptedAddress) updateData.encryptedAddress = encryptedAddress;
-
-    const contact = await prisma.contact.update({
-      where: { id },
-      data: updateData,
-      select: {
-        id: true,
-        encryptedName: true,
-        encryptedAddress: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-
-    res.json({
-      contact: {
-        id: contact.id,
-        encrypted_name: contact.encryptedName,
-        encrypted_address: contact.encryptedAddress,
-        created_at: contact.createdAt.toISOString(),
-        updated_at: contact.updatedAt.toISOString(),
-      },
-    });
-  } catch (error) {
-    console.error("Failed to update contact:", error);
-    
-    // Handle unique constraint violation
-    if (error instanceof Error && error.message.includes('Unique constraint')) {
-      return res.status(409).json({ 
-        error: "Contact with this address already exists",
-        code: "DUPLICATE_CONTACT"
-      });
-    }
-
-    res.status(500).json({ 
-      error: "Failed to update contact",
-      code: "UPDATE_FAILED"
-    });
-  }
-});
-
-/**
- * DELETE /api/contacts/:id
- * Delete a contact
- */
-router.delete("/:id", async (req: Request, res: Response) => {
-  try {
-    const { id } = req.params;
-    const walletAddress = getWalletAddress(req);
-    
-    if (!walletAddress) {
-      return res.status(401).json({ 
-        error: "Wallet address required",
-        code: "WALLET_ADDRESS_REQUIRED"
-      });
-    }
-
-    // Check if contact exists and belongs to user
-    const existingContact = await prisma.contact.findFirst({
-      where: { id, walletAddress },
-    });
-
-    if (!existingContact) {
-      return res.status(404).json({ 
-        error: "Contact not found",
-        code: "CONTACT_NOT_FOUND"
-      });
-    }
-
-    await prisma.contact.delete({
-      where: { id },
-    });
-
-    res.status(204).send();
-  } catch (error) {
-    console.error("Failed to delete contact:", error);
-    res.status(500).json({ 
-      error: "Failed to delete contact",
-      code: "DELETE_FAILED"
-    });
-  }
-});
-
-/**
- * GET /api/contacts/search
- * Search contacts (limited implementation since data is encrypted)
- */
-router.get("/search", async (req: Request, res: Response) => {
-  try {
-    const walletAddress = getWalletAddress(req);
-    const { q } = req.query;
-    
-    if (!walletAddress) {
-      return res.status(401).json({ 
-        error: "Wallet address required",
-        code: "WALLET_ADDRESS_REQUIRED"
-      });
-    }
-
-    if (!q || typeof q !== 'string') {
-      return res.status(400).json({ 
-        error: "Search query is required",
-        code: "INVALID_QUERY"
-      });
-    }
-
-    // Since data is encrypted, we can't search by content
-    // We'll return all contacts and let the client filter after decryption
-    const contacts = await prisma.contact.findMany({
-      where: { walletAddress },
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        encryptedName: true,
-        encryptedAddress: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
-
-    res.json({
-      contacts: contacts.map(contact => ({
-        id: contact.id,
-        encrypted_name: contact.encryptedName,
-        encrypted_address: contact.encryptedAddress,
-        created_at: contact.createdAt.toISOString(),
-        updated_at: contact.updatedAt.toISOString(),
-      })),
-      total: contacts.length,
-    });
-  } catch (error) {
-    console.error("Failed to search contacts:", error);
-    res.status(500).json({ 
-      error: "Failed to search contacts",
-      code: "SEARCH_FAILED"
-    });
-  }
-});
-
-/**
- * GET /api/contacts/export
- * Export all contacts as encrypted backup
- */
-router.get("/export", async (req: Request, res: Response) => {
-  try {
-    const walletAddress = getWalletAddress(req);
-    
-    if (!walletAddress) {
-      return res.status(401).json({ 
-        error: "Wallet address required",
-        code: "WALLET_ADDRESS_REQUIRED"
-      });
-    }
-
-    const contacts = await prisma.contact.findMany({
-      where: { walletAddress },
-      orderBy: { createdAt: "desc" },
-    });
-
-    // Create encrypted backup (client will handle the actual encryption)
-    const backupData = {
-      version: "1.0",
-      exportedAt: new Date().toISOString(),
-      contacts: contacts.map(contact => ({
-        id: contact.id,
-        encryptedName: contact.encryptedName,
-        encryptedAddress: contact.encryptedAddress,
-        createdAt: contact.createdAt.toISOString(),
-        updatedAt: contact.updatedAt.toISOString(),
-      })),
-    };
-
-    // In a real implementation, this would be encrypted on the client side
-    // For now, we'll return the data as-is
-    res.json({
-      encryptedBackup: JSON.stringify(backupData),
-    });
-  } catch (error) {
-    console.error("Failed to export contacts:", error);
-    res.status(500).json({ 
-      error: "Failed to export contacts",
-      code: "EXPORT_FAILED"
     });
   }
 });
@@ -470,34 +330,34 @@ router.post("/import", async (req: Request, res: Response) => {
   try {
     const walletAddress = getWalletAddress(req);
     const { encryptedBackup } = req.body;
-    
+
     if (!walletAddress) {
-      return res.status(401).json({ 
+      return res.status(401).json({
         error: "Wallet address required",
         code: "WALLET_ADDRESS_REQUIRED"
       });
     }
 
     if (!encryptedBackup) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: "Encrypted backup is required",
         code: "INVALID_BACKUP"
       });
     }
 
-    // In a real implementation, the client would decrypt this data
-    // For now, we'll parse it as JSON
+    // In a real implementation, the client would decrypt this data.
+    // For now, we'll parse it as JSON.
     const backupData = JSON.parse(encryptedBackup);
-    
+
     if (!backupData.contacts || !Array.isArray(backupData.contacts)) {
-      return res.status(400).json({ 
+      return res.status(400).json({
         error: "Invalid backup format",
         code: "INVALID_FORMAT"
       });
     }
 
     const importedContacts = [];
-    
+
     for (const contactData of backupData.contacts) {
       try {
         // Check for duplicates
@@ -544,9 +404,151 @@ router.post("/import", async (req: Request, res: Response) => {
     });
   } catch (error) {
     console.error("Failed to import contacts:", error);
-    res.status(500).json({ 
+    res.status(500).json({
       error: "Failed to import contacts",
       code: "IMPORT_FAILED"
+    });
+  }
+});
+
+/**
+ * PUT /api/contacts/:id
+ * Update an existing contact
+ */
+router.put("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const walletAddress = getWalletAddress(req);
+
+    if (!walletAddress) {
+      return res.status(401).json({
+        error: "Wallet address required",
+        code: "WALLET_ADDRESS_REQUIRED"
+      });
+    }
+
+    const validation = updateContactSchema.safeParse(req.body);
+    if (!validation.success) {
+      return res.status(400).json({
+        error: "Invalid request body",
+        code: "INVALID_REQUEST",
+        details: validation.error.issues
+      });
+    }
+
+    // Check if contact exists and belongs to user
+    const existingContact = await prisma.contact.findFirst({
+      where: { id, walletAddress },
+    });
+
+    if (!existingContact) {
+      return res.status(404).json({
+        error: "Contact not found",
+        code: "CONTACT_NOT_FOUND"
+      });
+    }
+
+    const { encryptedName, encryptedAddress } = validation.data;
+
+    // If updating address, check for duplicates
+    if (encryptedAddress && encryptedAddress !== existingContact.encryptedAddress) {
+      const duplicateContact = await prisma.contact.findFirst({
+        where: {
+          walletAddress,
+          encryptedAddress,
+          id: { not: id }, // Exclude current contact
+        },
+      });
+
+      if (duplicateContact) {
+        return res.status(409).json({
+          error: "Contact with this address already exists",
+          code: "DUPLICATE_CONTACT"
+        });
+      }
+    }
+
+    const updateData: { encryptedName?: string; encryptedAddress?: string } = {};
+    if (encryptedName) updateData.encryptedName = encryptedName;
+    if (encryptedAddress) updateData.encryptedAddress = encryptedAddress;
+
+    const contact = await prisma.contact.update({
+      where: { id },
+      data: updateData,
+      select: {
+        id: true,
+        encryptedName: true,
+        encryptedAddress: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    res.json({
+      contact: {
+        id: contact.id,
+        encrypted_name: contact.encryptedName,
+        encrypted_address: contact.encryptedAddress,
+        created_at: contact.createdAt.toISOString(),
+        updated_at: contact.updatedAt.toISOString(),
+      },
+    });
+  } catch (error) {
+    console.error("Failed to update contact:", error);
+
+    // Handle unique constraint violation
+    if (error instanceof Error && error.message.includes('Unique constraint')) {
+      return res.status(409).json({
+        error: "Contact with this address already exists",
+        code: "DUPLICATE_CONTACT"
+      });
+    }
+
+    res.status(500).json({
+      error: "Failed to update contact",
+      code: "UPDATE_FAILED"
+    });
+  }
+});
+
+/**
+ * DELETE /api/contacts/:id
+ * Delete a contact
+ */
+router.delete("/:id", async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+    const walletAddress = getWalletAddress(req);
+
+    if (!walletAddress) {
+      return res.status(401).json({
+        error: "Wallet address required",
+        code: "WALLET_ADDRESS_REQUIRED"
+      });
+    }
+
+    // Check if contact exists and belongs to user
+    const existingContact = await prisma.contact.findFirst({
+      where: { id, walletAddress },
+    });
+
+    if (!existingContact) {
+      return res.status(404).json({
+        error: "Contact not found",
+        code: "CONTACT_NOT_FOUND"
+      });
+    }
+
+    await prisma.contact.delete({
+      where: { id },
+    });
+
+    res.status(204).send();
+  } catch (error) {
+    console.error("Failed to delete contact:", error);
+    res.status(500).json({
+      error: "Failed to delete contact",
+      code: "DELETE_FAILED"
     });
   }
 });

--- a/shared/settlement-payload-schema.json
+++ b/shared/settlement-payload-schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "settlement-payload-schema",
+  "title": "Settlement Payload",
+  "description": "Canonical schema for the matching-engine settlement payload that Soroban contract tests verify against. Both the Rust backend (matching_engine/src/settlement/mod.rs) and the contract test harness (contracts/settlement/src/lib.rs) must produce and consume data that conforms to this schema.",
+  "type": "object",
+  "required": ["data", "data_hash", "encoded"],
+  "properties": {
+    "data": {
+      "$ref": "#/definitions/SettlementData"
+    },
+    "data_hash": {
+      "type": "string",
+      "description": "Hex-encoded SHA-256 hash of the SettlementData fields in canonical order (trade_id, maker, taker, token0, token1, amount0_be, amount1_be, price_be, timestamp_be, nonce). Used as the message that all three parties sign.",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "encoded": {
+      "type": "string",
+      "description": "Base64-encoded JSON of the SettlementData, used as the on-chain invocation argument."
+    }
+  },
+  "definitions": {
+    "SettlementData": {
+      "type": "object",
+      "description": "Single-trade settlement data shared between the matching engine and the Soroban settlement contract.",
+      "required": [
+        "trade_id",
+        "maker",
+        "taker",
+        "token0",
+        "token1",
+        "amount0",
+        "amount1",
+        "price",
+        "timestamp",
+        "nonce",
+        "maker_signature",
+        "taker_signature",
+        "engine_signature"
+      ],
+      "properties": {
+        "trade_id": {
+          "type": "string",
+          "description": "Unique identifier for the matched trade. The Soroban contract tracks settled trade_ids to prevent replay."
+        },
+        "maker": {
+          "type": "string",
+          "description": "Stellar account address of the order maker."
+        },
+        "taker": {
+          "type": "string",
+          "description": "Stellar account address of the order taker."
+        },
+        "token0": {
+          "type": "string",
+          "description": "Stellar contract address of the first token in the pair."
+        },
+        "token1": {
+          "type": "string",
+          "description": "Stellar contract address of the second token in the pair."
+        },
+        "amount0": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Stroops of token0 to transfer from maker to taker."
+        },
+        "amount1": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Stroops of token1 to transfer from taker to maker."
+        },
+        "price": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Execution price (token1 per token0, in stroops)."
+        },
+        "timestamp": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unix millisecond timestamp at which the trade was matched."
+        },
+        "nonce": {
+          "type": "string",
+          "description": "UUID v4 generated fresh for every settlement payload. Combined with trade_id in the hash to ensure each payload is unique even for retried settlements, enabling tamper-evident verification.",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "maker_signature": {
+          "type": "string",
+          "description": "Hex-encoded Ed25519 signature of data_hash by the maker's key (128 hex chars = 64 bytes).",
+          "pattern": "^[0-9a-f]{128}$"
+        },
+        "taker_signature": {
+          "type": "string",
+          "description": "Hex-encoded Ed25519 signature of data_hash by the taker's key (128 hex chars = 64 bytes).",
+          "pattern": "^[0-9a-f]{128}$"
+        },
+        "engine_signature": {
+          "type": "string",
+          "description": "Hex-encoded Ed25519 signature of data_hash by the matching engine's key (128 hex chars = 64 bytes).",
+          "pattern": "^[0-9a-f]{128}$"
+        }
+      }
+    },
+    "SettlementBatch": {
+      "type": "object",
+      "description": "Batch envelope wrapping multiple SettlementData entries for gas-efficient on-chain execution.",
+      "required": [
+        "batch_id",
+        "settlements",
+        "total_amount0",
+        "total_amount1",
+        "timestamp"
+      ],
+      "properties": {
+        "batch_id": {
+          "type": "string",
+          "description": "UUID v4 uniquely identifying this batch submission."
+        },
+        "settlements": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/SettlementData" },
+          "minItems": 1,
+          "description": "Ordered list of settlements in this batch."
+        },
+        "total_amount0": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Sum of all settlement amount0 values. The contract verifies this matches the per-settlement sum using checked arithmetic."
+        },
+        "total_amount1": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Sum of all settlement amount1 values. The contract verifies this matches the per-settlement sum using checked arithmetic."
+        },
+        "timestamp": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Unix millisecond timestamp when the batch was assembled."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
  Summary

  Resolves three issues across the settlement layer, contacts API, and API documentation.

  - #715 – Added nonce field to SettlementData (included in SHA-256 hash) so every settlement payload is unique and
  tamper-evident even for the same trade. Added two Soroban contract tests: duplicate trade_id (replay) rejected with error
  #5; empty signatures rejected with error #4. Added backend tests for tamper detection and nonce uniqueness. Created
  shared/settlement-payload-schema.json as the canonical cross-boundary schema.
  - #724 – Imported and mounted contactsRouter in app.ts at /api/contacts. Fixed Express route ordering in contacts.ts so
  static paths (/search, /export) resolve before the dynamic /:id segment. Added full supertest coverage for all eight
  endpoints: auth enforcement (401), list, get, create, update, delete, search, export, import — with duplicate rejection
  (409) and encryption-boundary assertions.
  - #725 – Added /api/contacts, /api/incidents, /api/onramp/webhook, and /api/deposits endpoints to openapi.yaml with
  request/response schemas. Added check-openapi-drift.ts script (npm run check:openapi) that compares mounted routes to
  documented paths and exits non-zero on drift.

  Changes

  - backend/matching_engine/src/settlement/mod.rs – nonce field, updated hash fn, 2 new tests
  - contracts/settlement/src/lib.rs – 2 new negative tests (replay, empty signature)
  - shared/settlement-payload-schema.json – new canonical schema
  - server/src/app.ts – mount contacts router
  - server/src/routes/contacts.ts – fix route order (static before dynamic)
  - server/src/__tests__/contacts.test.ts – new, 25-test end-to-end coverage
  - server/openapi.yaml – contacts, incidents, onramp, deposits paths + schemas
  - server/scripts/check-openapi-drift.ts – new drift check script
  - server/package.json – check:openapi npm script

  Closes

  Closes #715
  Closes #724
  Closes #725
