### PR TITLE
test: protocol compatibility matrix, execution quality scoring, off-ramp quote expiry, wallet session persistence (#815 #816 #819 #825)

### DIFF
--- a/client/src/auth/sessionPersistence.test.ts
+++ b/client/src/auth/sessionPersistence.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for wallet session persistence, clear, crash recovery, and
+ * cross-tab StorageEvent handling.
+ *
+ * session.ts exposes:
+ *   loadStoredSession()  — read from localStorage, return null on miss/corrupt
+ *   clearStoredSession() — remove the key
+ *
+ * Cross-tab sync is the caller's responsibility; these tests verify that the
+ * raw primitives produce the right state so higher-level hooks can rely on
+ * them when responding to StorageEvents.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { loadStoredSession, clearStoredSession } from "./session";
+import type { WalletSession } from "./types";
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = "stellar-yield.wallet-session";
+
+function makeSession(overrides: Partial<WalletSession> = {}): WalletSession {
+  return {
+    walletAddress: "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    walletAddressType: "account",
+    providerId: "freighter",
+    providerLabel: "Freighter",
+    verificationStatus: "verified",
+    connectedAt: new Date().toISOString(),
+    lastActivityAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+// ── loadStoredSession ─────────────────────────────────────────────────────────
+
+describe("loadStoredSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns null when localStorage has no session", () => {
+    expect(loadStoredSession()).toBeNull();
+  });
+
+  it("returns the stored session when valid JSON is present", () => {
+    const session = makeSession();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+
+    const loaded = loadStoredSession();
+    expect(loaded).not.toBeNull();
+    expect(loaded!.walletAddress).toBe(session.walletAddress);
+    expect(loaded!.providerId).toBe("freighter");
+    expect(loaded!.verificationStatus).toBe("verified");
+  });
+
+  it("preserves all optional fields (sessionKeyAddress, loginHint)", () => {
+    const session = makeSession({
+      providerId: "email",
+      providerLabel: "Email Smart Wallet",
+      walletAddressType: "contract",
+      sessionKeyAddress: "GBSESSION_KEY_ADDRESS",
+      sessionSecret: "SECRET",
+      loginHint: "user@example.com",
+      verificationStatus: "degraded",
+    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+
+    const loaded = loadStoredSession();
+    expect(loaded!.sessionKeyAddress).toBe("GBSESSION_KEY_ADDRESS");
+    expect(loaded!.loginHint).toBe("user@example.com");
+    expect(loaded!.verificationStatus).toBe("degraded");
+  });
+
+  it("returns null and removes the corrupt entry when JSON is invalid", () => {
+    localStorage.setItem(STORAGE_KEY, "{{not-valid-json}}");
+
+    const loaded = loadStoredSession();
+    expect(loaded).toBeNull();
+    // Should auto-remove the corrupt entry
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("is idempotent — calling it twice returns the same data", () => {
+    const session = makeSession();
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+
+    const first = loadStoredSession();
+    const second = loadStoredSession();
+    expect(first!.walletAddress).toBe(second!.walletAddress);
+  });
+});
+
+// ── clearStoredSession ────────────────────────────────────────────────────────
+
+describe("clearStoredSession", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("removes the session from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeSession()));
+    clearStoredSession();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("is a no-op when no session is stored", () => {
+    expect(() => clearStoredSession()).not.toThrow();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("causes loadStoredSession to return null after clearing", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeSession()));
+    clearStoredSession();
+    expect(loadStoredSession()).toBeNull();
+  });
+});
+
+// ── crash recovery (corrupt / truncated data) ─────────────────────────────────
+
+describe("loadStoredSession — crash recovery", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("handles an empty string stored for the key", () => {
+    localStorage.setItem(STORAGE_KEY, "");
+    // "" is falsy — should return null without throwing
+    const loaded = loadStoredSession();
+    expect(loaded).toBeNull();
+  });
+
+  it("handles 'null' literal stored as a string", () => {
+    localStorage.setItem(STORAGE_KEY, "null");
+    // JSON.parse("null") === null — treat as no session
+    const loaded = loadStoredSession();
+    expect(loaded).toBeNull();
+  });
+
+  it("handles a number stored as a string (wrong type)", () => {
+    localStorage.setItem(STORAGE_KEY, "42");
+    // JSON.parse returns 42 (number), cast to WalletSession — should still not throw
+    // The function returns it as-is (it's a simple cast); test that it does not throw
+    expect(() => loadStoredSession()).not.toThrow();
+  });
+
+  it("does not throw when localStorage.getItem itself throws", () => {
+    const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
+    vi.spyOn(window.localStorage, "getItem").mockImplementationOnce(() => {
+      throw new Error("localStorage unavailable");
+    });
+
+    // loadStoredSession is not designed to catch getItem errors (that's the
+    // platform contract), but we verify it propagates cleanly rather than
+    // silently corrupting state
+    expect(() => loadStoredSession()).toThrow("localStorage unavailable");
+
+    vi.restoreAllMocks();
+  });
+});
+
+// ── cross-tab StorageEvent recovery ──────────────────────────────────────────
+
+describe("cross-tab StorageEvent", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("loadStoredSession reflects a session written by another tab", () => {
+    // Simulate another tab writing a session directly to localStorage
+    // (StorageEvent fires in the *other* tabs, not the writing tab)
+    const session = makeSession({ walletAddress: "GCROSS_TAB_ADDRESS" });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+
+    // Our tab calls loadStoredSession in its StorageEvent handler
+    const loaded = loadStoredSession();
+    expect(loaded!.walletAddress).toBe("GCROSS_TAB_ADDRESS");
+  });
+
+  it("loadStoredSession returns null after another tab clears the session", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeSession()));
+
+    // Another tab calls clearStoredSession
+    localStorage.removeItem(STORAGE_KEY);
+
+    // Our tab re-reads in its StorageEvent handler
+    expect(loadStoredSession()).toBeNull();
+  });
+
+  it("StorageEvent carries the new session value in event.newValue", () => {
+    const session = makeSession({ walletAddress: "GEVENT_ADDR" });
+    const eventNewValue = JSON.stringify(session);
+
+    const event = new StorageEvent("storage", {
+      key: STORAGE_KEY,
+      newValue: eventNewValue,
+      oldValue: null,
+      storageArea: window.localStorage,
+    });
+
+    // The handler pattern: parse event.newValue, then optionally call loadStoredSession()
+    const parsed: WalletSession | null = event.newValue
+      ? (JSON.parse(event.newValue) as WalletSession)
+      : null;
+
+    expect(parsed).not.toBeNull();
+    expect(parsed!.walletAddress).toBe("GEVENT_ADDR");
+  });
+
+  it("StorageEvent newValue is null when the session is cleared by another tab", () => {
+    const event = new StorageEvent("storage", {
+      key: STORAGE_KEY,
+      newValue: null,
+      oldValue: JSON.stringify(makeSession()),
+      storageArea: window.localStorage,
+    });
+
+    const parsed: WalletSession | null = event.newValue
+      ? (JSON.parse(event.newValue) as WalletSession)
+      : null;
+
+    expect(parsed).toBeNull();
+  });
+
+  it("StorageEvent for a different key should not affect session state", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(makeSession()));
+
+    const event = new StorageEvent("storage", {
+      key: "some-other-key",
+      newValue: "irrelevant",
+      storageArea: window.localStorage,
+    });
+
+    // Handler should check event.key before acting
+    const isSessionKey = event.key === STORAGE_KEY;
+    expect(isSessionKey).toBe(false);
+
+    // Session untouched
+    expect(loadStoredSession()).not.toBeNull();
+  });
+});

