### PR TITLE
fix: harden zap validation, registry diff annotations, manifest alias tests, error code guardrails

### DIFF
--- a/client/src/features/zap/assets.test.ts
+++ b/client/src/features/zap/assets.test.ts
@@ -7,7 +7,9 @@ import {
   mergeVaultIntoZapSelectableAssets,
   shouldLoadZapMetadataFromApi,
   buildSelectableZapAssetsFromMetadata,
+  validateZapAssets,
 } from "./assets";
+import type { ZapAssetOption } from "./types";
 
 describe("loadZapAssetOptions", () => {
   afterEach(() => {
@@ -41,6 +43,58 @@ describe("loadZapAssetOptions", () => {
     vi.stubEnv("VITE_USDC_SAC_CONTRACT_ID", "");
     vi.stubEnv("VITE_AQUA_SAC_CONTRACT_ID", "");
     expect(loadZapAssetOptions().every((a) => a.contractId.length > 0)).toBe(true);
+  });
+
+  it("falls back to env vars when VITE_ZAP_ASSETS_JSON contains duplicate symbols", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7 },
+      { symbol: "XLM", name: "Duplicate", contractId: "CDDUP", decimals: 7 },
+    ];
+    vi.stubEnv("VITE_ZAP_ASSETS_JSON", JSON.stringify(assets));
+    vi.stubEnv("VITE_XLM_SAC_CONTRACT_ID", "CDXLMFALLBACK");
+    vi.stubEnv("VITE_USDC_SAC_CONTRACT_ID", "");
+    vi.stubEnv("VITE_AQUA_SAC_CONTRACT_ID", "");
+    const list = loadZapAssetOptions();
+    // Should have fallen back to env vars, not returned the invalid JSON list
+    expect(list.some((a) => a.contractId === "CDDUP")).toBe(false);
+  });
+
+  it("falls back when VITE_ZAP_ASSETS_JSON contains duplicate contractIds", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDSHARED", decimals: 7 },
+      { symbol: "USDC", name: "USD Coin", contractId: "CDSHARED", decimals: 6 },
+    ];
+    vi.stubEnv("VITE_ZAP_ASSETS_JSON", JSON.stringify(assets));
+    vi.stubEnv("VITE_XLM_SAC_CONTRACT_ID", "CDXLMENV");
+    vi.stubEnv("VITE_USDC_SAC_CONTRACT_ID", "");
+    vi.stubEnv("VITE_AQUA_SAC_CONTRACT_ID", "");
+    const list = loadZapAssetOptions();
+    expect(list.some((a) => a.contractId === "CDSHARED")).toBe(false);
+  });
+
+  it("falls back when VITE_ZAP_ASSETS_JSON has negative decimals", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: -1 },
+    ];
+    vi.stubEnv("VITE_ZAP_ASSETS_JSON", JSON.stringify(assets));
+    vi.stubEnv("VITE_XLM_SAC_CONTRACT_ID", "CDXLMENV");
+    vi.stubEnv("VITE_USDC_SAC_CONTRACT_ID", "");
+    vi.stubEnv("VITE_AQUA_SAC_CONTRACT_ID", "");
+    const list = loadZapAssetOptions();
+    // Negative decimals asset must not appear in the returned list
+    expect(list.every((a) => a.decimals >= 0)).toBe(true);
+  });
+
+  it("falls back when VITE_ZAP_ASSETS_JSON has non-integer decimals", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7.5 },
+    ];
+    vi.stubEnv("VITE_ZAP_ASSETS_JSON", JSON.stringify(assets));
+    vi.stubEnv("VITE_XLM_SAC_CONTRACT_ID", "CDXLMENV");
+    vi.stubEnv("VITE_USDC_SAC_CONTRACT_ID", "");
+    vi.stubEnv("VITE_AQUA_SAC_CONTRACT_ID", "");
+    const list = loadZapAssetOptions();
+    expect(list.every((a) => Number.isInteger(a.decimals))).toBe(true);
   });
 });
 
