### PR TITLE
feat: event-sourced strategy lifecycle audit (recommendation → execution → snapshot)

### DIFF
--- a/server/src/__tests__/strategyLifecycleAudit.test.ts
+++ b/server/src/__tests__/strategyLifecycleAudit.test.ts
@@ -1,5 +1,13 @@
 /**
- * Tests for the event-sourced strategy lifecycle audit service (#720).
+ * Unit tests for StrategyLifecycleAuditService (#34).
+ *
+ * Covers:
+ *  - Static helpers (generateEventId, correlationId, hashPayload)
+ *  - Complete execution path
+ *  - Blocked-by-oracle path
+ *  - Fallback-route path
+ *  - Failed execution path
+ *  - Replayed history query (correlationId scoped)
  */
 
 import { StrategyLifecycleAuditService } from "../services/strategyLifecycleAuditService";
@@ -7,90 +15,212 @@ import type {
   StrategyRecommendedEvent,
   StrategyQueuedEvent,
   StrategyRiskCheckedEvent,
+  OracleDecisionRecordedEvent,
+  FallbackRouteSelectedEvent,
   StrategyExecutedEvent,
+  StrategyExecutionFailedEvent,
   StrategyBlockedEvent,
   StrategySnapshottedEvent,
 } from "../types/strategyLifecycleEvents";
 
-let service: StrategyLifecycleAuditService;
+// ── Fixtures ──────────────────────────────────────────────────────────────────
 
 const strategyId = "strat-001";
-const now = new Date("2024-05-01T10:00:00Z");
+const correlationId = "corr-test-abc123";
+const actor = "optimizer-v2";
+const now = new Date("2025-01-15T10:00:00Z");
 
-const recommended: StrategyRecommendedEvent = {
-  strategyId,
-  timestamp: new Date(now.getTime()),
-  type: "StrategyRecommended",
-  recommendedBy: "optimizer-v2",
-  rationale: "High APY opportunity detected",
-  expectedApyBps: 645,
-};
+function makeRecommended(overrides: Partial<StrategyRecommendedEvent> = {}): StrategyRecommendedEvent {
+  return {
+    id: `evt-${Date.now()}-${Math.random().toString(16).slice(2, 6)}`,
+    strategyId,
+    correlationId,
+    actor,
+    timestamp: new Date(now),
+    type: "StrategyRecommended",
+    recommendedBy: "optimizer-v2",
+    rationale: "High APY detected in Blend protocol",
+    expectedApyBps: 645,
+    sourceDataHash: StrategyLifecycleAuditService.hashPayload({ apyBps: 645 }),
+    ...overrides,
+  };
+}
+
+const recommended = makeRecommended();
 
 const queued: StrategyQueuedEvent = {
+  id: "evt-q1",
   strategyId,
-  timestamp: new Date(now.getTime() + 1000),
+  correlationId,
+  actor: "queue-service",
+  timestamp: new Date(now.getTime() + 1_000),
   type: "StrategyQueued",
+  queueEntryId: "qe-001",
   queuePosition: 1,
   priority: "high",
 };
 
 const riskChecked: StrategyRiskCheckedEvent = {
+  id: "evt-r1",
   strategyId,
-  timestamp: new Date(now.getTime() + 2000),
+  correlationId,
+  actor: "risk-engine-v1",
+  timestamp: new Date(now.getTime() + 2_000),
   type: "StrategyRiskChecked",
   riskScore: 42,
   passed: true,
   checkedBy: "risk-engine-v1",
 };
 