--- a/client/src/features/analytics/protocolCompatibility.test.ts
+++ b/client/src/features/analytics/protocolCompatibility.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import {
+  checkProtocolCompatibility,
+  isFullySupported,
+  isIncompatible,
+  summariseMatrix,
+} from "./protocolCompatibility";
+
+// ── checkProtocolCompatibility — supported combinations ──────────────────────
+
+describe("checkProtocolCompatibility — supported combinations", () => {
+  it("classifies soroban::rpc as supported", () => {
+    const result = checkProtocolCompatibility("soroban", "rpc");
+    expect(result.tier).toBe("supported");
+    expect(result.message).toBeTruthy();
+  });
+
+  it("classifies horizon::rest-api as supported", () => {
+    const result = checkProtocolCompatibility("horizon", "rest-api");
+    expect(result.tier).toBe("supported");
+  });
+
+  it("classifies horizon::websocket as supported", () => {
+    expect(checkProtocolCompatibility("horizon", "websocket").tier).toBe("supported");
+  });
+
+  it("classifies stellar-anchor::rest-api as supported", () => {
+    expect(checkProtocolCompatibility("stellar-anchor", "rest-api").tier).toBe("supported");
+  });
+
+  it("classifies aqua::rest-api as supported", () => {
+    expect(checkProtocolCompatibility("aqua", "rest-api").tier).toBe("supported");
+  });
+
+  it("classifies aqua::graphql as supported", () => {
+    expect(checkProtocolCompatibility("aqua", "graphql").tier).toBe("supported");
+  });
+
+  it("classifies phoenix::rest-api as supported", () => {
+    expect(checkProtocolCompatibility("phoenix", "rest-api").tier).toBe("supported");
+  });
+
+  it("classifies blend::rpc as supported", () => {
+    expect(checkProtocolCompatibility("blend", "rpc").tier).toBe("supported");
+  });
+});
+
+// ── checkProtocolCompatibility — partial combinations ───────────────────────
+
+describe("checkProtocolCompatibility — partial (degraded) combinations", () => {
+  it("classifies soroban::rest-api as partial with a polling caveat", () => {
+    const result = checkProtocolCompatibility("soroban", "rest-api");
+    expect(result.tier).toBe("partial");
+    expect(result.message.toLowerCase()).toMatch(/poll/);
+  });
+
+  it("classifies soroban::graphql as partial", () => {
+    expect(checkProtocolCompatibility("soroban", "graphql").tier).toBe("partial");
+  });
+
+  it("classifies horizon::graphql as partial", () => {
+    expect(checkProtocolCompatibility("horizon", "graphql").tier).toBe("partial");
+  });
+
+  it("classifies stellar-anchor::websocket as partial", () => {
+    const result = checkProtocolCompatibility("stellar-anchor", "websocket");
+    expect(result.tier).toBe("partial");
+    expect(result.message).toBeTruthy();
+  });
+
+  it("classifies aqua::websocket as partial (rate-limited)", () => {
+    const result = checkProtocolCompatibility("aqua", "websocket");
+    expect(result.tier).toBe("partial");
+    expect(result.message.toLowerCase()).toMatch(/rate/);
+  });
+
+  it("classifies phoenix::graphql as partial (beta)", () => {
+    const result = checkProtocolCompatibility("phoenix", "graphql");
+    expect(result.tier).toBe("partial");
+    expect(result.message.toLowerCase()).toMatch(/beta/);
+  });
+
+  it("classifies blend::rest-api as partial", () => {
+    expect(checkProtocolCompatibility("blend", "rest-api").tier).toBe("partial");
+  });
+
+  it("classifies blend::graphql as partial", () => {
+    expect(checkProtocolCompatibility("blend", "graphql").tier).toBe("partial");
+  });
+});
+
+// ── checkProtocolCompatibility — incompatible combinations ──────────────────
+
+describe("checkProtocolCompatibility — incompatible combinations", () => {
+  it("classifies soroban::websocket as incompatible", () => {
+    const result = checkProtocolCompatibility("soroban", "websocket");
+    expect(result.tier).toBe("incompatible");
+    expect(result.message).toBeTruthy();
+  });
+
+  it("classifies soroban::ipfs as incompatible", () => {
+    expect(checkProtocolCompatibility("soroban", "ipfs").tier).toBe("incompatible");
+  });
+
+  it("classifies horizon::rpc as incompatible", () => {
+    expect(checkProtocolCompatibility("horizon", "rpc").tier).toBe("incompatible");
+  });
+
+  it("classifies horizon::ipfs as incompatible", () => {
+    expect(checkProtocolCompatibility("horizon", "ipfs").tier).toBe("incompatible");
+  });
+
+  it("classifies stellar-anchor::graphql as incompatible", () => {
+    expect(checkProtocolCompatibility("stellar-anchor", "graphql").tier).toBe("incompatible");
+  });
+
+  it("classifies stellar-anchor::rpc as incompatible", () => {
+    expect(checkProtocolCompatibility("stellar-anchor", "rpc").tier).toBe("incompatible");
+  });
+
+  it("classifies aqua::rpc as incompatible", () => {
+    expect(checkProtocolCompatibility("aqua", "rpc").tier).toBe("incompatible");
+  });
+
+  it("classifies phoenix::rpc as incompatible", () => {
+    expect(checkProtocolCompatibility("phoenix", "rpc").tier).toBe("incompatible");
+  });
+
+  it("classifies blend::websocket as incompatible", () => {
+    expect(checkProtocolCompatibility("blend", "websocket").tier).toBe("incompatible");
+  });
+
+  it("classifies blend::ipfs as incompatible", () => {
+    expect(checkProtocolCompatibility("blend", "ipfs").tier).toBe("incompatible");
+  });
+
+  it("carries a non-empty degradation message for every incompatible entry", () => {
+    const incompatiblePairs = [
+      ["soroban", "websocket"],
+      ["horizon", "rpc"],
+      ["stellar-anchor", "graphql"],
+      ["aqua", "ipfs"],
+      ["phoenix", "ipfs"],
+      ["blend", "websocket"],
+    ] as const;
+    for (const [p, d] of incompatiblePairs) {
+      const result = checkProtocolCompatibility(p, d);
+      expect(result.message.length, `${p}::${d} has empty message`).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── checkProtocolCompatibility — unknown combinations ───────────────────────
+
+describe("checkProtocolCompatibility — unknown / future combinations", () => {
+  it("returns 'unknown' for a protocol not in the matrix", () => {
+    const result = checkProtocolCompatibility("future-protocol", "rest-api");
+    expect(result.tier).toBe("unknown");
+  });
+
+  it("returns 'unknown' for a dataSource not in the matrix", () => {
+    const result = checkProtocolCompatibility("soroban", "grpc");
+    expect(result.tier).toBe("unknown");
+  });
+
+  it("returns a non-empty message even for unknown pairs", () => {
+    const result = checkProtocolCompatibility("unknown-proto", "unknown-ds");
+    expect(result.message.length).toBeGreaterThan(0);
+  });
+
+  it("is deterministic — same pair always yields the same result", () => {
+    const r1 = checkProtocolCompatibility("soroban", "rpc");
+    const r2 = checkProtocolCompatibility("soroban", "rpc");
+    expect(r1.tier).toBe(r2.tier);
+    expect(r1.message).toBe(r2.message);
+  });
+});
+
+// ── isFullySupported ─────────────────────────────────────────────────────────
+
+describe("isFullySupported", () => {
+  it("returns true for fully supported pairs", () => {
+    expect(isFullySupported("soroban", "rpc")).toBe(true);
+    expect(isFullySupported("horizon", "rest-api")).toBe(true);
+    expect(isFullySupported("aqua", "graphql")).toBe(true);
+  });
+
+  it("returns false for partial pairs", () => {
+    expect(isFullySupported("soroban", "rest-api")).toBe(false);
+    expect(isFullySupported("blend", "graphql")).toBe(false);
+  });
+
+  it("returns false for incompatible pairs", () => {
+    expect(isFullySupported("soroban", "websocket")).toBe(false);
+    expect(isFullySupported("horizon", "ipfs")).toBe(false);
+  });
+
+  it("returns false for unknown pairs", () => {
+    expect(isFullySupported("nonexistent", "rest-api")).toBe(false);
+  });
+});
+
+// ── isIncompatible ───────────────────────────────────────────────────────────
+
+describe("isIncompatible", () => {
+  it("returns true for incompatible pairs", () => {
+    expect(isIncompatible("soroban", "websocket")).toBe(true);
+    expect(isIncompatible("horizon", "rpc")).toBe(true);
+    expect(isIncompatible("blend", "ipfs")).toBe(true);
+  });
+
+  it("returns false for supported pairs", () => {
+    expect(isIncompatible("soroban", "rpc")).toBe(false);
+    expect(isIncompatible("horizon", "rest-api")).toBe(false);
+  });
+
+  it("returns false for partial pairs", () => {
+    expect(isIncompatible("soroban", "graphql")).toBe(false);
+  });
+
+  it("returns false for unknown pairs", () => {
+    expect(isIncompatible("future-proto", "websocket")).toBe(false);
+  });
+});
+
+// ── summariseMatrix ──────────────────────────────────────────────────────────
+
+describe("summariseMatrix", () => {
+  it("counts tiers correctly across a mixed batch", () => {
+    const pairs = [
+      { protocol: "soroban",  dataSource: "rpc"      }, // supported
+      { protocol: "soroban",  dataSource: "rest-api" }, // partial
+      { protocol: "soroban",  dataSource: "websocket"}, // incompatible
+      { protocol: "unknown",  dataSource: "rest-api" }, // unknown
+    ];
+    const summary = summariseMatrix(pairs);
+    expect(summary.total).toBe(4);
+    expect(summary.supported).toBe(1);
+    expect(summary.partial).toBe(1);
+    expect(summary.incompatible).toBe(1);
+    expect(summary.unknown).toBe(1);
+  });
+
+  it("collects degradation messages for all non-supported entries", () => {
+    const pairs = [
+      { protocol: "soroban", dataSource: "rest-api"  }, // partial — should have message
+      { protocol: "soroban", dataSource: "websocket" }, // incompatible — should have message
+      { protocol: "soroban", dataSource: "rpc"       }, // supported — no message
+    ];
+    const summary = summariseMatrix(pairs);
+    expect(summary.degradationMessages).toHaveLength(2);
+    summary.degradationMessages.forEach((msg) => {
+      expect(msg.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("returns all-zero counts for an empty batch", () => {
+    const summary = summariseMatrix([]);
+    expect(summary.total).toBe(0);
+    expect(summary.supported).toBe(0);
+    expect(summary.degradationMessages).toHaveLength(0);
+  });
+
+  it("returns all supported with no degradation messages for a fully healthy batch", () => {
+    const pairs = [
+      { protocol: "soroban",  dataSource: "rpc"      },
+      { protocol: "horizon",  dataSource: "rest-api" },
+      { protocol: "aqua",     dataSource: "graphql"  },
+    ];
+    const summary = summariseMatrix(pairs);
+    expect(summary.supported).toBe(3);
+    expect(summary.degradationMessages).toHaveLength(0);
+  });
+
+  it("handles an all-incompatible batch correctly", () => {
+    const pairs = [
+      { protocol: "soroban", dataSource: "websocket" },
+      { protocol: "horizon", dataSource: "rpc"       },
+      { protocol: "blend",   dataSource: "ipfs"      },
+    ];
+    const summary = summariseMatrix(pairs);
+    expect(summary.incompatible).toBe(3);
+    expect(summary.supported).toBe(0);
+    expect(summary.degradationMessages).toHaveLength(3);
+  });
+});

--- a/client/src/features/analytics/protocolCompatibility.ts
+++ b/client/src/features/analytics/protocolCompatibility.ts
@@ -1,0 +1,147 @@
+/**
+ * Protocol compatibility matrix for the Source Health panel.
+ *
+ * Each yield data source reports health via a (protocol, dataSource) pair.
+ * This module classifies that pair into one of four compatibility tiers and
+ * surfaces a human-readable degradation reason when the combination is not
+ * fully supported.
+ */
+
+export type ProtocolId =
+  | "soroban"
+  | "horizon"
+  | "stellar-anchor"
+  | "aqua"
+  | "phoenix"
+  | "blend";
+
+export type DataSourceId =
+  | "rest-api"
+  | "graphql"
+  | "websocket"
+  | "rpc"
+  | "ipfs";
+
+export type CompatibilityTier =
+  | "supported"      // protocol + dataSource work together without caveats
+  | "partial"        // works but with known limitations (e.g. no streaming)
+  | "incompatible"   // combination is explicitly not supported
+  | "unknown";       // no matrix entry — treat as unverified
+
+export interface CompatibilityResult {
+  tier: CompatibilityTier;
+  /** Human-readable message explaining any degradation or limitation. */
+  message: string;
+}
+
+/**
+ * Sparse compatibility matrix.
+ * Key format: `${protocolId}::${dataSourceId}`
+ * Absence means "unknown".
+ */
+const MATRIX: Record<string, CompatibilityResult> = {
+  // Soroban (smart contracts via RPC)
+  "soroban::rpc":        { tier: "supported",     message: "Soroban RPC is the canonical data source." },
+  "soroban::rest-api":   { tier: "partial",        message: "REST API does not expose Soroban event streams; polling only." },
+  "soroban::graphql":    { tier: "partial",        message: "GraphQL layer proxies RPC — adds latency overhead." },
+  "soroban::websocket":  { tier: "incompatible",   message: "Soroban does not support WebSocket subscriptions." },
+  "soroban::ipfs":       { tier: "incompatible",   message: "IPFS cannot serve live Soroban state." },
+
+  // Horizon (classic Stellar API)
+  "horizon::rest-api":   { tier: "supported",     message: "Horizon REST is the primary interface." },
+  "horizon::websocket":  { tier: "supported",     message: "Horizon SSE streams are fully supported." },
+  "horizon::rpc":        { tier: "incompatible",   message: "Horizon does not expose an RPC interface." },
+  "horizon::graphql":    { tier: "partial",        message: "Third-party GraphQL wrappers only — not officially supported." },
+  "horizon::ipfs":       { tier: "incompatible",   message: "IPFS cannot serve live Horizon ledger data." },
+
+  // Stellar Anchor (SEP-6/24/31)
+  "stellar-anchor::rest-api":  { tier: "supported",   message: "SEP-compliant REST is the standard interface." },
+  "stellar-anchor::graphql":   { tier: "incompatible", message: "Anchor protocol does not define a GraphQL schema." },
+  "stellar-anchor::websocket": { tier: "partial",      message: "Some anchors offer webhooks, but WebSocket is non-standard." },
+  "stellar-anchor::rpc":       { tier: "incompatible", message: "Anchors do not expose RPC endpoints." },
+  "stellar-anchor::ipfs":      { tier: "incompatible", message: "IPFS cannot serve Anchor SEP data." },
+
+  // Aqua / AMM pools
+  "aqua::rest-api":    { tier: "supported",     message: "Aqua pool data is served via REST." },
+  "aqua::graphql":     { tier: "supported",     message: "Aqua subgraph supports full GraphQL queries." },
+  "aqua::websocket":   { tier: "partial",       message: "WebSocket price feeds are rate-limited on free tier." },
+  "aqua::rpc":         { tier: "incompatible",  message: "Aqua has no RPC interface." },
+  "aqua::ipfs":        { tier: "incompatible",  message: "IPFS cannot serve live AMM pricing." },
+
+  // Phoenix DEX
+  "phoenix::rest-api":   { tier: "supported",   message: "Phoenix REST API provides full market data." },
+  "phoenix::graphql":    { tier: "partial",      message: "Phoenix GraphQL is in beta — schema may change." },
+  "phoenix::websocket":  { tier: "partial",      message: "WebSocket streaming is available but experimental." },
+  "phoenix::rpc":        { tier: "incompatible", message: "Phoenix does not expose an RPC interface." },
+  "phoenix::ipfs":       { tier: "incompatible", message: "IPFS cannot serve live Phoenix DEX data." },
+
+  // Blend (lending protocol)
+  "blend::rpc":        { tier: "supported",     message: "Blend exposes state via Soroban RPC." },
+  "blend::rest-api":   { tier: "partial",       message: "REST API is read-only and does not cover all Blend events." },
+  "blend::graphql":    { tier: "partial",       message: "Community-maintained subgraph; may lag behind chain." },
+  "blend::websocket":  { tier: "incompatible",  message: "Blend does not support WebSocket subscriptions." },
+  "blend::ipfs":       { tier: "incompatible",  message: "IPFS cannot serve live Blend lending state." },
+};
+
+const UNKNOWN_RESULT: CompatibilityResult = {
+  tier: "unknown",
+  message: "No compatibility data for this protocol/data-source combination.",
+};
+
+/**
+ * Look up the compatibility tier and degradation message for a
+ * (protocol, dataSource) pair.
+ */
+export function checkProtocolCompatibility(
+  protocol: ProtocolId | string,
+  dataSource: DataSourceId | string,
+): CompatibilityResult {
+  const key = `${protocol}::${dataSource}`;
+  return MATRIX[key] ?? UNKNOWN_RESULT;
+}
+
+/** True when the combination is known to work without caveats. */
+export function isFullySupported(protocol: string, dataSource: string): boolean {
+  return checkProtocolCompatibility(protocol, dataSource).tier === "supported";
+}
+
+/** True when the combination is explicitly not supported. */
+export function isIncompatible(protocol: string, dataSource: string): boolean {
+  return checkProtocolCompatibility(protocol, dataSource).tier === "incompatible";
+}
+
+/**
+ * Summarise a batch of (protocol, dataSource) pairs.
+ * Returns counts by tier and the first degradation message per non-supported entry.
+ */
+export interface MatrixSummary {
+  total: number;
+  supported: number;
+  partial: number;
+  incompatible: number;
+  unknown: number;
+  degradationMessages: string[];
+}
+
+export function summariseMatrix(
+  pairs: Array<{ protocol: string; dataSource: string }>,
+): MatrixSummary {
+  const summary: MatrixSummary = {
+    total: pairs.length,
+    supported: 0,
+    partial: 0,
+    incompatible: 0,
+    unknown: 0,
+    degradationMessages: [],
+  };
+
+  for (const { protocol, dataSource } of pairs) {
+    const result = checkProtocolCompatibility(protocol, dataSource);
+    summary[result.tier]++;
+    if (result.tier !== "supported") {
+      summary.degradationMessages.push(result.message);
+    }
+  }
+
+  return summary;
+}

--- a/client/src/features/fragmentation/__tests__/executionQualityScoring.test.ts
+++ b/client/src/features/fragmentation/__tests__/executionQualityScoring.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyExecutionQuality,
+  classifyFragmentationScore,
+  formatQualityScore,
+  QUALITY_THRESHOLDS,
+  QUALITY_SCALE,
+  FRAGMENTATION_THRESHOLDS,
+} from "../executionQualityUtils";
+
+// ── classifyExecutionQuality — interior values ───────────────────────────────
+
+describe("classifyExecutionQuality — interior values", () => {
+  it("classifies a clearly good score", () => {
+    const result = classifyExecutionQuality(85);
+    expect(result.label).toBe("Good");
+    expect(result.tier).toBe("good");
+    expect(result.materialImpact).toBe(false);
+  });
+
+  it("classifies a clearly fair score", () => {
+    const result = classifyExecutionQuality(60);
+    expect(result.label).toBe("Fair");
+    expect(result.tier).toBe("fair");
+    expect(result.materialImpact).toBe(true);
+  });
+
+  it("classifies a clearly poor score", () => {
+    const result = classifyExecutionQuality(30);
+    expect(result.label).toBe("Poor");
+    expect(result.tier).toBe("poor");
+    expect(result.materialImpact).toBe(true);
+  });
+});
+
+// ── classifyExecutionQuality — Good/Fair boundary (70) ───────────────────────
+
+describe("classifyExecutionQuality — Good/Fair boundary at 70", () => {
+  it("70.0 is Good (on the threshold — inclusive lower bound)", () => {
+    const result = classifyExecutionQuality(QUALITY_THRESHOLDS.GOOD);
+    expect(result.label).toBe("Good");
+    expect(result.materialImpact).toBe(false);
+  });
+
+  it("69.9 is Fair (just below Good threshold)", () => {
+    const result = classifyExecutionQuality(69.9);
+    expect(result.label).toBe("Fair");
+    expect(result.materialImpact).toBe(true);
+  });
+
+  it("70.1 is Good (just above threshold)", () => {
+    const result = classifyExecutionQuality(70.1);
+    expect(result.label).toBe("Good");
+    expect(result.materialImpact).toBe(false);
+  });
+
+  it("material impact flips exactly at 70", () => {
+    expect(classifyExecutionQuality(70).materialImpact).toBe(false);
+    expect(classifyExecutionQuality(69.999).materialImpact).toBe(true);
+  });
+});
+
+// ── classifyExecutionQuality — Fair/Poor boundary (50) ──────────────────────
+
+describe("classifyExecutionQuality — Fair/Poor boundary at 50", () => {
+  it("50.0 is Fair (on the threshold — inclusive lower bound)", () => {
+    const result = classifyExecutionQuality(QUALITY_THRESHOLDS.FAIR);
+    expect(result.label).toBe("Fair");
+    expect(result.tier).toBe("fair");
+  });
+
+  it("49.9 is Poor (just below Fair threshold)", () => {
+    const result = classifyExecutionQuality(49.9);
+    expect(result.label).toBe("Poor");
+    expect(result.tier).toBe("poor");
+  });
+
+  it("50.1 is Fair (just above Fair threshold)", () => {
+    const result = classifyExecutionQuality(50.1);
+    expect(result.label).toBe("Fair");
+  });
+
+  it("both Fair and Poor carry materialImpact=true", () => {
+    expect(classifyExecutionQuality(50).materialImpact).toBe(true);
+    expect(classifyExecutionQuality(49).materialImpact).toBe(true);
+  });
+});
+
+// ── classifyExecutionQuality — scale extremes ────────────────────────────────
+
+describe("classifyExecutionQuality — scale extremes", () => {
+  it("100 (maximum) is Good with no material impact", () => {
+    const result = classifyExecutionQuality(QUALITY_SCALE.MAX);
+    expect(result.label).toBe("Good");
+    expect(result.materialImpact).toBe(false);
+  });
+
+  it("0 (minimum) is Poor", () => {
+    const result = classifyExecutionQuality(QUALITY_SCALE.MIN);
+    expect(result.label).toBe("Poor");
+    expect(result.materialImpact).toBe(true);
+  });
+
+  it("values above 100 clamp to 100 (Good)", () => {
+    expect(classifyExecutionQuality(150).label).toBe("Good");
+  });
+
+  it("negative values clamp to 0 (Poor)", () => {
+    expect(classifyExecutionQuality(-10).label).toBe("Poor");
+  });
+});
+
+// ── classifyExecutionQuality — rounding stability ────────────────────────────
+
+describe("classifyExecutionQuality — rounding and near-threshold stability", () => {
+  it("69.999… stays Fair — does not round up to Good", () => {
+    // JavaScript float precision: 69.99999999 < 70
+    expect(classifyExecutionQuality(69.99999999).label).toBe("Fair");
+  });
+
+  it("50.000…1 stays Fair — does not round down to Poor", () => {
+    expect(classifyExecutionQuality(50.00000001).label).toBe("Fair");
+  });
+
+  it("identical scores always yield the same label", () => {
+    for (const score of [70, 50, 0, 100, 69.9, 49.9]) {
+      const r1 = classifyExecutionQuality(score);
+      const r2 = classifyExecutionQuality(score);
+      expect(r1.label).toBe(r2.label);
+    }
+  });
+});
+
+// ── formatQualityScore ───────────────────────────────────────────────────────
+
+describe("formatQualityScore", () => {
+  it("renders integers with one decimal place", () => {
+    expect(formatQualityScore(75)).toBe("75.0");
+    expect(formatQualityScore(0)).toBe("0.0");
+    expect(formatQualityScore(100)).toBe("100.0");
+  });
+
+  it("renders decimals to exactly one place", () => {
+    expect(formatQualityScore(69.9)).toBe("69.9");
+    expect(formatQualityScore(50.123)).toBe("50.1");
+  });
+});
+
+// ── classifyFragmentationScore ───────────────────────────────────────────────
+
+describe("classifyFragmentationScore — interior values", () => {
+  it("classifies a low fragmentation score", () => {
+    expect(classifyFragmentationScore(10)).toBe("Low");
+  });
+
+  it("classifies a medium fragmentation score", () => {
+    expect(classifyFragmentationScore(50)).toBe("Medium");
+  });
+
+  it("classifies a high fragmentation score", () => {
+    expect(classifyFragmentationScore(80)).toBe("High");
+  });
+});
+
+describe("classifyFragmentationScore — Low/Medium boundary at 33", () => {
+  it("33 is Low (on threshold — inclusive)", () => {
+    expect(classifyFragmentationScore(FRAGMENTATION_THRESHOLDS.LOW_MAX)).toBe("Low");
+  });
+
+  it("33.1 is Medium", () => {
+    expect(classifyFragmentationScore(33.1)).toBe("Medium");
+  });
+
+  it("32.9 is Low", () => {
+    expect(classifyFragmentationScore(32.9)).toBe("Low");
+  });
+});
+
+describe("classifyFragmentationScore — Medium/High boundary at 66", () => {
+  it("66 is Medium (on threshold — inclusive)", () => {
+    expect(classifyFragmentationScore(FRAGMENTATION_THRESHOLDS.MEDIUM_MAX)).toBe("Medium");
+  });
+
+  it("66.1 is High", () => {
+    expect(classifyFragmentationScore(66.1)).toBe("High");
+  });
+
+  it("65.9 is Medium", () => {
+    expect(classifyFragmentationScore(65.9)).toBe("Medium");
+  });
+});
+
+describe("classifyFragmentationScore — extremes", () => {
+  it("0 is Low", () => {
+    expect(classifyFragmentationScore(0)).toBe("Low");
+  });
+
+  it("100 is High", () => {
+    expect(classifyFragmentationScore(100)).toBe("High");
+  });
+});

--- a/client/src/features/fragmentation/executionQualityUtils.ts
+++ b/client/src/features/fragmentation/executionQualityUtils.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure scoring helpers for execution quality classification.
+ *
+ * Extracted from ExecutionQualityCard so thresholds and labels can be
+ * unit-tested independently of React rendering.
+ *
+ * Thresholds (from spec §4.2):
+ *   score >= 70  →  "Good"      (green)
+ *   score >= 50  →  "Fair"      (yellow)
+ *   score <  50  →  "Poor"      (red)
+ *
+ * Material impact (§4.3):
+ *   executionQualityScore < 70  →  materialImpact = true
+ */
+
+export type ExecutionQualityLabel = "Good" | "Fair" | "Poor";
+
+export type ExecutionQualityTier = "good" | "fair" | "poor";
+
+export interface ExecutionQualityClassification {
+  label:  ExecutionQualityLabel;
+  tier:   ExecutionQualityTier;
+  /** Whether this score triggers the material-impact warning. */
+  materialImpact: boolean;
+}
+
+/** Boundaries that define tier transitions. */
+export const QUALITY_THRESHOLDS = {
+  GOOD: 70,
+  FAIR: 50,
+} as const;
+
+/** Score range for the 0-100 execution quality scale. */
+export const QUALITY_SCALE = { MIN: 0, MAX: 100 } as const;
+
+/**
+ * Classify a raw execution quality score (0–100) into a label, tier, and
+ * material-impact flag.
+ *
+ * Scores outside [0, 100] are clamped before classification so callers
+ * don't need to guard against out-of-range values from the API.
+ */
+export function classifyExecutionQuality(
+  rawScore: number,
+): ExecutionQualityClassification {
+  const score = Math.max(QUALITY_SCALE.MIN, Math.min(QUALITY_SCALE.MAX, rawScore));
+
+  if (score >= QUALITY_THRESHOLDS.GOOD) {
+    return { label: "Good", tier: "good", materialImpact: false };
+  }
+  if (score >= QUALITY_THRESHOLDS.FAIR) {
+    return { label: "Fair", tier: "fair", materialImpact: true };
+  }
+  return { label: "Poor", tier: "poor", materialImpact: true };
+}
+
+/**
+ * Round a raw score to one decimal place, matching the display precision
+ * used by ExecutionQualityCard.
+ */
+export function formatQualityScore(score: number): string {
+  return score.toFixed(1);
+}
+
+/**
+ * Given a fragmentation score (0–100 HHI-derived scale), derive the
+ * FragmentationCategory label used in FragmentationMetrics.
+ *
+ * Thresholds (from README §3):
+ *   score <= 33  →  "Low"
+ *   score <= 66  →  "Medium"
+ *   score >  66  →  "High"
+ */
+export type FragmentationCategoryLabel = "Low" | "Medium" | "High";
+
+export const FRAGMENTATION_THRESHOLDS = {
+  LOW_MAX:    33,
+  MEDIUM_MAX: 66,
+} as const;
+
+export function classifyFragmentationScore(
+  score: number,
+): FragmentationCategoryLabel {
+  if (score <= FRAGMENTATION_THRESHOLDS.LOW_MAX)    return "Low";
+  if (score <= FRAGMENTATION_THRESHOLDS.MEDIUM_MAX) return "Medium";
+  return "High";
+}

--- a/client/src/features/offramp/__tests__/offRampQuoteExpiry.test.ts
+++ b/client/src/features/offramp/__tests__/offRampQuoteExpiry.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { OffRampService, isQuoteExpired, QUOTE_TTL_MS } from "../offRampService";
+import type { OffRampTransaction, WithdrawalRequest } from "../types";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_REQUEST: WithdrawalRequest = {
+  vaultContractId: "vault-001",
+  shares: 1000n,
+  usdcAmount: 5000n,
+  bankAccount: "123456789",
+  bankName: "Test Bank",
+  accountHolder: "Alice",
+};
+
+function makeTx(overrides: Partial<OffRampTransaction> = {}): OffRampTransaction {
+  const now = Date.now();
+  return {
+    id: "tx-1",
+    status: "pending",
+    amount: "5000",
+    currency: "USDC",
+    bankAccount: "123456789",
+    memo: "SY:Alice:000001",
+    createdAt: now,
+    quoteExpiresAt: now + QUOTE_TTL_MS,
+    ...overrides,
+  };
+}
+
+// ── isQuoteExpired — pure helper ──────────────────────────────────────────────
+
+describe("isQuoteExpired", () => {
+  it("returns false when quoteExpiresAt is in the future", () => {
+    const tx = makeTx({ quoteExpiresAt: Date.now() + 60_000 });
+    expect(isQuoteExpired(tx)).toBe(false);
+  });
+
+  it("returns true when quoteExpiresAt is in the past", () => {
+    const tx = makeTx({ quoteExpiresAt: Date.now() - 1 });
+    expect(isQuoteExpired(tx)).toBe(true);
+  });
+
+  it("returns true exactly at the expiry boundary (nowMs === quoteExpiresAt)", () => {
+    const expiresAt = 1_700_000_000_000;
+    const tx = makeTx({ quoteExpiresAt: expiresAt });
+    // nowMs equal to quoteExpiresAt: nowMs > quoteExpiresAt is false, so boundary is NOT expired
+    expect(isQuoteExpired(tx, expiresAt)).toBe(false);
+  });
+
+  it("returns true one millisecond after the boundary", () => {
+    const expiresAt = 1_700_000_000_000;
+    const tx = makeTx({ quoteExpiresAt: expiresAt });
+    expect(isQuoteExpired(tx, expiresAt + 1)).toBe(true);
+  });
+
+  it("returns false for a transaction with no quoteExpiresAt (non-expiring)", () => {
+    const tx = makeTx({ quoteExpiresAt: undefined });
+    expect(isQuoteExpired(tx)).toBe(false);
+  });
+
+  it("accepts an explicit nowMs override for time-controlled tests", () => {
+    const expiresAt = 1_000;
+    const tx = makeTx({ quoteExpiresAt: expiresAt });
+    expect(isQuoteExpired(tx, 999)).toBe(false);
+    expect(isQuoteExpired(tx, 1_001)).toBe(true);
+  });
+});
+
+// ── QUOTE_TTL_MS constant ─────────────────────────────────────────────────────
+
+describe("QUOTE_TTL_MS", () => {
+  it("is exactly 5 minutes in milliseconds", () => {
+    expect(QUOTE_TTL_MS).toBe(300_000);
+  });
+});
+
+// ── OffRampService — quote expiry stamping on initiateWithdrawal ──────────────
+
+describe("OffRampService — quoteExpiresAt stamping", () => {
+  let service: OffRampService;
+
+  beforeEach(() => {
+    service = new OffRampService("moonpay");
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stamps quoteExpiresAt = createdAt + QUOTE_TTL_MS on a successful withdrawal", async () => {
+    const fakeNow = 1_700_000_000_000;
+    vi.setSystemTime(fakeNow);
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ id: "tx-ok", status: "pending" }),
+    });
+
+    const tx = await service.initiateWithdrawal(VALID_REQUEST);
+    expect(tx.quoteExpiresAt).toBe(fakeNow + QUOTE_TTL_MS);
+    expect(tx.createdAt).toBe(fakeNow);
+  });
+
+  it("persists quoteExpiresAt to localStorage", async () => {
+    const fakeNow = 1_700_000_001_000;
+    vi.setSystemTime(fakeNow);
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "pending" }),
+    });
+
+    const tx = await service.initiateWithdrawal(VALID_REQUEST);
+    const stored = service.getAllTransactions().find((t) => t.id === tx.id);
+    expect(stored?.quoteExpiresAt).toBe(fakeNow + QUOTE_TTL_MS);
+  });
+
+  it("stamps quoteExpiresAt even when the submission fails", async () => {
+    const fakeNow = 1_700_000_002_000;
+    vi.setSystemTime(fakeNow);
+
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    try {
+      await service.initiateWithdrawal(VALID_REQUEST);
+    } catch {
+      // expected
+    }
+
+    const [stored] = service.getAllTransactions();
+    expect(stored.quoteExpiresAt).toBe(fakeNow + QUOTE_TTL_MS);
+    expect(stored.status).toBe("failed");
+  });
+});
+
+// ── Resume-state persistence across page reloads ──────────────────────────────
+
+describe("OffRampService — resume-state persistence", () => {
+  let service: OffRampService;
+
+  beforeEach(() => {
+    service = new OffRampService("moonpay");
+    localStorage.clear();
+    global.fetch = vi.fn();
+  });
+
+  it("getAllTransactions returns an empty array when localStorage is empty", () => {
+    expect(service.getAllTransactions()).toEqual([]);
+  });
+
+  it("persists a completed transaction across a new service instance", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "pending" }),
+    });
+
+    const tx = await service.initiateWithdrawal(VALID_REQUEST);
+
+    // Poll to completion
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "completed" }),
+    });
+    await service.pollStatus(tx.id);
+
+    // Simulate page reload — fresh service instance reads same localStorage
+    const freshService = new OffRampService("moonpay");
+    const [loaded] = freshService.getAllTransactions();
+    expect(loaded.status).toBe("completed");
+    expect(loaded.completedAt).toBeDefined();
+  });
+
+  it("does not poll a transaction that is already completed", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "pending" }),
+    });
+
+    const tx = await service.initiateWithdrawal(VALID_REQUEST);
+
+    // Drive it to completed
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: "completed" }),
+    });
+    await service.pollStatus(tx.id);
+
+    const callsBefore = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    // Second poll on a completed tx — should short-circuit
+    await service.pollStatus(tx.id);
+    expect((global.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(callsBefore);
+  });
+
+  it("retains all transactions after multiple writes", async () => {
+    for (let i = 0; i < 3; i++) {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ status: "pending" }),
+      });
+      await service.initiateWithdrawal({
+        ...VALID_REQUEST,
+        bankAccount: `${100_000_000 + i}`,
+      });
+    }
+
+    expect(service.getAllTransactions()).toHaveLength(3);
+  });
+
+  it("gracefully returns empty array when localStorage contains invalid JSON", () => {
+    localStorage.setItem("stellar_yield_offramp_txns", "not-json{{{");
+    const freshService = new OffRampService("moonpay");
+    expect(freshService.getAllTransactions()).toEqual([]);
+  });
+});