@@ -303,5 +357,90 @@ describe("getVaultContractIdFromEnv", () => {
   it("falls back to VITE_CONTRACT_ID", () => {
     vi.stubEnv("VITE_CONTRACT_ID", "CCC");
     expect(getVaultContractIdFromEnv()).toBe("CCC");
+  });
+});
+
+// ── validateZapAssets (issue #783) ──────────────────────────────────────────
+
+describe("validateZapAssets", () => {
+  it("returns no errors for a valid list", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7 },
+      { symbol: "USDC", name: "USD Coin", contractId: "CDUSDC", decimals: 6 },
+    ];
+    expect(validateZapAssets(assets)).toHaveLength(0);
+  });
+
+  it("reports duplicate symbol", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDX1", decimals: 7 },
+      { symbol: "XLM", name: "Duplicate XLM", contractId: "CDX2", decimals: 7 },
+    ];
+    const errors = validateZapAssets(assets);
+    expect(errors.some((e) => e.includes("Duplicate symbol") && e.includes("XLM"))).toBe(true);
+  });
+
+  it("reports duplicate contractId", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDSHARED", decimals: 7 },
+      { symbol: "USDC", name: "USD Coin", contractId: "CDSHARED", decimals: 6 },
+    ];
+    const errors = validateZapAssets(assets);
+    expect(errors.some((e) => e.includes("Duplicate contractId") && e.includes("CDSHARED"))).toBe(true);
+  });
+
+  it("reports negative decimals", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: -1 },
+    ];
+    const errors = validateZapAssets(assets);
+    expect(errors.some((e) => e.includes("XLM") && e.includes("invalid decimals"))).toBe(true);
+  });
+
+  it("reports non-integer decimals", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7.5 },
+    ];
+    const errors = validateZapAssets(assets);
+    expect(errors.some((e) => e.includes("XLM") && e.includes("invalid decimals"))).toBe(true);
+  });
+
+  it("accepts decimals=0 as valid", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 0 },
+    ];
+    expect(validateZapAssets(assets)).toHaveLength(0);
+  });
+
+  it("reports malformed iconUrl that does not start with http:// or https://", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7, iconUrl: "ftp://bad.example/icon.png" },
+    ];
+    const errors = validateZapAssets(assets);
+    expect(errors.some((e) => e.includes("iconUrl"))).toBe(true);
+  });
+
+  it("accepts valid https iconUrl without error", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7, iconUrl: "https://example.com/xlm.png" },
+    ];
+    expect(validateZapAssets(assets)).toHaveLength(0);
+  });
+
+  it("accepts undefined iconUrl without error", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDXLM", decimals: 7 },
+    ];
+    expect(validateZapAssets(assets)).toHaveLength(0);
+  });
+
+  it("reports all errors together for a fully malformed asset list", () => {
+    const assets: ZapAssetOption[] = [
+      { symbol: "XLM", name: "Stellar Lumens", contractId: "CDSHARED", decimals: -1 },
+      { symbol: "XLM", name: "Duplicate", contractId: "CDSHARED", decimals: 7.5 },
+    ];
+    const errors = validateZapAssets(assets);
+    // Expect: duplicate symbol, duplicate contractId, negative decimals on first, non-integer on second
+    expect(errors.length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/client/src/features/zap/assets.ts
+++ b/client/src/features/zap/assets.ts
@@ -11,7 +11,16 @@ export function loadZapAssetOptions(): ZapAssetOption[] {
     try {
       const parsed = JSON.parse(raw) as ZapAssetOption[];
       if (Array.isArray(parsed) && parsed.length > 0) {
-        return parsed;
+        const validationErrors = validateZapAssets(parsed);
+        if (validationErrors.length > 0) {
+          console.error(
+            "[ZapAssets] VITE_ZAP_ASSETS_JSON validation failed:",
+            validationErrors,
+          );
+          /* fall through to env-var fallback */
+        } else {
+          return parsed;
+        }
       }
     } catch {
       /* fall through */
@@ -64,8 +73,49 @@ function isZapAssetOption(v: unknown): v is ZapAssetOption {
     typeof v.name === "string" &&
     typeof v.contractId === "string" &&
     typeof v.decimals === "number" &&
-    Number.isFinite(v.decimals)
+    Number.isFinite(v.decimals) &&
+    Number.isInteger(v.decimals) &&
+    (v.decimals as number) >= 0
   );
+}
+
+/**
+ * Validates a list of zap asset options for duplicates and malformed values.
+ * Returns an array of human-readable error messages; an empty array means valid.
+ */
+export function validateZapAssets(assets: ZapAssetOption[]): string[] {
+  const errors: string[] = [];
+  const seenSymbols = new Set<string>();
+  const seenContractIds = new Set<string>();
+
+  for (const asset of assets) {
+    if (seenSymbols.has(asset.symbol)) {
+      errors.push(`Duplicate symbol: "${asset.symbol}"`);
+    }
+    seenSymbols.add(asset.symbol);
+
+    if (asset.contractId && seenContractIds.has(asset.contractId)) {
+      errors.push(`Duplicate contractId: "${asset.contractId}"`);
+    }
+    if (asset.contractId) seenContractIds.add(asset.contractId);
+
+    if (!Number.isInteger(asset.decimals) || asset.decimals < 0) {
+      errors.push(
+        `Asset "${asset.symbol}" has invalid decimals: ${asset.decimals} (must be a non-negative integer)`,
+      );
+    }
+
+    if (
+      asset.iconUrl !== undefined &&
+      !(asset.iconUrl.startsWith("http://") || asset.iconUrl.startsWith("https://"))
+    ) {
+      errors.push(
+        `Asset "${asset.symbol}" has a malformed iconUrl: "${asset.iconUrl}" (must start with http:// or https://)`,
+      );
+    }
+  }
+
+  return errors;
 }
 
 /** Fetches `/api/zap/supported-assets`; returns null on network or schema errors. */

--- a/client/src/utils/errorDecoder.test.ts
+++ b/client/src/utils/errorDecoder.test.ts
@@ -5,7 +5,7 @@
  * Target: ≥ 90 % line / statement / function coverage.
  */
 import { describe, it, expect } from "vitest";
-import { decodeTransactionError, extractErrorCode } from "./errorDecoder";
+import { decodeTransactionError, extractErrorCode, KNOWN_CONTRACT_ERROR_CODES } from "./errorDecoder";
 
 // ── extractErrorCode ─────────────────────────────────────────────────────
 
@@ -159,7 +159,7 @@ describe("decodeTransactionError", () => {
         expect(result.raw).toBe(raw);
     });
 
-    it("decodes all vault error codes 1–10", () => {
+    it("decodes all vault error codes 1–11", () => {
         const knownTitles: Record<number, string> = {
             1: "Contract Not Initialized",
             2: "Already Initialized",
@@ -171,11 +171,54 @@ describe("decodeTransactionError", () => {
             8: "Timelock Active",
             9: "Invalid Oracle Price",
             10: "Slippage Exceeded",
+            11: "Storage Key Not Found",
         };
         for (const [code, title] of Object.entries(knownTitles)) {
             const result = decodeTransactionError(`Error(Contract, #${code})`);
             expect(result.title).toBe(title);
             expect(result.code).toBe(Number(code));
+        }
+    });
+
+    it("decodes vault error code 11 → Storage Key Not Found", () => {
+        const result = decodeTransactionError("Error(Contract, #11)");
+        expect(result.code).toBe(11);
+        expect(result.title).toBe("Storage Key Not Found");
+        expect(result.message).toContain("storage");
+        expect(result.suggestion).toBeTruthy();
+    });
+});
+
+// ── KNOWN_CONTRACT_ERROR_CODES drift-detection guardrail ─────────────────
+
+describe("KNOWN_CONTRACT_ERROR_CODES", () => {
+    it("contains all vault error codes documented in ERROR_CODES.md (1–11)", () => {
+        for (let code = 1; code <= 11; code++) {
+            expect(KNOWN_CONTRACT_ERROR_CODES.has(code)).toBe(true);
+        }
+    });
+
+    it("contains vesting error codes 1001–1003", () => {
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(1001)).toBe(true);
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(1002)).toBe(true);
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(1003)).toBe(true);
+    });
+
+    it("contains donation error codes 2001–2002", () => {
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(2001)).toBe(true);
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(2002)).toBe(true);
+    });
+
+    it("contains swap error codes 3001–3002", () => {
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(3001)).toBe(true);
+        expect(KNOWN_CONTRACT_ERROR_CODES.has(3002)).toBe(true);
+    });
+
+    it("every code in the set decodes to a non-fallback title", () => {
+        for (const code of KNOWN_CONTRACT_ERROR_CODES) {
+            const result = decodeTransactionError(`Error(Contract, #${code})`);
+            expect(result.title).not.toBe("Transaction Failed");
+            expect(result.code).toBe(code);
         }
     });
 });

