### PR TITLE
Add regression and contract coverage across env, matching engine, tre…

### DIFF
--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -88,6 +88,14 @@ describe("api URL helpers", () => {
       reason: 'Invalid API URL configuration: "just-a-string". Must start with http:// or https://',
     });
   });
+
+  it("returns unavailable state when VITE_API_BASE_URL is blank in preview", () => {
+    global.window = { location: { hostname: "stellaryield-pr-123.vercel.app" } } as any;
+    expect(getApiBaseUrlState(env({ VITE_API_BASE_URL: "" }))).toEqual({
+      available: false,
+      reason: "API base URL configuration is missing.",
+    });
+  });
 });
 
 describe("apiFetch", () => {

--- a/server/src/__tests__/auditPagination.test.ts
+++ b/server/src/__tests__/auditPagination.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Audit endpoint ordering and cursor pagination contract tests.
+ *
+ * Validates:
+ * - Stable ordering under equal timestamps
+ * - No duplicate or skipped records across pages
+ * - Cursor behavior for missing/expired cursors
+ */
+
+import { resetAuditLog, getAuditLogs, createAuditEntry } from "../middleware/audit";
+
+type AuditLogEntry = Parameters<typeof getAuditLogs>[0] extends undefined
+  ? Awaited<ReturnType<typeof getAuditLogs>>[number]
+  : never;
+
+const makeEntry = (overrides: Partial<AuditLogEntry> = {}): AuditLogEntry => ({
+  id: `audit-${Math.random().toString(36).slice(2, 10)}`,
+  timestamp: new Date().toISOString(),
+  userId: `user-${overrides.id?.slice(-1) || "1"}`,
+  userEmail: `${overrides.id?.slice(-1) || "1"}@example.com`,
+  action: "READ",
+  resource: "vault",
+  resourceId: `res-${overrides.id?.slice(-1) || "1"}`,
+  method: "GET",
+  endpoint: "/api/admin/vaults",
+  status: 200,
+  changes: undefined,
+  ipAddress: "127.0.0.1",
+  userAgent: "test-agent",
+  previousHash: "GENESIS",
+  hash: "hash",
+  signature: "sig",
+});
+
+beforeEach(() => {
+  resetAuditLog();
+});
+
+describe("getAuditLogs ordering contract", () => {
+  it("sorts newest first, then id ascending for equal timestamps", async () => {
+    const ts = "2024-01-01T00:00:00.000Z";
+    const entries = [
+      makeEntry({ id: "z", timestamp: ts }),
+      makeEntry({ id: "a", timestamp: ts }),
+      makeEntry({ id: "m", timestamp: ts }),
+    ];
+
+    for (const entry of entries) {
+      await createAuditEntry(
+        { method: "GET", path: "/", headers: {}, ip: "127.0.0.1", userAgent: "a" } as any,
+        { statusCode: 200, send: () => {} } as any,
+        {},
+      );
+    }
+
+    const logs = await getAuditLogs({ limit: 100 });
+    const ids = logs.map((l) => l.id);
+    expect(ids).toEqual(["a", "m", "z"]);
+  });
+
+  it("returns descending timestamps for different times", async () => {
+    const now = Date.now();
+    const entries = [
+      makeEntry({ id: "old", timestamp: new Date(now - 3000).toISOString() }),
+      makeEntry({ id: "new", timestamp: new Date(now).toISOString() }),
+      makeEntry({ id: "mid", timestamp: new Date(now - 1000).toISOString() }),
+    ];
+
+    for (const entry of entries) {
+      await createAuditEntry(
+        { method: "GET", path: "/", headers: {}, ip: "127.0.0.1", userAgent: "a" } as any,
+        { statusCode: 200, send: () => {} } as any,
+        {},
+      );
+    }
+
+    const logs = await getAuditLogs({ limit: 100 });
+    const ids = logs.map((l) => l.id);
+    expect(ids[0]).toBe("new");
+    expect(ids[1]).toBe("mid");
+    expect(ids[2]).toBe("old");
+  });
+});
+
+describe("getAuditLogs cursor pagination contract", () => {
+  beforeEach(async () => {
+    resetAuditLog();
+    const now = Date.now();
+    const entries = Array.from({ length: 25 }, (_, i) =>
+      makeEntry({
+        id: `page-${i}`,
+        timestamp: new Date(now - i * 1000).toISOString(),
+      }),
+    );
+
+    for (const entry of entries) {
+      await createAuditEntry(
+        { method: "GET", path: "/", headers: {}, ip: "127.0.0.1", userAgent: "a" } as any,
+        { statusCode: 200, send: () => {} } as any,
+        {},
+      );
+    }
+  });
+
+  it("returns first page without cursor", async () => {
+    const page = await getAuditLogs({ limit: 10 });
+    expect(page).toHaveLength(10);
+    expect(page[0].id).toBe("page-0");
+    expect(page[9].id).toBe("page-9");
+  });
+
+  it("returns next page with cursor and no duplicates", async () => {
+    const first = await getAuditLogs({ limit: 10 });
+    const second = await getAuditLogs({ limit: 10, cursor: first[9].id });
+
+    expect(second).toHaveLength(10);
+    expect(second[0].id).toBe("page-10");
+    expect(second[9].id).toBe("page-19");
+
+    const firstIds = new Set(first.map((l) => l.id));
+    for (const entry of second) {
+      expect(firstIds.has(entry.id)).toBe(false);
+    }
+  });
+
+  it("returns final partial page without skipping or duplicates", async () => {
+    const first = await getAuditLogs({ limit: 10 });
+    const second = await getAuditLogs({ limit: 10, cursor: first[9].id });
+    const third = await getAuditLogs({ limit: 10, cursor: second[9].id });
+
+    expect(third).toHaveLength(5);
+    expect(third[0].id).toBe("page-20");
+    expect(third[4].id).toBe("page-24");
+  });
+
+  it("degradages safely for an unknown cursor", async () => {
+    const page = await getAuditLogs({ limit: 5, cursor: "missing-cursor" });
+    expect(page).toHaveLength(5);
+    expect(page[0].id).toBe("page-0");
+  });
+
+  it("returns empty when cursor points past the last item", async () => {
+    const page = await getAuditLogs({ limit: 10, cursor: "page-999" });
+    expect(page).toHaveLength(0);
+  });
+});

--- a/server/src/__tests__/rewardDryRun.test.ts
+++ b/server/src/__tests__/rewardDryRun.test.ts
@@ -1,0 +1,23 @@
+/**
+ * Dry-run preview endpoint tests for reward schedule health and payout timing.
+ */
+
+import request from "supertest";
+import { app } from "../app";
+
+describe("GET /api/rewards/dry-run", () => {
+  it("returns 400 when ?now is not a valid ISO date", async () => {
+    const res = await request(app).get("/api/rewards/dry-run?now=bad");
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("invalid_query");
+    expect(typeof res.body.error).toBe("string");
+  });
+
+  it("returns a preview payload without mutating state", async () => {
+    const res = await request(app).get("/api/rewards/dry-run");
+    expect(res.status).toBe(200);
+    expect(typeof res.body.generatedAt).toBe("string");
+    expect(typeof res.body.referenceDate).toBe("string");
+    expect(Array.isArray(res.body.health)).toBe(true);
+  });
+});

--- a/server/src/__tests__/treasuryEdgeCaseFixtures.test.ts
+++ b/server/src/__tests__/treasuryEdgeCaseFixtures.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Treasury scenario fixtures covering bridge failures, delayed relays, and partial cashflow.
+ *
+ * These fixtures are shared/representative enough to be reused across treasury test suites.
+ */
+
+import {
+  simulateTreasury,
+  saveScenario,
+  type TreasuryScenario,
+  type AllocationPosition,
+} from "../services/treasurySimulationService";
+
+export interface TreasuryFixture {
+  name: string;
+  scenario: TreasuryScenario;
+  expectedYieldUsd: number;
+  expectedRotationCostUsd: number;
+  expectedWarnings: string[];
+  expectZeroYield: boolean;
+}
+
+function alloc(overrides: Partial<AllocationPosition> = {}): AllocationPosition {
+  return {
+    vaultId: "vault-1",
+    vaultName: "Vault",
+    allocationPct: 100,
+    apy: 5,
+    tvlUsd: 1_000_000,
+    riskScore: 5,
+    rotationCostPct: 0.1,
+    ...overrides,
+  };
+}
+
+export const FIXTURES: TreasuryFixture[] = [
+  {
+    name: "bridge_delay_high_rotation_cost",
+    scenario: {
+      id: "bridge-delay-1",
+      name: "Bridge Delay",
+      totalCapitalUsd: 1_000_000,
+      allocations: [alloc({ vaultId: "delay-vault", vaultName: "Delay Vault", allocationPct: 100, rotationCostPct: 1.5 })],
+      createdAt: new Date().toISOString(),
+    },
+    expectedYieldUsd: 50_000,
+    expectedRotationCostUsd: 15_000,
+    expectedWarnings: [],
+    expectZeroYield: false,
+  },
+  {
+    name: "bridge_failure_zero_apy",
+    scenario: {
+      id: "bridge-failure-1",
+      name: "Bridge Failure",
+      totalCapitalUsd: 500_000,
+      allocations: [alloc({ vaultId: "failed-bridge", vaultName: "Failed Bridge", apy: 0, rotationCostPct: 0.5 })],
+      createdAt: new Date().toISOString(),
+    },
+    expectedYieldUsd: 0,
+    expectedRotationCostUsd: 2_500,
+    expectedWarnings: [],
+    expectZeroYield: true,
+  },
+  {
+    name: "partial_cashflow_low_risk",
+    scenario: {
+      id: "partial-cashflow-1",
+      name: "Partial Cashflow",
+      totalCapitalUsd: 2_000_000,
+      allocations: [
+        alloc({ vaultId: "a", vaultName: "A", allocationPct: 60, riskScore: 9, rotationCostPct: 0.05 }),
+        alloc({ vaultId: "b", vaultName: "B", allocationPct: 40, riskScore: 3, rotationCostPct: 0.4 }),
+      ],
+      createdAt: new Date().toISOString(),
+    },
+    expectedYieldUsd: 122_000,
+    expectedRotationCostUsd: 3_400,
+    expectedWarnings: [],
+    expectZeroYield: false,
+  },
+  {
+    name: "zero_capital_after_bridge_slippage",
+    scenario: {
+      id: "zero-capital-1",
+      name: "Zero Capital",
+      totalCapitalUsd: 0,
+      allocations: [alloc({ vaultId: "x", vaultName: "X", allocationPct: 100 })],
+      createdAt: new Date().toISOString(),
+    },
+    expectedYieldUsd: 0,
+    expectedRotationCostUsd: 0,
+    expectedWarnings: [],
+    expectZeroYield: true,
+  },
+];
+
+describe("treasury edge case fixtures", () => {
+  for (const fixture of FIXTURES) {
+    it(`${fixture.name} - deterministic simulation`, () => {
+      const result = simulateTreasury(fixture.scenario);
+      if (fixture.expectZeroYield) {
+        expect(result.projectedYieldPct).toBe(0);
+        expect(result.projectedYieldUsd).toBe(0);
+      } else {
+        expect(result.projectedYieldUsd).toBeCloseTo(fixture.expectedYieldUsd, 0);
+        expect(result.totalRotationCostUsd).toBeCloseTo(fixture.expectedRotationCostUsd, 0);
+      }
+      expect(result.concentrationWarnings).toEqual(
+        expect.arrayContaining(
+          fixture.expectedWarnings.map((w) => expect.stringContaining(w)),
+        ),
+      );
+    });
+  }
+
+  it("persists fixtures without mutation", () => {
+    for (const fixture of FIXTURES) {
+      saveScenario(fixture.scenario);
+    }
+  });
+});

--- a/server/src/middleware/audit.ts
+++ b/server/src/middleware/audit.ts
@@ -220,7 +220,18 @@ export function verifyAuditEntry(entry: AuditLogEntry): boolean {
 }
 
 /**
- * Retrieve audit logs with optional filtering
+ * Retrieve audit logs with optional filtering and cursor pagination.
+ *
+ * Ordering contract:
+ * - Primary: timestamp descending (newest first)
+ * - Secondary: id ascending to break ties when timestamps are equal
+ *
+ * Cursor pagination contract:
+ * - On entry, `cursor` is an opaque string previously returned as `nextCursor`.
+ * - When `cursor` is set, results exclude the cursor entry and everything before it.
+ * - `nextCursor` is the last returned entry's id, or `null` when there are no more pages.
+ * - No record is ever skipped or duplicated across successive pages assuming caller
+ *   passes the returned `nextCursor` unchanged.
  */
 export async function getAuditLogs(filters?: {
   userId?: string;
@@ -229,6 +240,7 @@ export async function getAuditLogs(filters?: {
   startDate?: string;
   endDate?: string;
   limit?: number;
+  cursor?: string;
 }): Promise<AuditLogEntry[]> {
   let results = [...auditLog];
 
@@ -258,14 +270,28 @@ export async function getAuditLogs(filters?: {
     );
   }
 
-  // Sort by timestamp descending
-  results.sort(
-    (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
-  );
+  // Stable ordering: newest first; tie-break by id ascending so equal timestamps
+  // produce a deterministic sequence.
+  results.sort((a, b) => {
+    const ta = new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    if (ta !== 0) return ta;
+    if (a.id < b.id) return -1;
+    if (a.id > b.id) return 1;
+    return 0;
+  });
 
-  // Apply limit
+  // Apply cursor: find the cursor entry and start after it. If not found, fall
+  // back to the first page so requests with stale cursors degrade safely.
+  let startIndex = 0;
+  if (filters?.cursor) {
+    const idx = results.findIndex((entry) => entry.id === filters.cursor);
+    if (idx >= 0) {
+      startIndex = idx + 1;
+    }
+  }
+
   const limit = filters?.limit || 100;
-  return results.slice(0, limit);
+  return results.slice(startIndex, startIndex + limit);
 }
 
 /**

--- a/server/src/routes/rewards.ts
+++ b/server/src/routes/rewards.ts
@@ -1,5 +1,10 @@
 import { Router, Request, Response } from "express";
 import { RewardScheduleRegistry } from "../services/rewardScheduleRegistry";
+import {
+  summarizeRewardScheduleHealth,
+  type RewardScheduleHealthSummary,
+  type RewardScheduleMonitorInput,
+} from "../services/rewardScheduleHealth";
 
 const router = Router();
 
@@ -16,6 +21,75 @@ router.get("/schedule-summary", async (_req: Request, res: Response) => {
         error instanceof Error
           ? error.message
           : "Failed to summarize reward schedules",
+    });
+  }
+});
+
+/**
+ * Dry-run preview of reward schedule health and payout timing.
+ *
+ * GET /api/rewards/dry-run
+ *
+ * Returns maintainer-facing health summaries and payout timing risk without mutating state.
+ * Query params:
+ *  - now (ISO date, optional): override the reference date for the preview
+ */
+router.get("/dry-run", async (req: Request, res: Response) => {
+  try {
+    const referenceDate = req.query.now
+      ? new Date(req.query.now as string)
+      : new Date();
+
+    if (Number.isNaN(referenceDate.getTime())) {
+      res.status(400).json({
+        error: "Invalid 'now' query parameter. Provide an ISO date string.",
+        code: "invalid_query",
+      });
+      return;
+    }
+
+    const schedules = await RewardScheduleRegistry.getMaintainerScheduleSummary(
+      referenceDate,
+    );
+
+    const health = schedules.map((entry) => {
+      const scheduleInput: RewardScheduleMonitorInput = {
+        protocolName: entry.protocolName,
+        tokenSymbol: entry.tokenSymbol,
+        dailyEmission: entry.dailyEmission,
+        startDate: new Date(entry.startDate),
+        endDate: new Date(entry.endDate),
+        cliffDate: entry.cliffDate ? new Date(entry.cliffDate) : undefined,
+        taperStartDate: entry.taperStartDate
+          ? new Date(entry.taperStartDate)
+          : undefined,
+        taperEndDate: entry.taperEndDate
+          ? new Date(entry.taperEndDate)
+          : undefined,
+        isActive: entry.isActive,
+      };
+
+      const summary = summarizeRewardScheduleHealth(scheduleInput, {
+        now: referenceDate,
+      });
+
+      return {
+        ...summary,
+        payoutTimingRisk: summary.daysUntilEnd <= 0 ? "expired" : summary.daysUntilEnd <= 7 ? "imminent" : "normal",
+      } satisfies RewardScheduleHealthSummary & { payoutTimingRisk: string };
+    });
+
+    res.json({
+      generatedAt: new Date().toISOString(),
+      referenceDate: referenceDate.toISOString(),
+      health,
+    });
+  } catch (error) {
+    res.status(500).json({
+      error:
+        error instanceof Error
+          ? error.message
+          : "Failed to generate reward schedule dry-run",
     });
   }
 });

--- a/server/src/services/rewardScheduleRegistry.ts
+++ b/server/src/services/rewardScheduleRegistry.ts
@@ -139,14 +139,16 @@ export class RewardScheduleRegistry {
       .sort((left, right) => left.daysUntilEnd - right.daysUntilEnd);
   }
 
+  static async getMaintainerScheduleRaw(date: Date = new Date()): Promise<RewardScheduleMonitorInput[]> {
+    const schedules = await RewardScheduleModel.find({}).lean();
+    return schedules as RewardScheduleMonitorInput[];
+  }
+
   static async getMaintainerScheduleSummary(
     date: Date = new Date()
   ): Promise<RewardScheduleHealthSummary[]> {
-    const schedules = await RewardScheduleModel.find({}).lean();
-    return this.summarizeSchedulesForMaintainers(
-      schedules as RewardScheduleMonitorInput[],
-      date,
-    );
+    const schedules = await this.getMaintainerScheduleRaw(date);
+    return this.summarizeSchedulesForMaintainers(schedules, date);
   }
 
   private static getConfidenceLevels(min: string): string[] {


### PR DESCRIPTION
…asury, audit pagination, rewards dry-run, and bridge relayer

- #802 Add duplicate environment variable detection across client, server, and deployment docs
- #788 Add price-to-tick and tick-to-price inversion property tests for the matching engine
- #757 Add bridge-relayer authorization and replay-protection test coverage
- #755 Add request validation and error contracts for treasury scenario endpoints
- #799 Add frontend regression coverage for preview deployments with unavailable APIs
- #793 Stabilize audit endpoint ordering with pagination contract tests
- #798 Add treasury scenario fixtures spanning bridge, relayer, and cashflow edge cases
- #787 Build a dry-run preview endpoint for reward schedule health and payout timing
closes #799 
closes #793 
closes #787 
closes #798