--- a/client/src/features/offramp/offRampService.ts
+++ b/client/src/features/offramp/offRampService.ts
@@ -28,6 +28,18 @@ function httpErrorType(status: number): OffRampErrorType {
     return "NETWORK_ERROR";
 }
 
+/** Default quote validity window: 5 minutes. */
+export const QUOTE_TTL_MS = 5 * 60 * 1_000;
+
+/**
+ * Returns true when the transaction's provider quote has expired.
+ * A transaction without a quoteExpiresAt is treated as non-expiring.
+ */
+export function isQuoteExpired(tx: import("./types").OffRampTransaction, nowMs = Date.now()): boolean {
+    if (tx.quoteExpiresAt === undefined) return false;
+    return nowMs > tx.quoteExpiresAt;
+}
+
 const STORAGE_KEY = "stellar_yield_offramp_txns";
 
 const OFFRAMP_PROXY = "/api/offramp";
@@ -46,6 +58,7 @@ export class OffRampService {
     async initiateWithdrawal(request: WithdrawalRequest): Promise<OffRampTransaction> {
         const txId = `offramp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
 
+        const now = Date.now();
         const transaction: OffRampTransaction = {
             id: txId,
             status: "pending",
@@ -53,7 +66,8 @@ export class OffRampService {
             currency: "USDC",
             bankAccount: request.bankAccount,
             memo: this.generateMemo(request),
-            createdAt: Date.now(),
+            createdAt: now,
+            quoteExpiresAt: now + QUOTE_TTL_MS,
             request, // Store request for potential retries
         };
 

--- a/client/src/features/offramp/types.ts
+++ b/client/src/features/offramp/types.ts
@@ -32,6 +32,8 @@ export interface OffRampTransaction {
     memo: string;
     createdAt: number;
     completedAt?: number;
+    /** Unix ms timestamp after which the provider quote is no longer valid. */
+    quoteExpiresAt?: number;
     errorMessage?: string;
     isRetryable?: boolean;
     request?: WithdrawalRequest;


### PR DESCRIPTION
## Summary

- **#815** – `protocolCompatibility.ts`: full 6×5 protocol × data-source matrix (soroban, horizon, stellar-anchor, aqua, phoenix, blend × rest-api, graphql, websocket, rpc, ipfs) with `supported`/`partial`/`incompatible`/`unknown` tiers + `checkProtocolCompatibility`, `isFullySupported`, `isIncompatible`, `summariseMatrix`. 40+ tests covering every tier, unknown pairs, and batch summarisation.

- **#816** – `executionQualityUtils.ts`: pure scoring helpers — `classifyExecutionQuality` (Good ≥70 / Fair ≥50 / Poor <50, `materialImpact=true` when <70), `classifyFragmentationScore` (Low ≤33 / Medium ≤66 / High), `formatQualityScore`. Boundary test suite hits both thresholds (70/50, 33/66), clamping behaviour, rounding stability, and determinism.

- **#819** – Adds `quoteExpiresAt` field to `OffRampTransaction` (stamped as `createdAt + QUOTE_TTL_MS` on every `initiateWithdrawal`). Exports `isQuoteExpired(tx, nowMs?)` and `QUOTE_TTL_MS = 300_000`. Tests cover expiry boundary (inclusive/exclusive), no-quoteExpiresAt passthrough, localStorage persistence of the stamp, and resume-state across simulated page reloads.

- **#825** – `sessionPersistence.test.ts`: tests `loadStoredSession` / `clearStoredSession` from `session.ts`, crash-recovery paths (corrupt JSON, `null` literal, empty string), and cross-tab `StorageEvent` patterns (session written by another tab, session cleared by another tab, key-filtering).

## Test plan

- [ ] `pnpm vitest run client/src/features/analytics/protocolCompatibility.test.ts`
- [ ] `pnpm vitest run client/src/features/fragmentation/__tests__/executionQualityScoring.test.ts`
- [ ] `pnpm vitest run client/src/features/offramp/__tests__/offRampQuoteExpiry.test.ts`
- [ ] `pnpm vitest run client/src/auth/sessionPersistence.test.ts`

Closes #815, closes #816, closes #819, closes #825

🤖 Generated with [Claude Code](https://claude.ai/claude-code)