### PR TITLE
fix: align relayer fee-bump route for issue 32

### DIFF
--- a/client/src/services/soroban.ts
+++ b/client/src/services/soroban.ts
@@ -286,7 +286,7 @@ export async function executeContractCallOn(
     let finalXdr = signedXdr;
     if (useFeeBump) {
       onPhase?.("submitting");
-      const resp = await fetch("/api/relayer/fee-bump", {
+      const resp = await apiFetch("/api/relayer/fee-bump", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ innerTxXdr: signedXdr }),

--- a/server/src/__tests__/deploymentSmoke.test.ts
+++ b/server/src/__tests__/deploymentSmoke.test.ts
@@ -158,6 +158,7 @@ describe("Backend runtime wiring — client-facing routes must not 404", () => {
     ["get", "/api/analytics/providers/uptime"],
     ["get", "/api/analytics/sources/health"],
     ["get", "/api/vaults/test-vault/share-price-history"],
+    ["post", "/relay/sign-fee-bump"],
     ["post", "/api/auth/challenge"],
     ["post", "/api/stress-scenarios/run"],
   ];

--- a/server/src/__tests__/routeAudit.test.ts
+++ b/server/src/__tests__/routeAudit.test.ts
@@ -34,6 +34,9 @@ describe("Route audit — mounted routes match client API calls (#723)", () => {
   it("GET /api/relayer/status is mounted", () =>
     probeRouteExists("get", "/api/relayer/status"));
 
+  it("POST /relay/sign-fee-bump is mounted", () =>
+    probeRouteExists("post", "/relay/sign-fee-bump"));
+
   it("POST /api/risk/drift/detect is mounted", () =>
     probeRouteExists("post", "/api/risk/drift/detect"));
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -115,6 +115,7 @@ export function createApp() {
   });
 
   app.post("/api/relayer/fee-bump", relayerLimiter, signFeeBump);
+  app.post("/relay/sign-fee-bump", relayerLimiter, signFeeBump);
   app.use("/api/yields", yieldsRouter);
   app.use("/api/leaderboard", leaderboardRouter);
   app.use("/api/notifications", notificationsRouter);

--- a/server/src/services/rebalanceExecutorService.ts
+++ b/server/src/services/rebalanceExecutorService.ts
@@ -271,7 +271,7 @@ export class RebalanceExecutorService {
   }
 
   private async signWithRelayer(innerXdr: string): Promise<string> {
-    const response = await fetch(`${this.config.relayerUrl}/relay/sign-fee-bump`, {
+    const response = await fetch(`${this.config.relayerUrl}/api/relayer/fee-bump`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ innerTxXdr: innerXdr }),


### PR DESCRIPTION
## Summary

Fix the gasless onboarding flow for issue #32 by aligning the fee-bump relayer route across the backend and callers.

## What changed

- Added a backward-compatible backend alias for the legacy fee-bump endpoint:
  - `/relay/sign-fee-bump`
  - `/api/relayer/fee-bump`
- Updated the rebalance executor to call the canonical relayer route.
- Kept the frontend fee-bump calls on the canonical relayer route.
- Added route coverage to prevent regressions.

## Why

The relayer handler existed, but one server-side caller still used the legacy `/relay/sign-fee-bump` path while the backend mounted `/api/relayer/fee-bump`. That mismatch could break fee-bumped transactions for onboarding and rebalance flows.

## Verification

- Added regression coverage for both:
  - `server/src/__tests__/routeAudit.test.ts`
  - `server/src/__tests__/deploymentSmoke.test.ts`
- Confirmed the code paths now use the same canonical fee-bump endpoint.

## Notes

- The legacy alias is kept temporarily for compatibility.
- This preserves existing behavior while reducing the chance of another route mismatch.warnings

Closes #32 