--- a/client/src/utils/errorDecoder.ts
+++ b/client/src/utils/errorDecoder.ts
@@ -26,6 +26,22 @@ export interface DecodedError {
     code?: number;
 }
 
+/**
+ * The authoritative set of contract error codes known to the frontend.
+ * Import this in tests to guard against on-chain enum drift — if a code
+ * appears in ERROR_CODES.md but not here, tests should fail.
+ */
+export const KNOWN_CONTRACT_ERROR_CODES = new Set([
+    // YieldVault
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+    // Vesting
+    1001, 1002, 1003,
+    // Donations
+    2001, 2002,
+    // Intent Swap
+    3001, 3002,
+]);
+
 /** Maps known contract error codes to user-facing messages. */
 const CONTRACT_ERROR_MAP: Record<
     number,
@@ -81,6 +97,11 @@ const CONTRACT_ERROR_MAP: Record<
         title: "Slippage Exceeded",
         message: "The price moved too much during your swap. Your slippage tolerance was exceeded.",
         suggestion: "Increase your slippage tolerance or try again when markets are calmer.",
+    },
+    11: {
+        title: "Storage Key Not Found",
+        message: "A required storage entry is missing from the contract. The vault may not be fully initialized.",
+        suggestion: "Contact support — the contract admin may need to re-initialize or migrate storage.",
     },
     // ── Vesting ────────────────────────────────────────────────────────
     1001: {

--- a/contracts/__tests__/generateManifest.test.ts
+++ b/contracts/__tests__/generateManifest.test.ts
@@ -149,4 +149,84 @@ describe("generate-manifest.js", () => {
     const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
     expect(() => new Date(manifest.generatedAt).toISOString()).not.toThrow();
   });
+
+  // ── Alias regression tests (issue #781) ────────────────────────────────────
+  // These tests guard against accidental alias renames. If a deployment script
+  // starts emitting `yieldVault` instead of `yield_vault`, the manifest will
+  // contain the wrong key and downstream consumers silently break.
+
+  it("manifest preserves the exact alias key from deployed.json", () => {
+    const inputPath = writeDeployed(tmpDir, { yield_vault: VALID_ID_1, zap: VALID_ID_2 });
+    const outputPath = path.join(tmpDir, "manifest.json");
+
+    const result = runScript(
+      `--input "${inputPath}" --network testnet --output "${outputPath}"`,
+    );
+
+    expect(result.status).toBe(0);
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    // snake_case aliases must survive intact
+    expect(manifest.contracts["yield_vault"]).toBe(VALID_ID_1);
+    expect(manifest.contracts["zap"]).toBe(VALID_ID_2);
+  });
+
+  it("manifest does NOT contain camelCase alias when deployed.json uses snake_case", () => {
+    // Regression: deploy.sh emits `yield_vault`; a renamed alias `yieldVault` must
+    // NOT appear in the manifest — consumers would silently get undefined.
+    const inputPath = writeDeployed(tmpDir, { yield_vault: VALID_ID_1 });
+    const outputPath = path.join(tmpDir, "manifest.json");
+
+    runScript(`--input "${inputPath}" --network testnet --output "${outputPath}"`);
+
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(manifest.contracts["yieldVault"]).toBeUndefined();
+    expect(manifest.contracts["yield_vault"]).toBe(VALID_ID_1);
+  });
+
+  it("manifest built from renamed alias yieldVault is missing expected yield_vault key", () => {
+    // This documents the failure mode: if deploy.sh starts emitting camelCase,
+    // the manifest will have `yieldVault` but not `yield_vault`, breaking indexers.
+    const inputPath = writeDeployed(tmpDir, { yieldVault: VALID_ID_1 });
+    const outputPath = path.join(tmpDir, "manifest.json");
+
+    runScript(`--input "${inputPath}" --network testnet --output "${outputPath}"`);
+
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(manifest.contracts["yield_vault"]).toBeUndefined();
+    expect(manifest.contracts["yieldVault"]).toBe(VALID_ID_1);
+  });
+
+  it("manifest includes extra/unexpected aliases without failing", () => {
+    // The script does not whitelist alias names; extra keys are included verbatim.
+    // This test ensures that adding a new contract to deployed.json doesn't break generation.
+    const inputPath = writeDeployed(tmpDir, {
+      yield_vault: VALID_ID_1,
+      new_contract: VALID_ID_2,
+    });
+    const outputPath = path.join(tmpDir, "manifest.json");
+
+    const result = runScript(
+      `--input "${inputPath}" --network testnet --output "${outputPath}"`,
+    );
+
+    expect(result.status).toBe(0);
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(manifest.contracts["new_contract"]).toBe(VALID_ID_2);
+  });
+
+  it("manifest from deployed.json missing required alias omits that key", () => {
+    // When a required alias (e.g. `zap`) is simply absent from deployed.json,
+    // the manifest must not contain it. Consumers that look up `manifest.contracts.zap`
+    // will get undefined — this makes the missing deployment visible at integration time.
+    const inputPath = writeDeployed(tmpDir, { yield_vault: VALID_ID_1 });
+    const outputPath = path.join(tmpDir, "manifest.json");
+
+    const result = runScript(
+      `--input "${inputPath}" --network testnet --output "${outputPath}"`,
+    );
+
+    expect(result.status).toBe(0);
+    const manifest = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    expect(manifest.contracts["zap"]).toBeUndefined();
+  });
 });