-const executed: StrategyExecutedEvent = {
+const oracleAllow: OracleDecisionRecordedEvent = {
+  id: "evt-o1",
   strategyId,
-  timestamp: new Date(now.getTime() + 3000),
+  correlationId,
+  actor: "oracle-sentinel",
+  timestamp: new Date(now.getTime() + 3_000),
+  type: "OracleDecisionRecorded",
+  assetId: "XLM",
+  oracleDecision: "ALLOW",
+  oracleState: "FRESH",
+  deviationPct: 0.8,
+  ageMs: 5_000,
+  reasons: [],
+};
+
+const oracleBlock: OracleDecisionRecordedEvent = {
+  ...oracleAllow,
+  id: "evt-o2",
+  oracleDecision: "BLOCK",
+  oracleState: "DEVIATED",
+  deviationPct: 7.2,
+  reasons: ["Price deviation 7.20% exceeds max 5%."],
+};
+
+const fallback: FallbackRouteSelectedEvent = {
+  id: "evt-f1",
+  strategyId,
+  correlationId,
+  actor: "failover-registry",
+  timestamp: new Date(now.getTime() + 4_000),
+  type: "FallbackRouteSelected",
+  originalProtocol: "Blend",
+  fallbackProtocol: "Soroswap",
+  fallbackReason: "Blend is down",
+};
+
+const executed: StrategyExecutedEvent = {
+  id: "evt-e1",
+  strategyId,
+  correlationId,
+  actor: "executor-agent",
+  timestamp: new Date(now.getTime() + 4_000),
   type: "StrategyExecuted",
   executedBy: "executor-agent",
   executionDurationMs: 120,
   resultApyBps: 640,
+  transactionHash: "abc123def456",
+  filledPercentage: 100,
+};
+
+const executionFailed: StrategyExecutionFailedEvent = {
+  id: "evt-ef1",
+  strategyId,
+  correlationId,
+  actor: "executor-agent",
+  timestamp: new Date(now.getTime() + 4_000),
+  type: "StrategyExecutionFailed",
+  failureClass: "TRANSIENT",
+  reason: "Network timeout during submission",
+  attemptNumber: 1,
+  willRetry: true,
 };
 
 const blocked: StrategyBlockedEvent = {
+  id: "evt-b1",
   strategyId,
-  timestamp: new Date(now.getTime() + 3000),
+  correlationId,
+  actor: "risk-engine-v1",
+  timestamp: new Date(now.getTime() + 4_000),
   type: "StrategyBlocked",
-  reason: "Exceeded risk threshold",
-  blockedBy: "risk-engine-v1",
+  reason: "Oracle price deviation exceeded threshold",
+  blockedBy: "oracle-sentinel",
 };
 
-beforeEach(() => {
-  service = new StrategyLifecycleAuditService();
-});
+const snapshotted: StrategySnapshottedEvent = {
+  id: "evt-s1",
+  strategyId,
+  correlationId,
+  actor: "snapshot-service",
+  timestamp: new Date(now.getTime() + 5_000),
+  type: "StrategySnapshotted",
+  snapshotId: "snap-001",
+  snapshotVersion: 3,
+  snapshotHash: "sha256-hash-value",
+  changeReason: "Post-execution snapshot",
+};
 
-// ------------------------------------------------------------------
-// recordEvent + getHistory
-// ------------------------------------------------------------------
+let service: StrategyLifecycleAuditService;
+beforeEach(() => { service = new StrategyLifecycleAuditService(); });
 
-describe("recordEvent + getHistory", () => {
-  it("returns empty array for an unknown strategy", () => {
-    expect(service.getHistory("unknown-strat")).toEqual([]);
+// ── Static helpers ────────────────────────────────────────────────────────────
+
+describe("static helpers", () => {
+  it("generateEventId has 'evt-' prefix", () => {
+    expect(StrategyLifecycleAuditService.generateEventId()).toMatch(/^evt-/);
   });
 
-  it("records a single event and returns it in history", () => {
-    service.recordEvent(recommended);
-    const history = service.getHistory(strategyId);
+  it("generateCorrelationId has 'corr-' prefix", () => {
+    expect(StrategyLifecycleAuditService.generateCorrelationId()).toMatch(/^corr-/);
+  });
 
-    expect(history).toHaveLength(1);
-    expect(history[0].type).toBe("StrategyRecommended");
+  it("hashPayload returns 64-char hex", () => {
+    expect(StrategyLifecycleAuditService.hashPayload({ x: 1 })).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("hashPayload is deterministic", () => {
+    const p = { apyBps: 600 };
+    expect(StrategyLifecycleAuditService.hashPayload(p)).toBe(
+      StrategyLifecycleAuditService.hashPayload(p),
+    );
+  });
+
+  it("hashPayload differs for different inputs", () => {
+    expect(StrategyLifecycleAuditService.hashPayload({ a: 1 })).not.toBe(
+      StrategyLifecycleAuditService.hashPayload({ a: 2 }),
+    );
+  });
+});
+
+// ── recordEvent + getHistory ──────────────────────────────────────────────────
+
+describe("recordEvent + getHistory", () => {
+  it("returns [] for unknown strategy", () => {
+    expect(service.getHistory("unknown")).toEqual([]);
+  });
+
+  it("records a single event", () => {
+    service.recordEvent(recommended);
+    expect(service.getHistory(strategyId)).toHaveLength(1);
+  });
+
+  it("preserves correlationId", () => {
+    service.recordEvent(recommended);
+    expect(service.getHistory(strategyId)[0].correlationId).toBe(correlationId);
+  });
+
+  it("preserves actor", () => {
+    service.recordEvent(recommended);
+    expect(service.getHistory(strategyId)[0].actor).toBe(actor);
+  });
+
+  it("preserves sourceDataHash", () => {
+    service.recordEvent(recommended);
+    expect(service.getHistory(strategyId)[0].sourceDataHash).toMatch(/^[0-9a-f]{64}$/);
   });
 
   it("records multiple events in insertion order", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(queued);
-    service.recordEvent(riskChecked);
-    service.recordEvent(executed);
-
-    const history = service.getHistory(strategyId);
-
-    expect(history).toHaveLength(4);
-    expect(history.map((e) => e.type)).toEqual([
+    [recommended, queued, riskChecked, executed].forEach((e) => service.recordEvent(e));
+    expect(service.getHistory(strategyId).map((e) => e.type)).toEqual([
       "StrategyRecommended",
       "StrategyQueued",
       "StrategyRiskChecked",
@@ -98,156 +228,233 @@ describe("recordEvent + getHistory", () => {
     ]);
   });
 
-  it("isolates events per strategy", () => {
-    service.recordEvent({ ...recommended, strategyId: "strat-A" });
-    service.recordEvent({ ...recommended, strategyId: "strat-B" });
-
-    expect(service.getHistory("strat-A")).toHaveLength(1);
-    expect(service.getHistory("strat-B")).toHaveLength(1);
+  it("isolates events by strategyId", () => {
+    service.recordEvent({ ...recommended, strategyId: "A" });
+    service.recordEvent({ ...recommended, strategyId: "B" });
+    expect(service.getHistory("A")).toHaveLength(1);
+    expect(service.getHistory("B")).toHaveLength(1);
   });
 
-  it("getHistory returns a copy — mutations do not affect the log", () => {
+  it("getHistory returns a copy — mutations don't affect the log", () => {
     service.recordEvent(recommended);
-    const history = service.getHistory(strategyId);
-    history.pop();
-
+    service.getHistory(strategyId).pop();
     expect(service.getHistory(strategyId)).toHaveLength(1);
   });
 });
 
-// ------------------------------------------------------------------
-// reconstructPath
-// ------------------------------------------------------------------
+// ── Complete execution path ───────────────────────────────────────────────────
 
-describe("reconstructPath", () => {
-  it("returns empty array for unknown strategy", () => {
-    expect(service.reconstructPath("ghost")).toEqual([]);
+describe("complete execution path", () => {
+  beforeEach(() => {
+    [recommended, queued, riskChecked, oracleAllow, executed, snapshotted].forEach(
+      (e) => service.recordEvent(e),
+    );
   });
 
-  it("matches the recorded insertion order — successful path", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(queued);
-    service.recordEvent(riskChecked);
-    service.recordEvent(executed);
-
+  it("reconstructPath matches insertion order", () => {
     expect(service.reconstructPath(strategyId)).toEqual([
       "StrategyRecommended",
       "StrategyQueued",
       "StrategyRiskChecked",
+      "OracleDecisionRecorded",
       "StrategyExecuted",
-    ]);
-  });
-
-  it("matches the recorded insertion order — blocked path", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(riskChecked);
-    service.recordEvent(blocked);
-
-    expect(service.reconstructPath(strategyId)).toEqual([
-      "StrategyRecommended",
-      "StrategyRiskChecked",
-      "StrategyBlocked",
-    ]);
-  });
-
-  it("includes StrategySnapshotted when recorded", () => {
-    const snapshotted: StrategySnapshottedEvent = {
-      strategyId,
-      timestamp: new Date(now.getTime() + 500),
-      type: "StrategySnapshotted",
-      snapshotId: "snap-001",
-      snapshotHash: "abc123",
-    };
-
-    service.recordEvent(recommended);
-    service.recordEvent(snapshotted);
-    service.recordEvent(executed);
-
-    expect(service.reconstructPath(strategyId)).toEqual([
-      "StrategyRecommended",
       "StrategySnapshotted",
+    ]);
+  });
+
+  it("isTraceable returns true", () => {
+    expect(service.isTraceable(strategyId)).toBe(true);
+  });
+
+  it("snapshot event carries version and changeReason", () => {
+    const snap = service.getHistory(strategyId).find(
+      (e) => e.type === "StrategySnapshotted",
+    ) as StrategySnapshottedEvent;
+    expect(snap.snapshotVersion).toBe(3);
+    expect(snap.changeReason).toBe("Post-execution snapshot");
+  });
+
+  it("executed event carries transactionHash and filledPercentage", () => {
+    const exec = service.getHistory(strategyId).find(
+      (e) => e.type === "StrategyExecuted",
+    ) as StrategyExecutedEvent;
+    expect(exec.transactionHash).toBe("abc123def456");
+    expect(exec.filledPercentage).toBe(100);
+  });
+});
+
+// ── Blocked oracle path ───────────────────────────────────────────────────────
+
+describe("blocked oracle path", () => {
+  beforeEach(() => {
+    [recommended, queued, riskChecked, oracleBlock, blocked].forEach(
+      (e) => service.recordEvent(e),
+    );
+  });
+
+  it("reconstructPath includes OracleDecisionRecorded and StrategyBlocked", () => {
+    expect(service.reconstructPath(strategyId)).toContain("OracleDecisionRecorded");
+    expect(service.reconstructPath(strategyId)).toContain("StrategyBlocked");
+  });
+
+  it("isTraceable returns true (blocked is terminal)", () => {
+    expect(service.isTraceable(strategyId)).toBe(true);
+  });
+
+  it("oracle block event carries deviationPct and reasons", () => {
+    const ev = service.getHistory(strategyId).find(
+      (e) => e.type === "OracleDecisionRecorded",
+    ) as OracleDecisionRecordedEvent;
+    expect(ev.oracleDecision).toBe("BLOCK");
+    expect(ev.deviationPct).toBe(7.2);
+    expect(ev.reasons).toContain("Price deviation 7.20% exceeds max 5%.");
+  });
+});
+
+// ── Fallback route path ───────────────────────────────────────────────────────
+
+describe("fallback route path", () => {
+  beforeEach(() => {
+    [recommended, queued, riskChecked, oracleBlock, fallback, executed].forEach(
+      (e) => service.recordEvent(e),
+    );
+  });
+
+  it("path contains FallbackRouteSelected and StrategyExecuted", () => {
+    const path = service.reconstructPath(strategyId);
+    expect(path).toContain("FallbackRouteSelected");
+    expect(path).toContain("StrategyExecuted");
+  });
+
+  it("isTraceable returns true", () => {
+    expect(service.isTraceable(strategyId)).toBe(true);
+  });
+
+  it("fallback event carries original and fallback protocol", () => {
+    const ev = service.getHistory(strategyId).find(
+      (e) => e.type === "FallbackRouteSelected",
+    ) as FallbackRouteSelectedEvent;
+    expect(ev.originalProtocol).toBe("Blend");
+    expect(ev.fallbackProtocol).toBe("Soroswap");
+    expect(ev.fallbackReason).toBe("Blend is down");
+  });
+});
+
+// ── Failed execution path ─────────────────────────────────────────────────────
+
+describe("failed execution path", () => {
+  it("StrategyExecutionFailed alone does not make chain traceable", () => {
+    [recommended, queued, riskChecked, oracleAllow, executionFailed].forEach(
+      (e) => service.recordEvent(e),
+    );
+    expect(service.isTraceable(strategyId)).toBe(false);
+  });
+
+  it("becomes traceable once StrategyBlocked follows failed attempts", () => {
+    service.recordEvent(recommended);
+    service.recordEvent(executionFailed);
+    service.recordEvent({ ...executionFailed, id: "evt-ef2", attemptNumber: 2, willRetry: false });
+    service.recordEvent(blocked);
+    expect(service.isTraceable(strategyId)).toBe(true);
+  });
+
+  it("execution failure event carries failureClass, willRetry, attemptNumber", () => {
+    service.recordEvent(executionFailed);
+    const ev = service.getHistory(strategyId)[0] as StrategyExecutionFailedEvent;
+    expect(ev.failureClass).toBe("TRANSIENT");
+    expect(ev.willRetry).toBe(true);
+    expect(ev.attemptNumber).toBe(1);
+  });
+});
+
+// ── Replayed history query via correlationId ──────────────────────────────────
+
+describe("replayed history query via correlationId", () => {
+  const corrA = "corr-chain-A";
+  const corrB = "corr-chain-B";
+  const stratA = "strat-alpha";
+  const stratB = "strat-beta";
+
+  beforeEach(() => {
+    service.recordEvent({ ...recommended, strategyId: stratA, correlationId: corrA });
+    service.recordEvent({ ...executed, strategyId: stratA, correlationId: corrA });
+    service.recordEvent({ ...recommended, strategyId: stratB, correlationId: corrB });
+    service.recordEvent({ ...blocked, strategyId: stratB, correlationId: corrB });
+  });
+
+  it("getByCorrelationId returns only matching events", () => {
+    const events = service.getByCorrelationId(corrA);
+    expect(events.every((e) => e.correlationId === corrA)).toBe(true);
+    expect(events).toHaveLength(2);
+  });
+
+  it("getByCorrelationId returns events in timestamp order", () => {
+    service.recordEvent({
+      ...riskChecked,
+      strategyId: stratA,
+      correlationId: corrA,
+      timestamp: new Date(now.getTime() + 500),
+    });
+    const events = service.getByCorrelationId(corrA);
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].timestamp.getTime()).toBeGreaterThanOrEqual(
+        events[i - 1].timestamp.getTime(),
+      );
+    }
+  });
+
+  it("getByCorrelationId returns [] for unknown correlationId", () => {
+    expect(service.getByCorrelationId("does-not-exist")).toEqual([]);
+  });
+
+  it("getCorrelationSummary returns correct strategyId", () => {
+    expect(service.getCorrelationSummary(corrA).strategyId).toBe(stratA);
+  });
+
+  it("getCorrelationSummary marks complete chain", () => {
+    expect(service.getCorrelationSummary(corrA).isComplete).toBe(true);
+    expect(service.getCorrelationSummary(corrB).isComplete).toBe(true);
+  });
+
+  it("getCorrelationSummary marks incomplete chain (no terminal event)", () => {
+    const corrC = "corr-chain-C";
+    service.recordEvent({ ...recommended, strategyId: "strat-gamma", correlationId: corrC });
+    expect(service.getCorrelationSummary(corrC).isComplete).toBe(false);
+  });
+
+  it("getCorrelationSummary path matches recorded event types in order", () => {
+    expect(service.getCorrelationSummary(corrA).path).toEqual([
+      "StrategyRecommended",
       "StrategyExecuted",
     ]);
   });
-});
 
-// ------------------------------------------------------------------
-// isTraceable
-// ------------------------------------------------------------------
-
-describe("isTraceable", () => {
-  it("returns false for an unknown strategy", () => {
-    expect(service.isTraceable("ghost")).toBe(false);
-  });
-
-  it("returns false when only StrategyRecommended is recorded (no terminal event)", () => {
-    service.recordEvent(recommended);
-
-    expect(service.isTraceable(strategyId)).toBe(false);
-  });
-
-  it("returns false when StrategyExecuted exists but no StrategyRecommended", () => {
-    service.recordEvent(executed);
-
-    expect(service.isTraceable(strategyId)).toBe(false);
-  });
-
-  it("returns true for a complete successful path (recommended → ... → executed)", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(queued);
-    service.recordEvent(riskChecked);
-    service.recordEvent(executed);
-
-    expect(service.isTraceable(strategyId)).toBe(true);
-  });
-
-  it("returns true for a complete blocked path (recommended → risk-checked → blocked)", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(riskChecked);
-    service.recordEvent(blocked);
-
-    expect(service.isTraceable(strategyId)).toBe(true);
-  });
-
-  it("returns true when both Executed and Blocked are present (edge case — re-run scenario)", () => {
-    service.recordEvent(recommended);
-    service.recordEvent(blocked);
-    service.recordEvent(recommended);
-    service.recordEvent(executed);
-
-    expect(service.isTraceable(strategyId)).toBe(true);
+  it("corrA events do not bleed into corrB summary", () => {
+    const summaryB = service.getCorrelationSummary(corrB);
+    expect(summaryB.events.every((e) => e.correlationId === corrB)).toBe(true);
   });
 });
 
-// ------------------------------------------------------------------
-// listTrackedStrategies
-// ------------------------------------------------------------------
+// ── listTrackedStrategies + reset ─────────────────────────────────────────────
 
 describe("listTrackedStrategies", () => {
-  it("returns empty list when no events recorded", () => {
+  it("returns [] when empty", () => {
     expect(service.listTrackedStrategies()).toHaveLength(0);
   });
 
   it("returns all tracked strategy IDs", () => {
-    service.recordEvent({ ...recommended, strategyId: "strat-X" });
-    service.recordEvent({ ...recommended, strategyId: "strat-Y" });
-
+    service.recordEvent({ ...recommended, strategyId: "X" });
+    service.recordEvent({ ...recommended, strategyId: "Y" });
     const ids = service.listTrackedStrategies();
-    expect(ids).toHaveLength(2);
-    expect(ids).toContain("strat-X");
-    expect(ids).toContain("strat-Y");
+    expect(ids).toContain("X");
+    expect(ids).toContain("Y");
   });
 });
 
-// ------------------------------------------------------------------
-// reset
-// ------------------------------------------------------------------
-
 describe("reset", () => {
-  it("clears all recorded events", () => {
+  it("clears all events and tracked strategies", () => {
     service.recordEvent(recommended);
     service.reset();
-
     expect(service.getHistory(strategyId)).toHaveLength(0);
     expect(service.listTrackedStrategies()).toHaveLength(0);
   });

--- a/server/src/__tests__/strategyLifecycleRoute.test.ts
+++ b/server/src/__tests__/strategyLifecycleRoute.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Route tests: GET /api/strategies/:strategyId/lifecycle (#34)
+ */
+
+import request from "supertest";
+import express from "express";
+
+// Mock all services that the strategies router imports before loading the router.
+jest.mock("../services/strategyLifecycleAuditService", () => ({
+  strategyLifecycleAuditService: {
+    getHistory: jest.fn(),
+    getCorrelationSummary: jest.fn(),
+    isTraceable: jest.fn(),
+  },
+}));
+jest.mock("../services/strategySnapshotVersioningService", () => ({
+  strategySnapshotVersioningService: { previewRollback: jest.fn() },
+}));
+jest.mock("../services/riskAdjustedYieldService", () => ({
+  rankStrategies: jest.fn(() => []),
+  filterByTimeWindow: jest.fn((s: unknown[]) => s),
+}));
+jest.mock("../services/protocolFailoverService", () => ({
+  failoverRegistry: {
+    apply: jest.fn(() => ({ included: [], excluded: [], evaluations: [], decisions: [] })),
+    excludedProtocols: jest.fn(() => []),
+    recentDecisions: jest.fn(() => []),
+  },
+}));
+jest.mock("../services/yieldReliabilityService", () => ({
+  yieldReliabilityEngine: {
+    calculateReliabilityScore: jest.fn(() =>
+      Promise.resolve({
+        status: "high",
+        metrics: { freshness: 1, historicalUptime: 1 },
+        signals: { lastSuccessfulFetch: new Date().toISOString(), consecutiveFailures: 0 },
+      }),
+    ),
+  },
+}));
+jest.mock("../services/strategyRotationService", () => ({
+  rotationRegistry: { current: jest.fn(() => null), recentDecisions: jest.fn(() => []) },
+}));
+jest.mock("../services/exportService", () => ({
+  exportService: { generateSnapshotBundle: jest.fn(() => Promise.resolve({})) },
+}));
+jest.mock("../config/protocols", () => ({ PROTOCOLS: [] }));
+jest.mock("../utils/riskScoring", () => ({ calculateRiskScore: jest.fn(() => ({ score: 5 })) }));
+
+// eslint-disable-next-line import/first
+import strategiesRouter from "../routes/strategies";
+
+const app = express();
+app.use(express.json());
+app.use("/api/strategies", strategiesRouter);
+
+const { strategyLifecycleAuditService: mockSvc } = require("../services/strategyLifecycleAuditService");
+
+const sampleEvents = [
+  {
+    id: "evt-1",
+    strategyId: "strat-001",
+    correlationId: "corr-abc",
+    actor: "optimizer",
+    timestamp: new Date("2025-01-15T10:00:00Z").toISOString(),
+    type: "StrategyRecommended",
+    recommendedBy: "optimizer",
+    rationale: "High APY",
+    expectedApyBps: 600,
+  },
+  {
+    id: "evt-2",
+    strategyId: "strat-001",
+    correlationId: "corr-abc",
+    actor: "executor",
+    timestamp: new Date("2025-01-15T10:01:00Z").toISOString(),
+    type: "StrategyExecuted",
+    executedBy: "executor",
+    executionDurationMs: 100,
+    resultApyBps: 590,
+    transactionHash: "0xabc",
+    filledPercentage: 100,
+  },
+];
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/strategies/:strategyId/lifecycle", () => {
+  it("returns 200 with full history (no correlationId filter)", async () => {
+    mockSvc.getHistory.mockReturnValue(sampleEvents);
+    mockSvc.isTraceable.mockReturnValue(true);
+
+    const res = await request(app).get("/api/strategies/strat-001/lifecycle");
+
+    expect(res.status).toBe(200);
+    expect(res.body.strategyId).toBe("strat-001");
+    expect(res.body.total).toBe(2);
+    expect(res.body.isTraceable).toBe(true);
+    expect(Array.isArray(res.body.events)).toBe(true);
+    expect(Array.isArray(res.body.path)).toBe(true);
+    expect(res.body.path).toContain("StrategyRecommended");
+    expect(res.body.path).toContain("StrategyExecuted");
+  });
+
+  it("scopes by correlationId when query param provided", async () => {
+    mockSvc.getCorrelationSummary.mockReturnValue({
+      correlationId: "corr-abc",
+      strategyId: "strat-001",
+      events: sampleEvents,
+      path: ["StrategyRecommended", "StrategyExecuted"],
+      isComplete: true,
+    });
+    mockSvc.isTraceable.mockReturnValue(true);
+
+    const res = await request(app)
+      .get("/api/strategies/strat-001/lifecycle?correlationId=corr-abc");
+
+    expect(res.status).toBe(200);
+    expect(res.body.correlationId).toBe("corr-abc");
+    expect(res.body.isComplete).toBe(true);
+    expect(mockSvc.getCorrelationSummary).toHaveBeenCalledWith("corr-abc");
+  });
+
+  it("filters correlationId results to the requested strategyId only", async () => {
+    const mixedEvents = [
+      ...sampleEvents,
+      {
+        id: "evt-x",
+        strategyId: "strat-other",
+        correlationId: "corr-abc",
+        actor: "x",
+        timestamp: new Date().toISOString(),
+        type: "StrategyQueued",
+        queueEntryId: "qe-x",
+        queuePosition: 2,
+        priority: "low",
+      },
+    ];
+    mockSvc.getCorrelationSummary.mockReturnValue({
+      correlationId: "corr-abc",
+      strategyId: "strat-001",
+      events: mixedEvents,
+      path: [],
+      isComplete: false,
+    });
+    mockSvc.isTraceable.mockReturnValue(false);
+
+    const res = await request(app)
+      .get("/api/strategies/strat-001/lifecycle?correlationId=corr-abc");
+
+    expect(res.status).toBe(200);
+    expect(
+      res.body.events.every((e: { strategyId: string }) => e.strategyId === "strat-001"),
+    ).toBe(true);
+  });
+
+  it("returns 200 with empty events for unknown strategyId", async () => {
+    mockSvc.getHistory.mockReturnValue([]);
+    mockSvc.isTraceable.mockReturnValue(false);
+
+    const res = await request(app).get("/api/strategies/no-such-strategy/lifecycle");
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(0);
+    expect(res.body.events).toEqual([]);
+  });
+
+  it("isTraceable flag reflects service response", async () => {
+    mockSvc.getHistory.mockReturnValue(sampleEvents);
+    mockSvc.isTraceable.mockReturnValue(false);
+
+    const res = await request(app).get("/api/strategies/strat-001/lifecycle");
+
+    expect(res.body.isTraceable).toBe(false);
+  });
+});

--- a/server/src/routes/strategies.ts
+++ b/server/src/routes/strategies.ts
@@ -16,6 +16,7 @@ import { yieldReliabilityEngine } from "../services/yieldReliabilityService";
 import { rotationRegistry } from "../services/strategyRotationService";
 import { exportService } from "../services/exportService";
 import { strategySnapshotVersioningService } from "../services/strategySnapshotVersioningService";
+import { strategyLifecycleAuditService } from "../services/strategyLifecycleAuditService";
 
 const router = Router();
 
@@ -252,5 +253,44 @@ router.get(
     }
   },
 );
+
+/**
+ * GET /api/strategies/:strategyId/lifecycle
+ *
+ * Returns the full event-sourced lifecycle history for a strategy.
+ * Events are returned in insertion (chronological) order.
+ *
+ * Query params:
+ *   correlationId — when provided, scopes results to a single chain and
+ *                   includes a traceability summary.
+ */
+router.get("/:strategyId/lifecycle", (req: Request, res: Response) => {
+  const { strategyId } = req.params;
+  const correlationId = req.query.correlationId as string | undefined;
+
+  if (correlationId) {
+    const summary = strategyLifecycleAuditService.getCorrelationSummary(correlationId);
+    // Guard: only return events that belong to the requested strategy.
+    const filtered = summary.events.filter((e) => e.strategyId === strategyId);
+    res.json({
+      strategyId,
+      correlationId,
+      events: filtered,
+      path: filtered.map((e) => e.type),
+      isComplete: summary.isComplete,
+      isTraceable: strategyLifecycleAuditService.isTraceable(strategyId),
+    });
+    return;
+  }
+
+  const events = strategyLifecycleAuditService.getHistory(strategyId);
+  res.json({
+    strategyId,
+    events,
+    path: events.map((e) => e.type),
+    isTraceable: strategyLifecycleAuditService.isTraceable(strategyId),
+    total: events.length,
+  });
+});
 
 export default router;

--- a/server/src/services/strategyLifecycleAuditService.ts
+++ b/server/src/services/strategyLifecycleAuditService.ts
@@ -1,17 +1,46 @@
+import crypto from "crypto";
 import type {
   StrategyLifecycleEvent,
   StrategyLifecycleEventType,
 } from "../types/strategyLifecycleEvents";
 
 /**
- * Event-sourced audit log for strategy lifecycle events (#720).
+ * Event-sourced audit log for strategy lifecycle events (#34).
  *
- * Events are appended in order and never mutated. The log is kept in-memory;
- * in production this would be backed by an append-only store (e.g. event
- * store, Kafka, or an immutable DB table).
+ * Events are appended in order and never mutated.  The log is keyed by
+ * strategyId *and* correlationId so callers can replay a full chain from
+ * recommendation through execution or failure.
+ *
+ * In production this would be backed by an append-only store (e.g. an
+ * immutable DB table, Kafka, or an event-store service).
  */
 export class StrategyLifecycleAuditService {
   private readonly log: Map<string, StrategyLifecycleEvent[]> = new Map();
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  /** Generate a stable unique event ID. */
+  static generateEventId(): string {
+    return `evt-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+  }
+
+  /** Generate a new correlationId for a fresh recommendation chain. */
+  static generateCorrelationId(): string {
+    return `corr-${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
+  }
+
+  /**
+   * SHA-256 hex of a payload object.  Used to populate `sourceDataHash` so
+   * audit replays can verify the input data was not tampered with.
+   */
+  static hashPayload(payload: unknown): string {
+    return crypto
+      .createHash("sha256")
+      .update(JSON.stringify(payload))
+      .digest("hex");
+  }
+
+  // ── write ──────────────────────────────────────────────────────────────────
 
   /**
    * Append an event to the log for the strategy identified by event.strategyId.
@@ -21,35 +50,50 @@ export class StrategyLifecycleAuditService {
     if (!this.log.has(strategyId)) {
       this.log.set(strategyId, []);
     }
-    // Defensive copy to prevent callers mutating recorded events
+    // Defensive copy — prevent callers mutating recorded events.
     this.log.get(strategyId)!.push({ ...event });
   }
 
+  // ── read ───────────────────────────────────────────────────────────────────
+
   /**
    * Return all recorded events for a strategy in insertion order.
-   * Returns an empty array if no events exist for the strategyId.
    */
   getHistory(strategyId: string): StrategyLifecycleEvent[] {
     return (this.log.get(strategyId) ?? []).slice();
   }
 
   /**
+   * Return all events that share the given correlationId, across any strategy.
+   * Events are returned in timestamp order.
+   */
+  getByCorrelationId(correlationId: string): StrategyLifecycleEvent[] {
+    const results: StrategyLifecycleEvent[] = [];
+    for (const events of this.log.values()) {
+      for (const e of events) {
+        if (e.correlationId === correlationId) {
+          results.push({ ...e });
+        }
+      }
+    }
+    return results.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+
+  /**
    * Return the ordered list of event types recorded for a strategy.
-   * Useful for asserting that the lifecycle proceeded in the expected order.
    */
   reconstructPath(strategyId: string): StrategyLifecycleEventType[] {
     return this.getHistory(strategyId).map((e) => e.type);
   }
 
   /**
-   * Return true if the strategy has both a StrategyRecommended event and
-   * at least one of StrategyExecuted or StrategyBlocked, indicating the
-   * lifecycle reached a terminal state and can be fully traced.
+   * True if the strategy has both a StrategyRecommended event and at least one
+   * terminal event (StrategyExecuted or StrategyBlocked), meaning the full
+   * chain can be traced.
    */
   isTraceable(strategyId: string): boolean {
     const events = this.getHistory(strategyId);
     const types = new Set(events.map((e) => e.type));
-
     return (
       types.has("StrategyRecommended") &&
       (types.has("StrategyExecuted") || types.has("StrategyBlocked"))
@@ -57,7 +101,35 @@ export class StrategyLifecycleAuditService {
   }
 
   /**
-   * Return a list of all strategy IDs that have at least one recorded event.
+   * Return a summary of the lifecycle chain identified by correlationId,
+   * including all event types present and whether the chain reached a terminal
+   * state.
+   */
+  getCorrelationSummary(correlationId: string): {
+    correlationId: string;
+    strategyId: string | null;
+    events: StrategyLifecycleEvent[];
+    path: StrategyLifecycleEventType[];
+    isComplete: boolean;
+  } {
+    const events = this.getByCorrelationId(correlationId);
+    const path = events.map((e) => e.type);
+    const types = new Set(path);
+    const strategyId = events[0]?.strategyId ?? null;
+
+    return {
+      correlationId,
+      strategyId,
+      events,
+      path,
+      isComplete:
+        types.has("StrategyRecommended") &&
+        (types.has("StrategyExecuted") || types.has("StrategyBlocked")),
+    };
+  }
+
+  /**
+   * Return all strategy IDs that have at least one recorded event.
    */
   listTrackedStrategies(): string[] {
     return Array.from(this.log.keys());

--- a/server/src/types/strategyLifecycleEvents.ts
+++ b/server/src/types/strategyLifecycleEvents.ts
@@ -1,23 +1,47 @@
 /**
- * Event types for the event-sourced strategy lifecycle audit (#720).
+ * Event types for the event-sourced strategy lifecycle audit (#34).
  *
  * Each event is immutable once recorded. The union type StrategyLifecycleEvent
  * covers every point in a strategy's lifecycle from first recommendation
  * through to final execution or block.
+ *
+ * All events carry a stable `correlationId` that links every event belonging
+ * to the same recommendation-through-execution chain, and an `actor` field
+ * identifying the system component or operator that generated the event.
+ * An optional `sourceDataHash` records a SHA-256 of the input data used so
+ * replays can verify nothing was altered.
  */
 
 export type StrategyLifecycleEventType =
   | "StrategyRecommended"
   | "StrategyQueued"
   | "StrategyRiskChecked"
+  | "OracleDecisionRecorded"
+  | "FallbackRouteSelected"
   | "StrategyExecuted"
+  | "StrategyExecutionFailed"
   | "StrategyBlocked"
   | "StrategySnapshotted";
 
 interface BaseEvent {
+  /** Unique event identifier. */
+  id: string;
   strategyId: string;
   timestamp: Date;
   type: StrategyLifecycleEventType;
+  /**
+   * Stable ID linking all events that belong to the same recommendation →
+   * execution chain. Assigned when the recommendation is first recorded and
+   * propagated to every downstream event.
+   */
+  correlationId: string;
+  /** System component or operator that produced the event. */
+  actor: string;
+  /**
+   * SHA-256 hex digest of the primary input payload used to produce this
+   * event. Allows audit replays to verify data integrity.
+   */
+  sourceDataHash?: string;
 }
 
 export interface StrategyRecommendedEvent extends BaseEvent {
@@ -29,6 +53,7 @@ export interface StrategyRecommendedEvent extends BaseEvent {
 
 export interface StrategyQueuedEvent extends BaseEvent {
   type: "StrategyQueued";
+  queueEntryId: string;
   queuePosition: number;
   priority: "high" | "medium" | "low";
 }
@@ -40,11 +65,41 @@ export interface StrategyRiskCheckedEvent extends BaseEvent {
   checkedBy: string;
 }
 
+/** Emitted when the oracle sentinel evaluates a price reading before execution. */
+export interface OracleDecisionRecordedEvent extends BaseEvent {
+  type: "OracleDecisionRecorded";
+  assetId: string;
+  oracleDecision: "ALLOW" | "DOWNGRADE" | "BLOCK";
+  oracleState: string;
+  deviationPct: number | null;
+  ageMs: number | null;
+  reasons: string[];
+}
+
+/** Emitted when the normal execution path is unavailable and a fallback is chosen. */
+export interface FallbackRouteSelectedEvent extends BaseEvent {
+  type: "FallbackRouteSelected";
+  originalProtocol: string;
+  fallbackProtocol: string;
+  fallbackReason: string;
+}
+
 export interface StrategyExecutedEvent extends BaseEvent {
   type: "StrategyExecuted";
   executedBy: string;
   executionDurationMs: number;
   resultApyBps: number;
+  transactionHash?: string;
+  filledPercentage?: number;
+}
+
+/** Emitted when execution is attempted but fails (distinct from StrategyBlocked). */
+export interface StrategyExecutionFailedEvent extends BaseEvent {
+  type: "StrategyExecutionFailed";
+  failureClass: string;
+  reason: string;
+  attemptNumber: number;
+  willRetry: boolean;
 }
 
 export interface StrategyBlockedEvent extends BaseEvent {
@@ -56,13 +111,18 @@ export interface StrategyBlockedEvent extends BaseEvent {
 export interface StrategySnapshottedEvent extends BaseEvent {
   type: "StrategySnapshotted";
   snapshotId: string;
+  snapshotVersion: number;
   snapshotHash: string;
+  changeReason?: string;
 }
 
 export type StrategyLifecycleEvent =
   | StrategyRecommendedEvent
   | StrategyQueuedEvent
   | StrategyRiskCheckedEvent
+  | OracleDecisionRecordedEvent
+  | FallbackRouteSelectedEvent
   | StrategyExecutedEvent
+  | StrategyExecutionFailedEvent
   | StrategyBlockedEvent
   | StrategySnapshottedEvent;


### PR DESCRIPTION
Closes #34


Implements a full event-sourced audit trail that links every stage of a strategy's lifecycle — from recommendation through oracle evaluation, queue entry, execution or failure, and snapshot — using a stable `correlationId` rather than timestamps alone.

### `types/strategyLifecycleEvents.ts`
- Added `id`, `correlationId`, `actor`, and `sourceDataHash` to all events
- New event types: `OracleDecisionRecorded`, `FallbackRouteSelected`, `StrategyExecutionFailed`
- `StrategySnapshottedEvent` now carries `snapshotVersion` and `changeReason`

### `services/strategyLifecycleAuditService.ts`
- Static helpers: `generateEventId`, `generateCorrelationId`, `hashPayload` (SHA-256)
- `getByCorrelationId` — replays all events in a chain across any strategy
- `getCorrelationSummary` — returns the event path and `isComplete` flag for a given chain

### `routes/strategies.ts`
- New endpoint: `GET /api/strategies/:strategyId/lifecycle`
- Optional `?correlationId=` param scopes the response to a single recommendation-through-execution chain

## Tests (42 passing)

`strategyLifecycleAudit.test.ts` — service unit tests
`strategyLifecycleRoute.test.ts` — HTTP endpoint tests

Scenarios covered per acceptance criteria:
- Complete execution path
- Oracle-blocked path
- Fallback route selected
- Failed execution with retry metadata
- Replayed history query scoped by `correlationId`

## Validation
```
npm test -- strategy      # strategyLifecycleAudit, strategyLifecycleRoute
npm test -- rebalance     # existing rebalance tests unaffected
npm run build             # no new type errors introduced
```