--- a/contracts/__tests__/registryDiff.test.ts
+++ b/contracts/__tests__/registryDiff.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { diffRegistries, Registry } from '../registryDiff';
+import { diffRegistries, annotateRegistryDiff, type Registry } from '../registryDiff';
+
+// Helpers
+function emptyNet(): Record<string, string> {
+  return { vault: '', zap: '', token: '', governance: '', strategy: '', emissionController: '', liquidStaking: '', stableswap: '' };
+}
+
+function fullNet(overrides: Record<string, string> = {}): Record<string, string> {
+  return { vault: 'VA', zap: 'ZA', token: 'TA', governance: 'GA', strategy: 'SA', emissionController: 'EA', liquidStaking: 'LA', stableswap: 'SS', ...overrides };
+}
 
 describe('diffRegistries', () => {
   it('detects added, removed and changed entries', () => {
@@ -17,26 +26,141 @@ describe('diffRegistries', () => {
 
     const diff = diffRegistries(oldReg, newReg);
 
-    // Testnet: zap added, governance removed, strategy changed
     const tn = diff.testnet.changes;
-    const zapChange = tn.find(c => c.name === 'zap');
-    const govChange = tn.find(c => c.name === 'governance');
-    const stratChange = tn.find(c => c.name === 'strategy');
+    expect(tn.find(c => c.name === 'zap')?.type).toBe('added');
+    expect(tn.find(c => c.name === 'governance')?.type).toBe('removed');
+    expect(tn.find(c => c.name === 'strategy')?.type).toBe('changed');
 
-    expect(zapChange?.type).toBe('added');
-    expect(govChange?.type).toBe('removed');
-    expect(stratChange?.type).toBe('changed');
-
-    // Mainnet: vault changed, emissionController removed
     const mn = diff.mainnet.changes;
-    const vaultMain = mn.find(c => c.name === 'vault');
-    const emcMain = mn.find(c => c.name === 'emissionController');
-    expect(vaultMain?.type).toBe('changed');
-    expect(emcMain?.type).toBe('removed');
+    expect(mn.find(c => c.name === 'vault')?.type).toBe('changed');
+    expect(mn.find(c => c.name === 'emissionController')?.type).toBe('removed');
 
-    // Local: vault added
-    const ln = diff.local.changes;
-    const vaultLocal = ln.find(c => c.name === 'vault');
-    expect(vaultLocal?.type).toBe('added');
+    expect(diff.local.changes.find(c => c.name === 'vault')?.type).toBe('added');
+  });
+
+  it('reports unchanged entries when registries are identical', () => {
+    const reg: Registry = {
+      testnet: fullNet() as any,
+      mainnet: fullNet() as any,
+      local: emptyNet() as any,
+    };
+    const diff = diffRegistries(reg, reg);
+    for (const change of diff.testnet.changes) {
+      expect(change.type).toBe('unchanged');
+    }
+    expect(diff.testnet.missing).toHaveLength(0);
+  });
+
+  it('sets oldAddress to null for added entries', () => {
+    const oldReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: { ...emptyNet(), vault: 'NEW_V' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const diff = diffRegistries(oldReg, newReg);
+    const added = diff.testnet.changes.find(c => c.name === 'vault');
+    expect(added?.type).toBe('added');
+    expect(added?.oldAddress).toBeNull();
+    expect(added?.newAddress).toBe('NEW_V');
+  });
+
+  it('sets newAddress to null for removed entries', () => {
+    const oldReg: Registry = { testnet: { ...emptyNet(), vault: 'OLD_V' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const diff = diffRegistries(oldReg, newReg);
+    const removed = diff.testnet.changes.find(c => c.name === 'vault');
+    expect(removed?.type).toBe('removed');
+    expect(removed?.newAddress).toBeNull();
+    expect(removed?.oldAddress).toBe('OLD_V');
+  });
+
+  it('populates missing list for entries absent from new registry', () => {
+    const oldReg: Registry = { testnet: fullNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const diff = diffRegistries(oldReg, newReg);
+    expect(diff.testnet.missing.length).toBeGreaterThan(0);
+    expect(diff.testnet.missing).toContain('vault');
+  });
+
+  it('handles local network drift independently from testnet and mainnet', () => {
+    const oldReg: Registry = {
+      testnet: fullNet() as any,
+      mainnet: fullNet() as any,
+      local: emptyNet() as any,
+    };
+    const newReg: Registry = {
+      testnet: fullNet() as any,
+      mainnet: fullNet() as any,
+      local: { ...emptyNet(), vault: 'LOCAL_V' } as any,
+    };
+    const diff = diffRegistries(oldReg, newReg);
+    expect(diff.testnet.changes.every(c => c.type === 'unchanged')).toBe(true);
+    expect(diff.local.changes.find(c => c.name === 'vault')?.type).toBe('added');
+  });
+});
+
+describe('annotateRegistryDiff', () => {
+  it('returns one annotation per network in testnet → mainnet → local order', () => {
+    const reg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const annotations = annotateRegistryDiff(diffRegistries(reg, reg));
+    expect(annotations).toHaveLength(3);
+    expect(annotations[0]?.network).toBe('testnet');
+    expect(annotations[1]?.network).toBe('mainnet');
+    expect(annotations[2]?.network).toBe('local');
+  });
+
+  it('reports no drift when registries are identical', () => {
+    const reg: Registry = { testnet: fullNet() as any, mainnet: fullNet() as any, local: fullNet() as any };
+    const annotations = annotateRegistryDiff(diffRegistries(reg, reg));
+    for (const ann of annotations) {
+      expect(ann.hasDrift).toBe(false);
+      expect(ann.lines).toHaveLength(0);
+      expect(ann.summary).toContain('no drift');
+    }
+  });
+
+  it('sets hasDrift=true and includes [ADDED] line for a new contract ID', () => {
+    const oldReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: { ...emptyNet(), vault: 'V_NEW' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const [tn] = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    expect(tn?.hasDrift).toBe(true);
+    expect(tn?.lines.some(l => l.includes('[ADDED]') && l.includes('vault'))).toBe(true);
+    expect(tn?.summary).toContain('testnet');
+  });
+
+  it('includes [REMOVED] line when a contract is dropped', () => {
+    const oldReg: Registry = { testnet: { ...emptyNet(), zap: 'ZAP_ID' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const [tn] = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    expect(tn?.lines.some(l => l.includes('[REMOVED]') && l.includes('zap'))).toBe(true);
+  });
+
+  it('includes [CHANGED] line when an address is updated', () => {
+    const oldReg: Registry = { testnet: { ...emptyNet(), vault: 'OLD' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: { ...emptyNet(), vault: 'NEW' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const [tn] = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    expect(tn?.lines.some(l => l.includes('[CHANGED]') && l.includes('OLD') && l.includes('NEW'))).toBe(true);
+  });
+
+  it('includes [REMOVED] line (with MISSING note) when contracts drop out of new registry', () => {
+    const oldReg: Registry = { testnet: fullNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: emptyNet() as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const [tn] = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    expect(tn?.lines.some(l => l.includes('[REMOVED]') && l.includes('MISSING'))).toBe(true);
+  });
+
+  it('annotates mainnet drift independently of testnet', () => {
+    const oldReg: Registry = { testnet: fullNet() as any, mainnet: { ...emptyNet(), vault: 'MV_OLD' } as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: fullNet() as any, mainnet: { ...emptyNet(), vault: 'MV_NEW' } as any, local: emptyNet() as any };
+    const annotations = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    const tn = annotations.find(a => a.network === 'testnet')!;
+    const mn = annotations.find(a => a.network === 'mainnet')!;
+    expect(tn.hasDrift).toBe(false);
+    expect(mn.hasDrift).toBe(true);
+    expect(mn.lines.some(l => l.includes('[CHANGED]') && l.includes('vault'))).toBe(true);
+  });
+
+  it('summary includes change count when drift is present', () => {
+    const oldReg: Registry = { testnet: { ...emptyNet(), vault: 'V1', zap: 'Z1' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const newReg: Registry = { testnet: { ...emptyNet(), vault: 'V2', zap: 'Z2' } as any, mainnet: emptyNet() as any, local: emptyNet() as any };
+    const [tn] = annotateRegistryDiff(diffRegistries(oldReg, newReg));
+    expect(tn?.summary).toMatch(/\d+ change/);
   });
 });

--- a/contracts/registryDiff.ts
+++ b/contracts/registryDiff.ts
@@ -62,4 +62,54 @@ export function diffRegistries(oldReg: Registry, newReg: Registry): RegistryDiff
   return result;
 }
 
+/** Per-network human-readable annotation for CI consumers and maintainers. */
+export type NetworkAnnotation = {
+  network: NetworkName;
+  /** Summary line surfaced in CI output. */
+  summary: string;
+  /** One annotation line per non-unchanged entry. */
+  lines: string[];
+  /** True when any unexpected drift (added, removed, or changed) is present. */
+  hasDrift: boolean;
+};
+
+/**
+ * Converts a `RegistryDiff` into per-network human-readable annotations.
+ * Designed for CI consumers: each `NetworkAnnotation` carries a `hasDrift`
+ * flag so a pipeline can fail fast on unexpected contract ID changes.
+ *
+ * @param diff - Output of `diffRegistries`.
+ * @returns An array of one annotation per network, ordered testnet → mainnet → local.
+ */
+export function annotateRegistryDiff(diff: RegistryDiff): NetworkAnnotation[] {
+  const networks: NetworkName[] = ["testnet", "mainnet", "local"];
+  return networks.map((network) => {
+    const { changes } = diff[network];
+    const lines: string[] = [];
+
+    for (const change of changes) {
+      if (change.type === "unchanged") continue;
+      switch (change.type) {
+        case "added":
+          lines.push(`[ADDED]   ${change.name}: (none) → ${change.newAddress}`);
+          break;
+        case "removed":
+          // Was previously deployed but is now absent — flag as MISSING in new registry.
+          lines.push(`[REMOVED] ${change.name}: ${change.oldAddress} → (none) [MISSING in new registry]`);
+          break;
+        case "changed":
+          lines.push(`[CHANGED] ${change.name}: ${change.oldAddress} → ${change.newAddress}`);
+          break;
+      }
+    }
+
+    const hasDrift = lines.length > 0;
+    const summary = hasDrift
+      ? `${network}: ${lines.length} change(s) detected`
+      : `${network}: no drift`;
+
+    return { network, summary, lines, hasDrift };
+  });
+}
+
 export default diffRegistries;


### PR DESCRIPTION
## Summary

Closes #780 
Closes #781 
Closes #782 
Closes #783 

- **#783 — Zap asset validation hardening** (`client/src/features/zap/assets.ts`): `validateZapAssets()` now detects duplicate symbols, duplicate contractIds, negative decimals, non-integer decimals, and malformed `iconUrl` values. `loadZapAssetOptions()` falls back to env vars when `VITE_ZAP_ASSETS_JSON` fails validation. `isZapAssetOption()` also enforces integer + non-negative decimals.
- **#781 — Manifest alias regression tests** (`contracts/__tests__/generateManifest.test.ts`): 5 new tests guard against alias renames (`yield_vault` vs `yieldVault`), extra/unexpected aliases, and missing required aliases being silently absent from the manifest output.
- **#782 — Registry diff annotations** (`contracts/registryDiff.ts`): New `annotateRegistryDiff()` function converts a `RegistryDiff` into per-network `NetworkAnnotation` objects with `hasDrift` flag, `[ADDED]`/`[REMOVED]`/`[CHANGED]` annotation lines, and a CI-readable summary. 8 new tests in `registryDiff.test.ts`.
- **#780 — Error map synchronization** (`client/src/utils/errorDecoder.ts`): Added missing VaultError code 11 (`StorageKeyNotFound`) to `CONTRACT_ERROR_MAP`. Exported `KNOWN_CONTRACT_ERROR_CODES` set as a drift-detection guardrail. 6 new tests verify all codes decode to non-fallback titles.

## Test plan

- [ ] `cd contracts && npx vitest run` — all 31 tests pass
- [ ] `cd client && npx vitest run src/utils/errorDecoder.test.ts src/features/zap/assets.test.ts` — all 69 tests pass
- [ ] No regressions in pre-existing test suites