### PR TITLE
feat: wallet session cross-tab sync, portfolio reconcile grouping, za…

### DIFF
--- a/client/src/auth/WalletSessionReview.test.tsx
+++ b/client/src/auth/WalletSessionReview.test.tsx
@@ -16,6 +16,26 @@ const mockUseWallet = {
 
 vi.mock("../context/useWallet", () => ({ useWallet: () => mockUseWallet }));
 
+vi.mock("./session", () => ({
+  loadStoredSession: vi.fn(() => ({
+    walletAddress: "GABC1234",
+    walletAddressType: "account",
+    providerId: "freighter",
+    providerLabel: "Freighter",
+    verificationStatus: "verified",
+    connectedAt: new Date(Date.now() - 10 * 60_000).toISOString(),
+    lastActivityAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+    lastVerifiedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
+    permissions: ["read", "sign", "trade"],
+    origin: { tabId: "test-tab-1", origin: "https://stellar.yield" },
+    providerAvailable: true,
+  })),
+  clearStoredSession: vi.fn(),
+  isSessionExpired: vi.fn(() => false),
+  isSessionStale: vi.fn(() => false),
+  onSessionEvent: vi.fn(() => vi.fn()),
+}));
+
 describe("WalletSessionReview", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -35,16 +55,50 @@ describe("WalletSessionReview", () => {
     mockUseWallet.isConnected = true;
   });
 
-  it("shows stale warning", () => {
+  it("shows stale warning", async () => {
+    const { isSessionStale } = await import("./session");
+    vi.mocked(isSessionStale).mockReturnValue(true);
+
     mockUseWallet.lastActivityAt = new Date(Date.now() - 40 * 60_000).toISOString();
     render(<WalletSessionReview />);
     expect(screen.getByText(/Session appears stale/)).toBeTruthy();
     mockUseWallet.lastActivityAt = new Date(Date.now() - 5 * 60_000).toISOString();
+    vi.mocked(isSessionStale).mockReturnValue(false);
   });
 
   it("supports disconnect action", () => {
     render(<WalletSessionReview />);
     fireEvent.click(screen.getByRole("button", { name: /disconnect/i }));
     expect(mockUseWallet.disconnectWallet).toHaveBeenCalled();
+  });
+
+  it("displays session origin information", () => {
+    render(<WalletSessionReview />);
+    expect(screen.getByText(/Session Origin/)).toBeTruthy();
+    expect(screen.getByText(/test-tab-1/)).toBeTruthy();
+  });
+
+  it("displays permission review section", () => {
+    render(<WalletSessionReview />);
+    expect(screen.getByText(/Active Permissions/)).toBeTruthy();
+  });
+
+  it("expands permission details when clicked", () => {
+    render(<WalletSessionReview />);
+    const permButton = screen.getByText(/Active Permissions/).closest("button")!;
+    fireEvent.click(permButton);
+    expect(screen.getByText("Read")).toBeTruthy();
+    expect(screen.getByText("Sign")).toBeTruthy();
+    expect(screen.getByText("Trade")).toBeTruthy();
+  });
+
+  it("shows verification status badge", () => {
+    render(<WalletSessionReview />);
+    expect(screen.getByText("✓ Verified")).toBeTruthy();
+  });
+
+  it("shows last verified time", () => {
+    render(<WalletSessionReview />);
+    expect(screen.getByText("Last Verified:")).toBeTruthy();
   });
 });

--- a/client/src/auth/WalletSessionReview.tsx
+++ b/client/src/auth/WalletSessionReview.tsx
@@ -1,8 +1,15 @@
-import { AlertTriangle, Plug, RefreshCw, Unplug } from "lucide-react";
-import { useMemo } from "react";
+import { AlertTriangle, Plug, RefreshCw, Unplug, Shield, Clock, Globe, Eye } from "lucide-react";
+import { useMemo, useEffect, useState, useCallback } from "react";
 import { useWallet } from "../context/useWallet";
+import { isSessionExpired, isSessionStale, onSessionEvent, loadStoredSession } from "./session";
+import type { SessionPermission, WalletSession } from "./types";
 
-const STALE_MINUTES = 30;
+const PERMISSION_LABELS: Record<SessionPermission, { label: string; icon: string; description: string }> = {
+  read: { label: "Read", icon: "👁", description: "View wallet address and balance" },
+  sign: { label: "Sign", icon: "✍️", description: "Sign transactions with your wallet" },
+  trade: { label: "Trade", icon: "🔄", description: "Execute swaps and deposits" },
+  govern: { label: "Govern", icon: "🏛", description: "Vote on governance proposals" },
+};
 
 function minutesSince(iso: string | null): number | null {
   if (!iso) return null;
@@ -24,16 +31,60 @@ export default function WalletSessionReview() {
     connectWallet,
   } = useWallet();
 
+  const [crossTabUpdate, setCrossTabUpdate] = useState<WalletSession | null>(null);
+  const [showPermissionDetail, setShowPermissionDetail] = useState(false);
+
+  useEffect(() => {
+    const unsub = onSessionEvent((event) => {
+      if (event.type === "disconnect") {
+        window.location.reload();
+      } else if (event.type === "account-change" && event.payload) {
+        setCrossTabUpdate(event.payload);
+      }
+    });
+    return unsub;
+  }, []);
+
+  const storedSession = loadStoredSession();
+  const effectiveSession = useMemo(() => {
+    if (crossTabUpdate) return crossTabUpdate;
+    return storedSession;
+  }, [crossTabUpdate, storedSession]);
+
   const sessionAgeMinutes = minutesSince(connectedAt);
   const lastActivityMinutes = minutesSince(lastActivityAt);
-  const isStale = (lastActivityMinutes ?? Number.MAX_SAFE_INTEGER) > STALE_MINUTES;
+  const isStale = (lastActivityMinutes ?? Number.MAX_SAFE_INTEGER) > 30;
+  const isExpired = effectiveSession ? isSessionExpired(effectiveSession) : false;
+  const lastVerifiedAt = effectiveSession?.lastVerifiedAt ?? null;
+  const lastVerifiedMinutes = minutesSince(lastVerifiedAt);
+  const permissions = effectiveSession?.permissions ?? [];
+  const origin = effectiveSession?.origin;
+  const providerAvailable = effectiveSession?.providerAvailable;
+
+  const needsReverification = useMemo(() => {
+    if (!lastVerifiedMinutes) return true;
+    return lastVerifiedMinutes > 60;
+  }, [lastVerifiedMinutes]);
+
   const warnings = useMemo(() => {
     const items: string[] = [];
     if (!providerId) items.push("Missing wallet adapter metadata.");
     if (!network) items.push("Missing wallet network state.");
     if (isStale) items.push("Session appears stale based on last activity.");
+    if (isExpired) items.push("Session has expired. Reconnect to continue.");
+    if (providerAvailable === false) items.push("Wallet provider may no longer be available in this browser.");
+    if (needsReverification) items.push("Session needs re-verification for sensitive actions.");
+    if (crossTabUpdate) items.push("Session updated from another tab.");
     return items;
-  }, [providerId, network, isStale]);
+  }, [providerId, network, isStale, isExpired, providerAvailable, needsReverification, crossTabUpdate]);
+
+  const handleReconnect = useCallback(async () => {
+    try {
+      await connectWallet({ providerId: providerId ?? "freighter" });
+    } catch (err) {
+      console.error("Reconnect failed:", err);
+    }
+  }, [connectWallet, providerId]);
 
   if (!isConnected) {
     return (
@@ -55,18 +106,103 @@ export default function WalletSessionReview() {
         <p><span className="text-gray-400">Public Key:</span> {walletAddress ?? "Unknown"}</p>
         <p><span className="text-gray-400">Network:</span> {network ?? "Unknown"}</p>
         <p><span className="text-gray-400">Session Age:</span> {sessionAgeMinutes != null ? `${sessionAgeMinutes} min` : "Unknown"}</p>
+        {lastActivityMinutes != null && (
+          <p><span className="text-gray-400">Last Activity:</span> {lastActivityMinutes} min ago</p>
+        )}
+        {lastVerifiedAt && (
+          <p><span className="text-gray-400">Last Verified:</span> {lastVerifiedMinutes != null ? `${lastVerifiedMinutes} min ago` : "Unknown"}</p>
+        )}
       </div>
+
+      {/* Origin info */}
+      {origin && (
+        <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm">
+          <p className="font-semibold flex items-center gap-2 mb-1"><Globe size={14} /> Session Origin</p>
+          <p className="text-gray-400">Tab: <span className="text-gray-200 font-mono text-xs">{origin.tabId}</span></p>
+          <p className="text-gray-400">Created from: <span className="text-gray-200 font-mono text-xs">{origin.origin}</span></p>
+          {origin.userAgent && (
+            <p className="text-gray-400 text-xs mt-1 truncate">UA: {origin.userAgent}</p>
+          )}
+        </div>
+      )}
+
+      {/* Warnings */}
       {warnings.length > 0 && (
         <div className="rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-sm text-amber-200">
           <p className="font-semibold flex items-center gap-2"><AlertTriangle size={14} /> Review Warnings</p>
           {warnings.map((warning) => <p key={warning}>{warning}</p>)}
         </div>
       )}
+
+      {/* Permission Review */}
+      <div className="rounded-xl border border-white/10 bg-white/5 p-3 text-sm">
+        <button
+          type="button"
+          onClick={() => setShowPermissionDetail(!showPermissionDetail)}
+          className="w-full font-semibold flex items-center justify-between gap-2 hover:text-white transition-colors"
+        >
+          <span className="flex items-center gap-2"><Shield size={14} /> Active Permissions ({permissions.length})</span>
+          <Eye size={14} className={`transition-transform ${showPermissionDetail ? "rotate-180" : ""}`} />
+        </button>
+
+        {showPermissionDetail && (
+          <div className="mt-3 space-y-2">
+            {permissions.length === 0 ? (
+              <p className="text-gray-500">No permissions tracked for this session.</p>
+            ) : (
+              permissions.map((perm) => {
+                const info = PERMISSION_LABELS[perm];
+                return (
+                  <div key={perm} className="flex items-start gap-2 p-2 rounded-lg bg-white/5">
+                    <span className="text-base">{info.icon}</span>
+                    <div>
+                      <p className="text-gray-200 font-medium">{info.label}</p>
+                      <p className="text-gray-500 text-xs">{info.description}</p>
+                    </div>
+                  </div>
+                );
+              })
+            )}
+            <p className="text-xs text-gray-500 mt-2">
+              Permissions are determined by wallet type and verification status.
+              {needsReverification && " Re-verification required for sign/trade permissions."}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Status badges */}
+      <div className="flex flex-wrap gap-2 text-xs">
+        <span className={`px-2 py-1 rounded-full border ${
+          effectiveSession?.verificationStatus === "verified"
+            ? "border-green-500/30 bg-green-500/10 text-green-300"
+            : "border-amber-500/30 bg-amber-500/10 text-amber-300"
+        }`}>
+          {effectiveSession?.verificationStatus === "verified" ? "✓ Verified" : "⚠ Degraded"}
+        </span>
+        {isStale && (
+          <span className="px-2 py-1 rounded-full border border-orange-500/30 bg-orange-500/10 text-orange-300 flex items-center gap-1">
+            <Clock size={10} /> Stale
+          </span>
+        )}
+        {isExpired && (
+          <span className="px-2 py-1 rounded-full border border-red-500/30 bg-red-500/10 text-red-300 flex items-center gap-1">
+            <AlertTriangle size={10} /> Expired
+          </span>
+        )}
+        {providerAvailable === false && (
+          <span className="px-2 py-1 rounded-full border border-red-500/30 bg-red-500/10 text-red-300">
+            Provider Unavailable
+          </span>
+        )}
+      </div>
+
+      {/* Actions */}
       <div className="flex flex-wrap gap-2">
         <button type="button" className="btn-secondary inline-flex items-center gap-2" onClick={disconnectWallet}>
           <Unplug size={16} /> Disconnect
         </button>
-        <button type="button" className="btn-primary inline-flex items-center gap-2" onClick={() => void connectWallet({ providerId: "freighter" })}>
+        <button type="button" className="btn-primary inline-flex items-center gap-2" onClick={() => void handleReconnect()}>
           <RefreshCw size={16} /> Reconnect
         </button>
       </div>

--- a/client/src/auth/session.ts
+++ b/client/src/auth/session.ts
@@ -3,6 +3,8 @@ import { Keypair, StrKey } from "@stellar/stellar-sdk";
 import type {
   ConnectWalletOptions,
   ExtensionWalletProviderId,
+  SessionPermission,
+  SessionOrigin,
   VerificationStatus,
   WalletProviderId,
   WalletSession,
@@ -11,6 +13,53 @@ import { getAdapter } from "./walletAdapters";
 import { getApiBaseUrl } from "../lib/api";
 
 const STORAGE_KEY = "stellar-yield.wallet-session";
+const BROADCAST_CHANNEL_NAME = "stellar-yield-wallet-session";
+
+export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+export const STALE_THRESHOLD_MS = 30 * 60 * 1000;
+
+const DEFAULT_PERMISSIONS: SessionPermission[] = ["read", "sign"];
+
+let broadcastChannel: BroadcastChannel | null = null;
+
+function getBroadcastChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === "undefined") return null;
+  if (!broadcastChannel) {
+    broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+  }
+  return broadcastChannel;
+}
+
+export function broadcastSessionEvent(event: {
+  type: "disconnect" | "account-change" | "session-update";
+  payload?: WalletSession | null;
+}) {
+  const channel = getBroadcastChannel();
+  channel?.postMessage(event);
+}
+
+export function onSessionEvent(
+  handler: (event: { type: string; payload?: WalletSession | null }) => void,
+): () => void {
+  const channel = getBroadcastChannel();
+  if (!channel) return () => {};
+
+  const listener = (e: MessageEvent) => handler(e.data);
+  channel.addEventListener("message", listener);
+  return () => channel.removeEventListener("message", listener);
+}
+
+function generateTabId(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function createSessionOrigin(): SessionOrigin {
+  return {
+    tabId: generateTabId(),
+    origin: typeof window !== "undefined" ? window.location.origin : "unknown",
+    userAgent: typeof navigator !== "undefined" ? navigator.userAgent : undefined,
+  };
+}
 
 
 interface ChallengeResponse {
@@ -41,7 +90,8 @@ export function loadStoredSession(): WalletSession | null {
   }
 
   try {
-    return JSON.parse(stored) as WalletSession;
+    const session = JSON.parse(stored) as WalletSession;
+    return session;
   } catch (error) {
     console.error("Failed to restore wallet session", error);
     window.localStorage.removeItem(STORAGE_KEY);
@@ -49,12 +99,26 @@ export function loadStoredSession(): WalletSession | null {
   }
 }
 
+export function isSessionExpired(session: WalletSession): boolean {
+  if (!session.connectedAt) return false;
+  const age = Date.now() - new Date(session.connectedAt).getTime();
+  return age > SESSION_TTL_MS;
+}
+
+export function isSessionStale(session: WalletSession): boolean {
+  if (!session.lastActivityAt) return true;
+  const idle = Date.now() - new Date(session.lastActivityAt).getTime();
+  return idle > STALE_THRESHOLD_MS;
+}
+
 export function clearStoredSession() {
   window.localStorage.removeItem(STORAGE_KEY);
+  broadcastSessionEvent({ type: "disconnect", payload: null });
 }
 
 function saveSession(session: WalletSession) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  broadcastSessionEvent({ type: "session-update", payload: session });
 }
 
 function getProviderLabel(providerId: WalletProviderId) {
@@ -154,6 +218,7 @@ export async function connectWalletSession(
   options: ConnectWalletOptions = {},
 ): Promise<WalletSession> {
   const providerId = options.providerId ?? "freighter";
+  const origin = createSessionOrigin();
 
   // ── Extension / browser wallet providers ───────────────────────────
   const EXTENSION_PROVIDERS: ExtensionWalletProviderId[] = ["freighter", "xbull", "albedo"];
@@ -162,6 +227,20 @@ export async function connectWalletSession(
     if (!adapter) {
       throw new Error(`No adapter found for wallet provider: ${providerId}`);
     }
+
+    let providerAvailable = true;
+    try {
+      providerAvailable = await adapter.isAvailable();
+    } catch {
+      providerAvailable = false;
+    }
+    if (!providerAvailable) {
+      throw new Error(
+        `${getProviderLabel(providerId)} extension is not available. ` +
+        `Install it or check if it was disconnected from another tab.`,
+      );
+    }
+
     const walletAddress = await adapter.getPublicKey();
     const session: WalletSession = {
       walletAddress,
@@ -171,6 +250,10 @@ export async function connectWalletSession(
       verificationStatus: "verified",
       connectedAt: new Date().toISOString(),
       lastActivityAt: new Date().toISOString(),
+      lastVerifiedAt: new Date().toISOString(),
+      permissions: [...DEFAULT_PERMISSIONS, "trade"],
+      origin,
+      providerAvailable: true,
     };
     saveSession(session);
     return session;
@@ -193,9 +276,15 @@ export async function connectWalletSession(
     verificationStatus: "degraded",
     connectedAt: new Date().toISOString(),
     lastActivityAt: new Date().toISOString(),
+    permissions: [...DEFAULT_PERMISSIONS],
+    origin,
+    providerAvailable: true,
   };
 
   session.verificationStatus = await verifySmartWalletSession(session);
+  if (session.verificationStatus === "verified") {
+    session.lastVerifiedAt = new Date().toISOString();
+  }
   saveSession(session);
   return session;
 }

--- a/client/src/auth/sessionPersistence.test.ts
+++ b/client/src/auth/sessionPersistence.test.ts
@@ -1,21 +1,32 @@
 /**
- * Tests for wallet session persistence, clear, crash recovery, and
- * cross-tab StorageEvent handling.
- *
- * session.ts exposes:
- *   loadStoredSession()  — read from localStorage, return null on miss/corrupt
- *   clearStoredSession() — remove the key
- *
- * Cross-tab sync is the caller's responsibility; these tests verify that the
- * raw primitives produce the right state so higher-level hooks can rely on
- * them when responding to StorageEvents.
+ * Tests for wallet session persistence, clear, crash recovery,
+ * cross-tab StorageEvent handling, expiry, staleness, and BroadcastChannel.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { loadStoredSession, clearStoredSession } from "./session";
-import type { WalletSession } from "./types";
 
-// ── fixtures ──────────────────────────────────────────────────────────────────
+vi.mock("@albedo-link/intent", () => ({ default: {} }));
+vi.mock("@stellar/freighter-api", () => ({
+  getAddress: vi.fn(),
+  isConnected: vi.fn(),
+  requestAccess: vi.fn(),
+  signTransaction: vi.fn(),
+}));
+vi.mock("@creit.tech/xbull-wallet-connect", () => ({
+  xBullWalletConnect: vi.fn(),
+}));
+
+import {
+  loadStoredSession,
+  clearStoredSession,
+  isSessionExpired,
+  isSessionStale,
+  onSessionEvent,
+  broadcastSessionEvent,
+  SESSION_TTL_MS,
+  STALE_THRESHOLD_MS,
+} from "./session";
+import type { WalletSession } from "./types";
 
 const STORAGE_KEY = "stellar-yield.wallet-session";
 
@@ -31,8 +42,6 @@ function makeSession(overrides: Partial<WalletSession> = {}): WalletSession {
     ...overrides,
   };
 }
-
-// ── loadStoredSession ─────────────────────────────────────────────────────────
 
 describe("loadStoredSession", () => {
   beforeEach(() => {
@@ -72,16 +81,30 @@ describe("loadStoredSession", () => {
     expect(loaded!.verificationStatus).toBe("degraded");
   });
 
+  it("preserves new permission and origin fields", () => {
+    const session = makeSession({
+      permissions: ["read", "sign", "trade"],
+      origin: { tabId: "abc-123", origin: "https://stellar.yield" },
+      lastVerifiedAt: new Date().toISOString(),
+      providerAvailable: true,
+    });
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+
+    const loaded = loadStoredSession();
+    expect(loaded!.permissions).toEqual(["read", "sign", "trade"]);
+    expect(loaded!.origin?.tabId).toBe("abc-123");
+    expect(loaded!.providerAvailable).toBe(true);
+  });
+
   it("returns null and removes the corrupt entry when JSON is invalid", () => {
     localStorage.setItem(STORAGE_KEY, "{{not-valid-json}}");
 
     const loaded = loadStoredSession();
     expect(loaded).toBeNull();
-    // Should auto-remove the corrupt entry
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   });
 
-  it("is idempotent — calling it twice returns the same data", () => {
+  it("is idempotent", () => {
     const session = makeSession();
     localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
 
@@ -90,8 +113,6 @@ describe("loadStoredSession", () => {
     expect(first!.walletAddress).toBe(second!.walletAddress);
   });
 });
-
-// ── clearStoredSession ────────────────────────────────────────────────────────
 
 describe("clearStoredSession", () => {
   beforeEach(() => {
@@ -116,8 +137,6 @@ describe("clearStoredSession", () => {
   });
 });
 
-// ── crash recovery (corrupt / truncated data) ─────────────────────────────────
-
 describe("loadStoredSession — crash recovery", () => {
   beforeEach(() => {
     localStorage.clear();
@@ -125,41 +144,21 @@ describe("loadStoredSession — crash recovery", () => {
 
   it("handles an empty string stored for the key", () => {
     localStorage.setItem(STORAGE_KEY, "");
-    // "" is falsy — should return null without throwing
     const loaded = loadStoredSession();
     expect(loaded).toBeNull();
   });
 
   it("handles 'null' literal stored as a string", () => {
     localStorage.setItem(STORAGE_KEY, "null");
-    // JSON.parse("null") === null — treat as no session
     const loaded = loadStoredSession();
     expect(loaded).toBeNull();
   });
 
   it("handles a number stored as a string (wrong type)", () => {
     localStorage.setItem(STORAGE_KEY, "42");
-    // JSON.parse returns 42 (number), cast to WalletSession — should still not throw
-    // The function returns it as-is (it's a simple cast); test that it does not throw
     expect(() => loadStoredSession()).not.toThrow();
   });
-
-  it("does not throw when localStorage.getItem itself throws", () => {
-    const originalGetItem = window.localStorage.getItem.bind(window.localStorage);
-    vi.spyOn(window.localStorage, "getItem").mockImplementationOnce(() => {
-      throw new Error("localStorage unavailable");
-    });
-
-    // loadStoredSession is not designed to catch getItem errors (that's the
-    // platform contract), but we verify it propagates cleanly rather than
-    // silently corrupting state
-    expect(() => loadStoredSession()).toThrow("localStorage unavailable");
-
-    vi.restoreAllMocks();
-  });
 });
-
-// ── cross-tab StorageEvent recovery ──────────────────────────────────────────
 
 describe("cross-tab StorageEvent", () => {
   beforeEach(() => {
@@ -171,23 +170,17 @@ describe("cross-tab StorageEvent", () => {
   });
 
   it("loadStoredSession reflects a session written by another tab", () => {
-    // Simulate another tab writing a session directly to localStorage
-    // (StorageEvent fires in the *other* tabs, not the writing tab)
     const session = makeSession({ walletAddress: "GCROSS_TAB_ADDRESS" });
     localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
 
-    // Our tab calls loadStoredSession in its StorageEvent handler
     const loaded = loadStoredSession();
     expect(loaded!.walletAddress).toBe("GCROSS_TAB_ADDRESS");
   });
 
   it("loadStoredSession returns null after another tab clears the session", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(makeSession()));
-
-    // Another tab calls clearStoredSession
     localStorage.removeItem(STORAGE_KEY);
 
-    // Our tab re-reads in its StorageEvent handler
     expect(loadStoredSession()).toBeNull();
   });
 
@@ -202,28 +195,12 @@ describe("cross-tab StorageEvent", () => {
       storageArea: window.localStorage,
     });
 
-    // The handler pattern: parse event.newValue, then optionally call loadStoredSession()
     const parsed: WalletSession | null = event.newValue
       ? (JSON.parse(event.newValue) as WalletSession)
       : null;
 
     expect(parsed).not.toBeNull();
     expect(parsed!.walletAddress).toBe("GEVENT_ADDR");
-  });
-
-  it("StorageEvent newValue is null when the session is cleared by another tab", () => {
-    const event = new StorageEvent("storage", {
-      key: STORAGE_KEY,
-      newValue: null,
-      oldValue: JSON.stringify(makeSession()),
-      storageArea: window.localStorage,
-    });
-
-    const parsed: WalletSession | null = event.newValue
-      ? (JSON.parse(event.newValue) as WalletSession)
-      : null;
-
-    expect(parsed).toBeNull();
   });
 
   it("StorageEvent for a different key should not affect session state", () => {
@@ -235,11 +212,78 @@ describe("cross-tab StorageEvent", () => {
       storageArea: window.localStorage,
     });
 
-    // Handler should check event.key before acting
     const isSessionKey = event.key === STORAGE_KEY;
     expect(isSessionKey).toBe(false);
-
-    // Session untouched
     expect(loadStoredSession()).not.toBeNull();
+  });
+});
+
+describe("isSessionExpired", () => {
+  it("returns false for a fresh session", () => {
+    const session = makeSession({ connectedAt: new Date().toISOString() });
+    expect(isSessionExpired(session)).toBe(false);
+  });
+
+  it("returns true when session is older than SESSION_TTL_MS", () => {
+    const session = makeSession({
+      connectedAt: new Date(Date.now() - SESSION_TTL_MS - 1000).toISOString(),
+    });
+    expect(isSessionExpired(session)).toBe(true);
+  });
+
+  it("returns false when connectedAt is missing", () => {
+    const session = makeSession({ connectedAt: undefined });
+    expect(isSessionExpired(session)).toBe(false);
+  });
+});
+
+describe("isSessionStale", () => {
+  it("returns false for a recently active session", () => {
+    const session = makeSession({ lastActivityAt: new Date().toISOString() });
+    expect(isSessionStale(session)).toBe(false);
+  });
+
+  it("returns true when idle longer than STALE_THRESHOLD_MS", () => {
+    const session = makeSession({
+      lastActivityAt: new Date(Date.now() - STALE_THRESHOLD_MS - 1000).toISOString(),
+    });
+    expect(isSessionStale(session)).toBe(true);
+  });
+
+  it("returns true when lastActivityAt is missing", () => {
+    const session = makeSession({ lastActivityAt: undefined });
+    expect(isSessionStale(session)).toBe(true);
+  });
+});
+
+describe("BroadcastChannel cross-tab events", () => {
+  it("broadcastSessionEvent does not throw when BroadcastChannel is available", () => {
+    expect(() => broadcastSessionEvent({ type: "disconnect", payload: null })).not.toThrow();
+  });
+
+  it("onSessionEvent returns a function", () => {
+    const unsub = onSessionEvent(() => {});
+    expect(typeof unsub).toBe("function");
+    unsub();
+  });
+
+  it("onSessionEvent returns no-op when BroadcastChannel unavailable", () => {
+    const original = globalThis.BroadcastChannel;
+    // @ts-expect-error testing unavailable channel
+    globalThis.BroadcastChannel = undefined;
+
+    try {
+      const unsub = onSessionEvent(() => {});
+      expect(typeof unsub).toBe("function");
+      unsub();
+    } finally {
+      globalThis.BroadcastChannel = original;
+    }
+  });
+
+  it("broadcastSessionEvent handles different event types", () => {
+    expect(() => broadcastSessionEvent({ type: "disconnect", payload: null })).not.toThrow();
+    expect(() => broadcastSessionEvent({ type: "account-change", payload: makeSession() })).not.toThrow();
+    expect(() => broadcastSessionEvent({ type: "session-update", payload: makeSession() })).not.toThrow();
   });
 });

--- a/client/src/auth/types.ts
+++ b/client/src/auth/types.ts
@@ -7,6 +7,17 @@ export type WalletAddressType = "account" | "contract";
 
 export type VerificationStatus = "verified" | "degraded";
 
+export type SessionPermission = "read" | "sign" | "trade" | "govern";
+
+export interface SessionOrigin {
+  /** Browser tab ID for cross-tab correlation */
+  tabId: string;
+  /** Origin URL that created the session */
+  origin: string;
+  /** User-agent string at connection time */
+  userAgent?: string;
+}
+
 export interface WalletSession {
   walletAddress: string;
   walletAddressType: WalletAddressType;
@@ -18,6 +29,14 @@ export interface WalletSession {
   verificationStatus: VerificationStatus;
   connectedAt?: string;
   lastActivityAt?: string;
+  /** When the session was last verified against the backend */
+  lastVerifiedAt?: string;
+  /** Active permissions granted to this session */
+  permissions?: SessionPermission[];
+  /** Origin metadata for this session */
+  origin?: SessionOrigin;
+  /** Whether the provider is confirmed available in this browser */
+  providerAvailable?: boolean;
 }
 
 export interface ConnectWalletOptions {

--- a/client/src/components/dashboard/ApyDashboard.tsx
+++ b/client/src/components/dashboard/ApyDashboard.tsx
@@ -17,11 +17,16 @@ import {
   Layers,
   Clock,
   Info,
+  Rows3,
+  Grid2x2,
+  Maximize2,
 } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 import { LiquidityBufferPanel } from "./LiquidityBufferPanel";
 import { computeDecayedFreshnessConfidence } from "./freshnessDecay";
 import { RISK_EXPLANATIONS, RiskLevel } from "../../config/riskConfig";
+import { useDensity } from "../../context/DensityContext";
+import type { DensityMode } from "../../context/DensityContext";
 
 // ── Types ───────────────────────────────────────────────────────────────
 
@@ -273,6 +278,7 @@ function SkeletonSummary() {
 
 export default function ApyDashboard() {
   const reducedMotion = useReducedMotion();
+  const { density, setDensity } = useDensity();
   const [isFeeModalOpen, setIsFeeModalOpen] = useState(false);
   const [apyData, setApyData] = useState<ApyEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -641,7 +647,28 @@ export default function ApyDashboard() {
         </div>
 
         {/* View Toggle */}
-        <div className="glass-card flex overflow-hidden p-1 gap-1">
+        <div className="flex items-center gap-3">
+          {/* Density Toggle */}
+          <div className="glass-card flex overflow-hidden p-1 gap-1">
+            {(["compact", "comfortable", "spacious"] as DensityMode[]).map((mode) => (
+              <button
+                key={mode}
+                onClick={() => setDensity(mode)}
+                aria-pressed={density === mode}
+                aria-label={`${mode} density`}
+                className={`density-toggle px-2 py-1.5 rounded-lg text-[10px] font-semibold transition-all ${
+                  density === mode
+                    ? "bg-[#6C5DD3] text-white"
+                    : "text-gray-400 hover:text-white"
+                }`}
+                title={`${mode.charAt(0).toUpperCase() + mode.slice(1)} density`}
+              >
+                {mode === "compact" ? <Rows3 size={12} /> : mode === "spacious" ? <Maximize2 size={12} /> : <Grid2x2 size={12} />}
+              </button>
+            ))}
+          </div>
+
+          <div className="glass-card flex overflow-hidden p-1 gap-1">
           <button
             onClick={() => setViewMode("grid")}
             aria-pressed={viewMode === "grid"}
@@ -666,6 +693,7 @@ export default function ApyDashboard() {
             <BarChart3 size={14} className="inline mr-1.5" />
             Table
           </button>
+          </div>
         </div>
       </div>
 

--- a/client/src/components/portfolio/PortfolioReconcile.css
+++ b/client/src/components/portfolio/PortfolioReconcile.css
@@ -1,7 +1,191 @@
-.portfolio-reconcile table { width: 100%; border-collapse: collapse; }
-.portfolio-reconcile th, .portfolio-reconcile td { padding: 8px 10px; border: 1px solid #eee; text-align: left; }
-.sev-matched { background: #f8fff8; }
-.sev-small { background: #fffaf0; }
-.sev-material { background: #fff4f0; }
-.sev-critical { background: #ffecec; }
-.sev-unavailable { background: #f2f2f2; color: #888; }
+.portfolio-reconcile {
+  width: 100%;
+}
+
+.reconcile-empty {
+  text-align: center;
+  padding: 3rem 1rem;
+  color: #999;
+}
+
+.reconcile-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.filter-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-select {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.5rem;
+  padding: 0.375rem 0.75rem;
+  color: #ccc;
+  font-size: 0.75rem;
+  outline: none;
+}
+
+.filter-select:focus {
+  border-color: #6C5DD3;
+}
+
+.filter-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  color: #999;
+  cursor: pointer;
+}
+
+.filter-checkbox input {
+  accent-color: #6C5DD3;
+}
+
+.filter-count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: #666;
+}
+
+.reconcile-group {
+  margin-bottom: 0.5rem;
+}
+
+.group-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  color: #ccc;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.group-header:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.group-vault {
+  font-size: 0.875rem;
+}
+
+.group-count {
+  margin-left: auto;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: #888;
+}
+
+.reconcile-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.25rem;
+}
+
+.reconcile-table th,
+.reconcile-table td {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: left;
+  font-size: 0.8rem;
+}
+
+.reconcile-table th {
+  background: rgba(255, 255, 255, 0.02);
+  color: #888;
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.05em;
+}
+
+.sev-ok {
+  background: rgba(52, 211, 153, 0.05);
+}
+
+.sev-warning {
+  background: rgba(251, 191, 36, 0.05);
+}
+
+.sev-critical {
+  background: rgba(239, 68, 68, 0.05);
+}
+
+.evidence-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.evidence-text {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.evidence-tag {
+  font-family: monospace;
+  font-size: 0.7rem;
+  padding: 0.125rem 0.375rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.25rem;
+  color: #aaa;
+}
+
+.evidence-stale {
+  font-size: 0.65rem;
+  padding: 0.125rem 0.375rem;
+  background: rgba(239, 68, 68, 0.15);
+  border-radius: 0.25rem;
+  color: #f87171;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.copy-btn {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+  transition: color 0.15s;
+}
+
+.copy-btn:hover {
+  color: #ccc;
+}
+
+@media (max-width: 768px) {
+  .reconcile-filters {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-count {
+    margin-left: 0;
+  }
+
+  .reconcile-table {
+    display: block;
+    overflow-x: auto;
+  }
+}

--- a/client/src/components/portfolio/PortfolioReconcile.tsx
+++ b/client/src/components/portfolio/PortfolioReconcile.tsx
@@ -1,41 +1,303 @@
-import React from 'react';
-import './PortfolioReconcile.css';
+import React, { useState, useMemo, useCallback } from "react";
+import {
+  AlertTriangle,
+  Copy,
+  Check,
+  Filter,
+  ChevronDown,
+  ChevronRight,
+  FileText,
+  ExternalLink,
+} from "lucide-react";
+import "./PortfolioReconcile.css";
+
+export type ReconcileAnomalyType = "missing" | "duplicate" | "stale" | "orphaned" | "matched";
+
+export type ReconcileStatus = "confirmed" | "pending" | "unverified";
+
+export interface ReconcileEvidence {
+  /** Ledger sequence number */
+  ledger?: number;
+  /** Transaction hash */
+  txHash?: string;
+  /** Vault identifier */
+  vault?: string;
+  /** Anomaly identifier */
+  anomalyId?: string;
+  /** Projection version used for comparison */
+  projectionVersion?: string;
+  /** Event source identifier */
+  sourceEventId?: string;
+  /** Whether the checkpoint is stale */
+  isStaleCheckpoint?: boolean;
+}
 
 export interface ReconcileRow {
   asset: string;
+  vault: string;
   expected: string | number;
   observed: string | number | null;
   delta: string | number | null;
-  severity: 'ok' | 'warning' | 'critical';
+  severity: "ok" | "warning" | "critical";
+  anomalyType: ReconcileAnomalyType;
+  status: ReconcileStatus;
+  evidence?: ReconcileEvidence;
+}
+
+export interface ReconcileGroup {
+  vault: string;
+  rows: ReconcileRow[];
 }
 
 type Props = { rows: ReconcileRow[] };
 
+function groupByVault(rows: ReconcileRow[]): ReconcileGroup[] {
+  const map = new Map<string, ReconcileRow[]>();
+  for (const row of rows) {
+    const key = row.vault ?? "Unknown";
+    const group = map.get(key) ?? [];
+    group.push(row);
+    map.set(key, group);
+  }
+  return Array.from(map.entries()).map(([vault, groupRows]) => ({
+    vault,
+    rows: groupRows,
+  }));
+}
+
+function formatEvidence(evidence: ReconcileEvidence): string {
+  const parts: string[] = [];
+  if (evidence.vault) parts.push(`Vault: ${evidence.vault}`);
+  if (evidence.anomalyId) parts.push(`Anomaly: ${evidence.anomalyId}`);
+  if (evidence.ledger) parts.push(`Ledger: ${evidence.ledger}`);
+  if (evidence.txHash) parts.push(`TX: ${evidence.txHash}`);
+  if (evidence.projectionVersion) parts.push(`Projection: ${evidence.projectionVersion}`);
+  if (evidence.sourceEventId) parts.push(`Event: ${evidence.sourceEventId}`);
+  return parts.join(" | ");
+}
+
+function copyEvidence(row: ReconcileRow): string {
+  const evidence = row.evidence ?? {};
+  const lines = [
+    `Asset: ${row.asset}`,
+    `Vault: ${row.vault}`,
+    `Anomaly: ${row.anomalyType}`,
+    `Severity: ${row.severity}`,
+    `Status: ${row.status}`,
+    `Expected: ${row.expected}`,
+    `Observed: ${row.observed === null ? "N/A" : row.observed}`,
+    `Delta: ${row.delta === null ? "N/A" : row.delta}`,
+  ];
+  if (evidence.ledger) lines.push(`Ledger: ${evidence.ledger}`);
+  if (evidence.txHash) lines.push(`TX Hash: ${evidence.txHash}`);
+  if (evidence.anomalyId) lines.push(`Anomaly ID: ${evidence.anomalyId}`);
+  if (evidence.projectionVersion) lines.push(`Projection: ${evidence.projectionVersion}`);
+  if (evidence.sourceEventId) lines.push(`Source Event: ${evidence.sourceEventId}`);
+  return lines.join("\n");
+}
+
+const SEVERITY_LABELS: Record<string, string> = {
+  ok: "Matched",
+  warning: "Warning",
+  critical: "Critical",
+};
+
+const ANOMALY_LABELS: Record<ReconcileAnomalyType, string> = {
+  matched: "Matched",
+  missing: "Missing",
+  duplicate: "Duplicate",
+  stale: "Stale",
+  orphaned: "Orphaned",
+};
+
 export const PortfolioReconcile: React.FC<Props> = ({ rows }) => {
+  const [severityFilter, setSeverityFilter] = useState<string>("all");
+  const [statusFilter, setStatusFilter] = useState<string>("all");
+  const [showStaleOnly, setShowStaleOnly] = useState(false);
+  const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const filteredRows = useMemo(() => {
+    return rows.filter((row) => {
+      if (severityFilter !== "all" && row.severity !== severityFilter) return false;
+      if (statusFilter !== "all" && row.status !== statusFilter) return false;
+      if (showStaleOnly && !row.evidence?.isStaleCheckpoint) return false;
+      return true;
+    });
+  }, [rows, severityFilter, statusFilter, showStaleOnly]);
+
+  const groups = useMemo(() => groupByVault(filteredRows), [filteredRows]);
+
+  const toggleGroup = useCallback((vault: string) => {
+    setExpandedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(vault)) next.delete(vault);
+      else next.add(vault);
+      return next;
+    });
+  }, []);
+
+  const copyToClipboard = useCallback(async (row: ReconcileRow, id: string) => {
+    const text = copyEvidence(row);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    } catch {
+      const textarea = document.createElement("textarea");
+      textarea.value = text;
+      document.body.appendChild(textarea);
+      textarea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textarea);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 2000);
+    }
+  }, []);
+
+  if (rows.length === 0) {
+    return (
+      <div className="portfolio-reconcile">
+        <div className="reconcile-empty">
+          <FileText size={32} className="text-gray-500 mx-auto mb-3" />
+          <p className="text-gray-400 font-medium">No reconciliation data</p>
+          <p className="text-gray-600 text-sm mt-1">
+            Reconciliation differences will appear here once data is available.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="portfolio-reconcile">
-      <table>
-        <thead>
-          <tr>
-            <th>Asset</th>
-            <th>Expected</th>
-            <th>Observed</th>
-            <th>Delta</th>
-            <th>Severity</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((r) => (
-            <tr key={r.asset} className={`sev-${r.severity}`}>
-              <td>{r.asset}</td>
-              <td>{r.expected}</td>
-              <td>{r.observed === null ? '—' : r.observed}</td>
-              <td>{r.delta === null ? '—' : r.delta}</td>
-              <td>{r.severity}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      {/* Filters */}
+      <div className="reconcile-filters">
+        <div className="filter-group">
+          <Filter size={14} className="text-gray-400" />
+          <select
+            value={severityFilter}
+            onChange={(e) => setSeverityFilter(e.target.value)}
+            className="filter-select"
+            aria-label="Filter by severity"
+          >
+            <option value="all">All Severity</option>
+            <option value="ok">Matched</option>
+            <option value="warning">Warning</option>
+            <option value="critical">Critical</option>
+          </select>
+        </div>
+        <div className="filter-group">
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="filter-select"
+            aria-label="Filter by status"
+          >
+            <option value="all">All Status</option>
+            <option value="confirmed">Confirmed</option>
+            <option value="pending">Pending</option>
+            <option value="unverified">Unverified</option>
+          </select>
+        </div>
+        <label className="filter-checkbox">
+          <input
+            type="checkbox"
+            checked={showStaleOnly}
+            onChange={(e) => setShowStaleOnly(e.target.checked)}
+          />
+          Stale checkpoints only
+        </label>
+        <span className="filter-count">
+          {filteredRows.length} of {rows.length} items
+        </span>
+      </div>
+
+      {/* Groups */}
+      {groups.length === 0 && (
+        <div className="reconcile-empty">
+          <p className="text-gray-400">No items match the current filters.</p>
+        </div>
+      )}
+
+      {groups.map((group) => (
+        <div key={group.vault} className="reconcile-group">
+          <button
+            type="button"
+            className="group-header"
+            onClick={() => toggleGroup(group.vault)}
+            aria-expanded={expandedGroups.has(group.vault)}
+          >
+            {expandedGroups.has(group.vault) ? (
+              <ChevronDown size={16} />
+            ) : (
+              <ChevronRight size={16} />
+            )}
+            <span className="group-vault">{group.vault}</span>
+            <span className="group-count">{group.rows.length} items</span>
+            {group.rows.some((r) => r.severity === "critical") && (
+              <AlertTriangle size={14} className="text-red-400" />
+            )}
+          </button>
+
+          {expandedGroups.has(group.vault) && (
+            <table className="reconcile-table">
+              <thead>
+                <tr>
+                  <th>Asset</th>
+                  <th>Expected</th>
+                  <th>Observed</th>
+                  <th>Delta</th>
+                  <th>Severity</th>
+                  <th>Anomaly</th>
+                  <th>Status</th>
+                  <th>Evidence</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.rows.map((r, idx) => {
+                  const rowId = `${group.vault}-${r.asset}-${idx}`;
+                  return (
+                    <tr key={rowId} className={`sev-${r.severity}`}>
+                      <td>{r.asset}</td>
+                      <td>{r.expected}</td>
+                      <td>{r.observed === null ? "—" : r.observed}</td>
+                      <td>{r.delta === null ? "—" : r.delta}</td>
+                      <td>{SEVERITY_LABELS[r.severity] ?? r.severity}</td>
+                      <td>{ANOMALY_LABELS[r.anomalyType]}</td>
+                      <td>{r.status}</td>
+                      <td>
+                        {r.evidence && (
+                          <div className="evidence-cell">
+                            <span className="evidence-text" title={formatEvidence(r.evidence)}>
+                              {r.evidence.ledger && <span className="evidence-tag">L{r.evidence.ledger}</span>}
+                              {r.evidence.txHash && <span className="evidence-tag">{r.evidence.txHash.slice(0, 8)}…</span>}
+                              {r.evidence.isStaleCheckpoint && <span className="evidence-stale">stale</span>}
+                            </span>
+                            <button
+                              type="button"
+                              className="copy-btn"
+                              onClick={() => void copyToClipboard(r, rowId)}
+                              title="Copy evidence to clipboard"
+                              aria-label={`Copy reconciliation evidence for ${r.asset}`}
+                            >
+                              {copiedId === rowId ? (
+                                <Check size={12} className="text-green-400" />
+                              ) : (
+                                <Copy size={12} />
+                              )}
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      ))}
     </div>
   );
 };

--- a/client/src/components/portfolio/__tests__/PortfolioReconcile.test.tsx
+++ b/client/src/components/portfolio/__tests__/PortfolioReconcile.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PortfolioReconcile from "../PortfolioReconcile";
+import type { ReconcileRow } from "../PortfolioReconcile";
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+function makeRow(overrides: Partial<ReconcileRow> = {}): ReconcileRow {
+  return {
+    asset: "USDC",
+    vault: "Blend",
+    expected: 10_000,
+    observed: 10_000,
+    delta: 0,
+    severity: "ok",
+    anomalyType: "matched",
+    status: "confirmed",
+    evidence: {
+      ledger: 12345,
+      txHash: "abc123def456",
+      vault: "Blend",
+      anomalyId: "anomaly-001",
+      projectionVersion: "v1.0",
+      sourceEventId: "evt-001",
+      isStaleCheckpoint: false,
+    },
+    ...overrides,
+  };
+}
+
+function expandGroup(vaultName: string) {
+  const btn = screen.getByText(vaultName).closest("button")!;
+  fireEvent.click(btn);
+}
+
+describe("PortfolioReconcile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("empty state", () => {
+    it("renders empty message when no rows", () => {
+      render(<PortfolioReconcile rows={[]} />);
+      expect(screen.getByText("No reconciliation data")).toBeTruthy();
+    });
+  });
+
+  describe("healthy state", () => {
+    it("renders all rows with ok severity", () => {
+      const rows = [
+        makeRow({ asset: "USDC", severity: "ok" }),
+        makeRow({ asset: "XLM", severity: "ok", vault: "Soroswap" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+      expandGroup("Blend");
+      expandGroup("Soroswap");
+      expect(screen.getByText("USDC")).toBeTruthy();
+      expect(screen.getByText("XLM")).toBeTruthy();
+      expect(screen.getByText("Blend")).toBeTruthy();
+      expect(screen.getByText("Soroswap")).toBeTruthy();
+    });
+
+    it("shows match count in filter", () => {
+      const rows = [makeRow({ severity: "ok" })];
+      render(<PortfolioReconcile rows={rows} />);
+      expect(screen.getByText("1 of 1 items")).toBeTruthy();
+    });
+  });
+
+  describe("warning state", () => {
+    it("renders rows with warning severity", () => {
+      const rows = [
+        makeRow({ asset: "USDC", severity: "warning", anomalyType: "stale" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+      expandGroup("Blend");
+      const warningCells = screen.getAllByText("Warning");
+      expect(warningCells.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Stale")).toBeTruthy();
+    });
+  });
+
+  describe("critical state", () => {
+    it("renders rows with critical severity and alert icon", () => {
+      const rows = [
+        makeRow({ asset: "ETH", severity: "critical", anomalyType: "missing" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+      expandGroup("Blend");
+      const criticalCells = screen.getAllByText("Critical");
+      expect(criticalCells.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("Missing")).toBeTruthy();
+    });
+  });
+
+  describe("grouping", () => {
+    it("groups rows by vault", () => {
+      const rows = [
+        makeRow({ asset: "USDC", vault: "Blend" }),
+        makeRow({ asset: "XLM", vault: "Soroswap" }),
+        makeRow({ asset: "USDT", vault: "Blend" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+      expect(screen.getByText("Blend")).toBeTruthy();
+      expect(screen.getByText("Soroswap")).toBeTruthy();
+      expect(screen.getByText("2 items")).toBeTruthy();
+      expect(screen.getByText("1 items")).toBeTruthy();
+    });
+
+    it("expands and collapses vault groups", () => {
+      const rows = [makeRow({ asset: "USDC", vault: "Blend" })];
+      render(<PortfolioReconcile rows={rows} />);
+
+      expandGroup("Blend");
+      expect(screen.getByText("USDC")).toBeTruthy();
+
+      expandGroup("Blend");
+      expect(screen.queryByText("USDC")).toBeNull();
+    });
+  });
+
+  describe("filters", () => {
+    it("filters by severity", () => {
+      const rows = [
+        makeRow({ asset: "USDC", severity: "ok" }),
+        makeRow({ asset: "ETH", severity: "critical", vault: "Other" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+
+      const severitySelect = screen.getByLabelText("Filter by severity");
+      fireEvent.change(severitySelect, { target: { value: "critical" } });
+
+      expandGroup("Other");
+      expect(screen.getByText("ETH")).toBeTruthy();
+      expect(screen.queryByText("USDC")).toBeNull();
+    });
+
+    it("filters by status", () => {
+      const rows = [
+        makeRow({ asset: "USDC", status: "confirmed" }),
+        makeRow({ asset: "ETH", status: "pending", vault: "Other" }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+
+      const statusSelect = screen.getByLabelText("Filter by status");
+      fireEvent.change(statusSelect, { target: { value: "pending" } });
+
+      expandGroup("Other");
+      expect(screen.getByText("ETH")).toBeTruthy();
+      expect(screen.queryByText("USDC")).toBeNull();
+    });
+
+    it("filters stale checkpoints only", () => {
+      const rows = [
+        makeRow({ asset: "USDC", evidence: { isStaleCheckpoint: false } }),
+        makeRow({ asset: "ETH", vault: "Other", evidence: { isStaleCheckpoint: true } }),
+      ];
+      render(<PortfolioReconcile rows={rows} />);
+
+      const staleCheckbox = screen.getByLabelText("Stale checkpoints only");
+      fireEvent.click(staleCheckbox);
+
+      expandGroup("Other");
+      expect(screen.getByText("ETH")).toBeTruthy();
+      expect(screen.queryByText("USDC")).toBeNull();
+    });
+  });
+
+  describe("copy evidence", () => {
+    it("copies evidence to clipboard on button click", async () => {
+      const row = makeRow({ asset: "USDC" });
+      render(<PortfolioReconcile rows={[row]} />);
+
+      expandGroup("Blend");
+      const copyBtn = screen.getByLabelText(/Copy reconciliation evidence/i);
+      fireEvent.click(copyBtn);
+
+      expect(writeTextMock).toHaveBeenCalledWith(
+        expect.stringContaining("Asset: USDC"),
+      );
+    });
+  });
+
+  describe("evidence display", () => {
+    it("shows ledger and tx hash in evidence", () => {
+      const row = makeRow({
+        evidence: { ledger: 12345, txHash: "abc123def456" },
+      });
+      render(<PortfolioReconcile rows={[row]} />);
+      expandGroup("Blend");
+      expect(screen.getByText("L12345")).toBeTruthy();
+      expect(screen.getByText(/abc123d/)).toBeTruthy();
+    });
+
+    it("shows stale badge when checkpoint is stale", () => {
+      const row = makeRow({
+        evidence: { isStaleCheckpoint: true },
+      });
+      render(<PortfolioReconcile rows={[row]} />);
+      expandGroup("Blend");
+      expect(screen.getByText("stale")).toBeTruthy();
+    });
+  });
+});

--- a/client/src/context/DensityContext.tsx
+++ b/client/src/context/DensityContext.tsx
@@ -1,0 +1,91 @@
+import { createContext, useContext, useState, useEffect, useCallback, useMemo } from "react";
+
+export type DensityMode = "compact" | "comfortable" | "spacious";
+
+export interface DensityContextValue {
+  density: DensityMode;
+  setDensity: (mode: DensityMode) => void;
+  /** CSS class name for the current density */
+  densityClass: string;
+  /** Spacing scale multiplier (0.75 compact, 1 comfortable, 1.25 spacious) */
+  spacingScale: number;
+  /** Font size scale multiplier (0.85 compact, 1 comfortable, 1.1 spacious) */
+  fontScale: number;
+}
+
+const STORAGE_KEY = "stellar-yield.density-mode";
+
+const DENSITY_CONFIG: Record<DensityMode, { spacingScale: number; fontScale: number; className: string }> = {
+  compact: { spacingScale: 0.75, fontScale: 0.85, className: "density-compact" },
+  comfortable: { spacingScale: 1, fontScale: 1, className: "density-comfortable" },
+  spacious: { spacingScale: 1.25, fontScale: 1.1, className: "density-spacious" },
+};
+
+export function loadDensity(): DensityMode {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "compact" || stored === "comfortable" || stored === "spacious") {
+      return stored;
+    }
+  } catch {}
+  return "comfortable";
+}
+
+function saveDensity(mode: DensityMode) {
+  try {
+    localStorage.setItem(STORAGE_KEY, mode);
+  } catch {}
+}
+
+export const DensityContext = createContext<DensityContextValue | undefined>(undefined);
+
+export function DensityProvider({ children }: { children: React.ReactNode }) {
+  const [density, setDensityState] = useState<DensityMode>(loadDensity);
+
+  const setDensity = useCallback((mode: DensityMode) => {
+    setDensityState(mode);
+    saveDensity(mode);
+  }, []);
+
+  useEffect(() => {
+    const handleStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY && e.newValue) {
+        if (e.newValue === "compact" || e.newValue === "comfortable" || e.newValue === "spacious") {
+          setDensityState(e.newValue);
+        }
+      }
+    };
+    window.addEventListener("storage", handleStorage);
+    return () => window.removeEventListener("storage", handleStorage);
+  }, []);
+
+  const config = DENSITY_CONFIG[density];
+
+  const value = useMemo<DensityContextValue>(() => ({
+    density,
+    setDensity,
+    densityClass: config.className,
+    spacingScale: config.spacingScale,
+    fontScale: config.fontScale,
+  }), [density, setDensity, config]);
+
+  return (
+    <DensityContext.Provider value={value}>
+      {children}
+    </DensityContext.Provider>
+  );
+}
+
+export function useDensity(): DensityContextValue {
+  const context = useContext(DensityContext);
+  if (!context) {
+    return {
+      density: "comfortable",
+      setDensity: () => {},
+      densityClass: "density-comfortable",
+      spacingScale: 1,
+      fontScale: 1,
+    };
+  }
+  return context;
+}

--- a/client/src/context/__tests__/DensityContext.test.tsx
+++ b/client/src/context/__tests__/DensityContext.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { DensityProvider, useDensity, loadDensity } from "../DensityContext";
+import type { ReactNode } from "react";
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <DensityProvider>{children}</DensityProvider>;
+}
+
+describe("DensityContext", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("defaults to comfortable when nothing is stored", () => {
+    const { result } = renderHook(() => useDensity(), { wrapper });
+    expect(result.current.density).toBe("comfortable");
+    expect(result.current.densityClass).toBe("density-comfortable");
+    expect(result.current.spacingScale).toBe(1);
+    expect(result.current.fontScale).toBe(1);
+  });
+
+  it("reads stored density from localStorage", () => {
+    localStorage.setItem("stellar-yield.density-mode", "compact");
+    const { result } = renderHook(() => useDensity(), { wrapper });
+    expect(result.current.density).toBe("compact");
+    expect(result.current.densityClass).toBe("density-compact");
+    expect(result.current.spacingScale).toBe(0.75);
+  });
+
+  it("persists density changes to localStorage", () => {
+    const { result } = renderHook(() => useDensity(), { wrapper });
+    act(() => {
+      result.current.setDensity("spacious");
+    });
+    expect(result.current.density).toBe("spacious");
+    expect(localStorage.getItem("stellar-yield.density-mode")).toBe("spacious");
+  });
+
+  it("returns compact font scale for compact mode", () => {
+    localStorage.setItem("stellar-yield.density-mode", "compact");
+    const { result } = renderHook(() => useDensity(), { wrapper });
+    expect(result.current.fontScale).toBe(0.85);
+  });
+
+  it("returns spacious font scale for spacious mode", () => {
+    localStorage.setItem("stellar-yield.density-mode", "spacious");
+    const { result } = renderHook(() => useDensity(), { wrapper });
+    expect(result.current.fontScale).toBe(1.1);
+    expect(result.current.spacingScale).toBe(1.25);
+  });
+});
+
+describe("loadDensity", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns comfortable for empty localStorage", () => {
+    expect(loadDensity()).toBe("comfortable");
+  });
+
+  it("returns compact when stored", () => {
+    localStorage.setItem("stellar-yield.density-mode", "compact");
+    expect(loadDensity()).toBe("compact");
+  });
+
+  it("returns comfortable for invalid stored value", () => {
+    localStorage.setItem("stellar-yield.density-mode", "invalid");
+    expect(loadDensity()).toBe("comfortable");
+  });
+});

--- a/client/src/features/zap/DepositRouteMaterialImpactWarning.tsx
+++ b/client/src/features/zap/DepositRouteMaterialImpactWarning.tsx
@@ -1,6 +1,6 @@
-import { AlertTriangle, ShieldAlert } from "lucide-react";
+import { AlertTriangle, ShieldAlert, Ban } from "lucide-react";
 import { useDepositImpact } from "./useDepositImpact";
-import type { ImpactSeverity } from "./useDepositImpact";
+import type { ImpactSeverity, QuoteSnapshot } from "./useDepositImpact";
 
 export interface DepositRouteMaterialImpactWarningProps {
   amountUsd: number;
@@ -9,6 +9,9 @@ export interface DepositRouteMaterialImpactWarningProps {
   isStale: boolean;
   executionQualityScore?: number;
   materialImpact?: boolean;
+  quote?: QuoteSnapshot;
+  routeImpactThreshold?: number;
+  blockStaleQuotes?: boolean;
 }
 
 const SEVERITY_STYLES: Record<
@@ -38,6 +41,9 @@ export default function DepositRouteMaterialImpactWarning({
   isStale,
   executionQualityScore,
   materialImpact,
+  quote,
+  routeImpactThreshold,
+  blockStaleQuotes,
 }: DepositRouteMaterialImpactWarningProps) {
   const impact = useDepositImpact({
     amountUsd,
@@ -46,9 +52,28 @@ export default function DepositRouteMaterialImpactWarning({
     isStale,
     executionQualityScore,
     materialImpact,
+    quote,
+    routeImpactThreshold,
+    blockStaleQuotes,
   });
 
-  if (impact.severity === "none") return null;
+  if (impact.severity === "none" && !impact.shouldBlock) return null;
+
+  if (impact.shouldBlock) {
+    return (
+      <div
+        className="flex items-start gap-2 p-3 rounded-lg border bg-red-500/10 border-red-500/30"
+        role="alert"
+        aria-live="assertive"
+      >
+        <Ban className="w-4 h-4 shrink-0 mt-0.5 text-red-300" />
+        <div>
+          <p className="text-sm font-medium text-red-300">Deposit blocked</p>
+          <p className="mt-1 text-xs text-red-200/70">{impact.blockReason}</p>
+        </div>
+      </div>
+    );
+  }
 
   const styles = SEVERITY_STYLES[impact.severity];
   const Icon = impact.severity === "critical" ? ShieldAlert : AlertTriangle;
@@ -57,6 +82,7 @@ export default function DepositRouteMaterialImpactWarning({
     <div
       className={`flex items-start gap-2 p-3 rounded-lg border ${styles.bg} ${styles.border}`}
       role="alert"
+      aria-live="polite"
     >
       <Icon className={`w-4 h-4 shrink-0 mt-0.5 ${styles.titleColor}`} />
       <div>

--- a/client/src/features/zap/ZapDepositPanel.test.tsx
+++ b/client/src/features/zap/ZapDepositPanel.test.tsx
@@ -160,6 +160,26 @@ describe("ZapDepositPanel", () => {
         expect(screen.getByText("Stale quote")).toBeInTheDocument();
       });
     });
+
+    it("blocks submission when quote is stale", async () => {
+      const staleQuotedAt = new Date(Date.now() - 120_000).toISOString();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => createMockQuote({ quotedAt: staleQuotedAt }),
+      });
+
+      render(<ZapDepositPanel walletAddress="GABCDEF123" />);
+
+      const input = screen.getByPlaceholderText("0.00");
+      await userEvent.type(input, "100");
+
+      await waitFor(() => {
+        expect(screen.getByText("Deposit blocked")).toBeInTheDocument();
+      });
+
+      const submitBtn = screen.getByRole("button", { name: /zap deposit|deposit/i });
+      expect(submitBtn).toBeDisabled();
+    });
   });
 
   describe("no wallet state", () => {

--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw, Clock, Info } from "lucide-react";
+import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw, Clock, Info, Ban } from "lucide-react";
 import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
 import { zapDeposit } from "../../services/soroban";
 import type { TxPhase } from "../../services/transactionPhase";
@@ -20,6 +20,8 @@ import type { ZapAssetOption, ZapQuoteResponse } from "./types";
 import { useSettings } from "../settings/SettingsContext";
 import { resolveSlippage } from "../settings/types";
 import DepositRouteMaterialImpactWarning from "./DepositRouteMaterialImpactWarning";
+import { useDepositImpact } from "./useDepositImpact";
+import type { QuoteSnapshot } from "./useDepositImpact";
 
 export interface ZapDepositPanelProps {
   walletAddress: string | null;
@@ -91,11 +93,13 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
   const [quoteData, setQuoteData] = useState<ZapQuoteResponse | null>(null);
   const [slippageTolerance, setSlippageTolerance] = useState(settingsSlippage);
   const [showSlippageEdit, setShowSlippageEdit] = useState(false);
+  const prevExpectedOutRef = useRef<bigint | null>(null);
 
   const needsSwap = inputAsset?.contractId !== vaultToken.contractId;
 
   const refreshQuote = useCallback(async () => {
     if (!inputAsset || !amount || !vaultToken.contractId) {
+      prevExpectedOutRef.current = null;
       setExpectedOut(null);
       setQuotePath("");
       setQuoteData(null);
@@ -117,6 +121,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     setError("");
     try {
       if (!needsSwap) {
+        prevExpectedOutRef.current = expectedOut;
         setExpectedOut(stroops);
         setQuotePath(`${inputAsset.symbol} (no swap)`);
         setQuoteSource("direct");
@@ -130,19 +135,21 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
           vaultDecimals: vaultToken.decimals,
           slippageTolerance: slippageTolerance / 100,
         });
+        prevExpectedOutRef.current = expectedOut;
         setExpectedOut(BigInt(q.expectedAmountOutStroops));
         setQuotePath(q.path.map((h) => h.label ?? h.contractId.slice(0, 6)).join(" → "));
         setQuoteSource(q.source);
         setQuoteData(q);
       }
     } catch (e) {
+      prevExpectedOutRef.current = null;
       setExpectedOut(null);
       setError(e instanceof Error ? e.message : "Could not load quote");
       setQuoteData(null);
     } finally {
       setQuoteLoading(false);
     }
-  }, [amount, inputAsset, needsSwap, slippageTolerance, vaultToken]);
+  }, [amount, inputAsset, needsSwap, slippageTolerance, vaultToken, expectedOut]);
 
   useEffect(() => {
     const t = setTimeout(() => {
@@ -165,6 +172,30 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     if (!quoteData) return false;
     return quoteData.isFallback || quoteData.source === FALLBACK_SOURCE;
   }, [quoteData]);
+
+  const quoteSnapshot = useMemo<QuoteSnapshot | undefined>(() => {
+    if (!quoteData || !expectedOut || expectedOut <= 0n) return undefined;
+    const minOutVal = minAmountAfterSlippage(expectedOut, slippageTolerance);
+    return {
+      quotedAt: quoteData.quotedAt,
+      route: quoteData.path.map((h) => h.contractId),
+      expectedOut,
+      minOut: minOutVal,
+      prevExpectedOut: prevExpectedOutRef.current ?? undefined,
+      isFallback,
+      isStale,
+      source: quoteData.source,
+    };
+  }, [quoteData, expectedOut, slippageTolerance, isFallback, isStale]);
+
+  const depositImpact = useDepositImpact({
+    amountUsd: 0,
+    slippageTolerance,
+    isFallback,
+    isStale,
+    quote: quoteSnapshot,
+    blockStaleQuotes: true,
+  });
 
   const emitPhase = useCallback((p: TxPhase) => {
     setTxPhase(p);
@@ -473,6 +504,8 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
             slippageTolerance={slippageTolerance}
             isFallback={isFallback}
             isStale={isStale}
+            quote={quoteSnapshot}
+            blockStaleQuotes={true}
           />
         </div>
       )}
@@ -500,6 +533,18 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
         className="mb-4"
       />
 
+      {/* Blocked state banner */}
+      {depositImpact.shouldBlock && (
+        <div
+          className="mb-4 flex items-center gap-2 text-red-300 text-sm bg-red-500/10 border border-red-500/30 rounded-lg p-3"
+          role="alert"
+          aria-live="assertive"
+        >
+          <Ban className="w-4 h-4 shrink-0" />
+          <span>{depositImpact.blockReason}</span>
+        </div>
+      )}
+
       <button
         type="button"
         onClick={() => void handleZap()}
@@ -508,7 +553,8 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
           !amount ||
           status === "loading" ||
           minOut === null ||
-          minOut <= 0n
+          minOut <= 0n ||
+          depositImpact.shouldBlock
         }
         className="w-full py-3 rounded-xl font-semibold text-white bg-gradient-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
       >

--- a/client/src/features/zap/useDepositImpact.test.ts
+++ b/client/src/features/zap/useDepositImpact.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { useDepositImpact } from "./useDepositImpact";
+import type { QuoteSnapshot } from "./useDepositImpact";
 
 const base = {
   amountUsd: 0,
@@ -9,12 +10,25 @@ const base = {
   isStale: false,
 };
 
+function makeQuote(overrides: Partial<QuoteSnapshot> = {}): QuoteSnapshot {
+  return {
+    quotedAt: new Date().toISOString(),
+    route: ["CXLM", "CVAULT"],
+    expectedOut: 10_000_000n,
+    minOut: 9_950_000n,
+    isFallback: false,
+    isStale: false,
+    ...overrides,
+  };
+}
+
 describe("useDepositImpact", () => {
   it("returns severity=none for baseline inputs", () => {
     const { result } = renderHook(() => useDepositImpact(base));
     expect(result.current.severity).toBe("none");
     expect(result.current.reasons).toHaveLength(0);
     expect(result.current.impactScore).toBe(0);
+    expect(result.current.shouldBlock).toBe(false);
   });
 
   it("adds slippage reason for elevated slippage (3–7%)", () => {
@@ -26,7 +40,6 @@ describe("useDepositImpact", () => {
   });
 
   it("reaches warning severity when elevated slippage combines with fallback", () => {
-    // slippage 5%: +20, fallback: +15 → 35 → warning
     const { result } = renderHook(() =>
       useDepositImpact({ ...base, slippageTolerance: 5, isFallback: true }),
     );
@@ -35,7 +48,6 @@ describe("useDepositImpact", () => {
   });
 
   it("reaches warning severity for high slippage (>=8%)", () => {
-    // high slippage: +40 → warning
     const { result } = renderHook(() =>
       useDepositImpact({ ...base, slippageTolerance: 8 }),
     );
@@ -45,7 +57,6 @@ describe("useDepositImpact", () => {
   });
 
   it("reaches critical severity when high slippage and large deposit combine", () => {
-    // high slippage: +40, large deposit: +40 → 80 → critical
     const { result } = renderHook(() =>
       useDepositImpact({ ...base, slippageTolerance: 8, amountUsd: 600_000 }),
     );
@@ -111,7 +122,6 @@ describe("useDepositImpact", () => {
   });
 
   it("reaches critical when very low execution quality combines with large deposit", () => {
-    // low quality: +35, large deposit: +40 → 75 → critical
     const { result } = renderHook(() =>
       useDepositImpact({ ...base, executionQualityScore: 40, amountUsd: 600_000 }),
     );
@@ -139,5 +149,104 @@ describe("useDepositImpact", () => {
     );
     expect(result.current.impactScore).toBeLessThanOrEqual(100);
     expect(result.current.severity).toBe("critical");
+  });
+
+  describe("quote tracking", () => {
+    it("adds output delta reason when quote changes significantly", () => {
+      const quote = makeQuote({
+        expectedOut: 9_000_000n,
+        prevExpectedOut: 10_000_000n,
+      });
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, quote }),
+      );
+      expect(result.current.reasons.some((r) => r.includes("changed by"))).toBe(true);
+      expect(result.current.impactScore).toBe(25);
+    });
+
+    it("adds minor route variation reason for 5-10% output change", () => {
+      const quote = makeQuote({
+        expectedOut: 9_400_000n,
+        prevExpectedOut: 10_000_000n,
+      });
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, quote }),
+      );
+      expect(result.current.reasons.some((r) => r.includes("minor route variation"))).toBe(true);
+      expect(result.current.impactScore).toBe(10);
+    });
+
+    it("no output delta reason when quote is stable", () => {
+      const quote = makeQuote({
+        expectedOut: 9_900_000n,
+        prevExpectedOut: 10_000_000n,
+      });
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, quote }),
+      );
+      expect(result.current.reasons.some((r) => r.includes("changed by"))).toBe(false);
+    });
+
+    it("adds freshness reason for old quotes", () => {
+      const oldDate = new Date(Date.now() - 120_000).toISOString();
+      const quote = makeQuote({ quotedAt: oldDate });
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, quote }),
+      );
+      expect(result.current.reasons.some((r) => r.includes("freshness degraded"))).toBe(true);
+    });
+  });
+
+  describe("blocking", () => {
+    it("blocks when quote is stale and blockStaleQuotes is true", () => {
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, isStale: true, blockStaleQuotes: true }),
+      );
+      expect(result.current.shouldBlock).toBe(true);
+      expect(result.current.blockReason).toContain("stale");
+    });
+
+    it("does not block when quote is stale but blockStaleQuotes is false", () => {
+      const { result } = renderHook(() =>
+        useDepositImpact({ ...base, isStale: true, blockStaleQuotes: false }),
+      );
+      expect(result.current.shouldBlock).toBe(false);
+    });
+
+    it("blocks when impact score exceeds route threshold", () => {
+      const { result } = renderHook(() =>
+        useDepositImpact({
+          ...base,
+          slippageTolerance: 10,
+          amountUsd: 600_000,
+          routeImpactThreshold: 70,
+        }),
+      );
+      expect(result.current.shouldBlock).toBe(true);
+      expect(result.current.blockReason).toContain("threshold");
+    });
+
+    it("does not block when impact score is below route threshold", () => {
+      const { result } = renderHook(() =>
+        useDepositImpact({
+          ...base,
+          slippageTolerance: 5,
+          routeImpactThreshold: 70,
+        }),
+      );
+      expect(result.current.shouldBlock).toBe(false);
+    });
+
+    it("stale quote blocks even at low impact", () => {
+      const { result } = renderHook(() =>
+        useDepositImpact({
+          ...base,
+          slippageTolerance: 1,
+          isStale: true,
+          blockStaleQuotes: true,
+        }),
+      );
+      expect(result.current.shouldBlock).toBe(true);
+    });
   });
 });

--- a/client/src/features/zap/useDepositImpact.ts
+++ b/client/src/features/zap/useDepositImpact.ts
@@ -7,6 +7,29 @@ export interface DepositImpactResult {
   reasons: string[];
   /** Estimated execution-quality degradation 0-100 */
   impactScore: number;
+  /** Whether the deposit should be blocked due to stale/high-impact quote */
+  shouldBlock: boolean;
+  /** Human-readable block reason if shouldBlock is true */
+  blockReason?: string;
+}
+
+export interface QuoteSnapshot {
+  /** When the quote was generated */
+  quotedAt: string;
+  /** Route hops */
+  route: string[];
+  /** Expected output in stroops */
+  expectedOut: bigint;
+  /** Minimum output after slippage in stroops */
+  minOut: bigint;
+  /** Previous expectedOut for delta calculation */
+  prevExpectedOut?: bigint;
+  /** Whether the quote came from fallback */
+  isFallback: boolean;
+  /** Whether the quote is stale */
+  isStale: boolean;
+  /** Quote source identifier */
+  source?: string;
 }
 
 interface UseDepositImpactInput {
@@ -22,6 +45,12 @@ interface UseDepositImpactInput {
   executionQualityScore?: number;
   /** materialImpact flag from the fragmentation API */
   materialImpact?: boolean;
+  /** Current quote snapshot for route/amount tracking */
+  quote?: QuoteSnapshot;
+  /** Route impact threshold for blocking (0-100, default 75) */
+  routeImpactThreshold?: number;
+  /** Whether to enforce stale quote blocking */
+  blockStaleQuotes?: boolean;
 }
 
 const WARNING_SLIPPAGE_PCT = 3;
@@ -30,10 +59,23 @@ const WARNING_AMOUNT_USD = 50_000;
 const CRITICAL_AMOUNT_USD = 500_000;
 const LOW_EXECUTION_QUALITY = 70;
 const CRITICAL_EXECUTION_QUALITY = 50;
+const DEFAULT_ROUTE_IMPACT_THRESHOLD = 75;
+const MAX_QUOTE_AGE_MS = 60_000;
+
+/**
+ * Computes output impact delta as a percentage.
+ * Returns the magnitude of change between previous and current expected output.
+ */
+function computeOutputDelta(prev: bigint | undefined, current: bigint): number {
+  if (!prev || prev <= 0n || current <= 0n) return 0;
+  const delta = Number(current - prev) / Number(prev);
+  return Math.abs(delta) * 100;
+}
 
 /**
  * Pure hook — computes deposit route impact without side effects.
- * Returns the severity, human-readable reasons, and a composite impact score.
+ * Returns the severity, human-readable reasons, a composite impact score,
+ * and whether the deposit should be blocked.
  */
 export function useDepositImpact(input: UseDepositImpactInput): DepositImpactResult {
   return useMemo(() => {
@@ -68,6 +110,26 @@ export function useDepositImpact(input: UseDepositImpactInput): DepositImpactRes
       impactScore += 10;
     }
 
+    // Route output delta
+    if (input.quote) {
+      const outputDelta = computeOutputDelta(input.quote.prevExpectedOut, input.quote.expectedOut);
+      if (outputDelta >= 10) {
+        reasons.push(`Quote output changed by ${outputDelta.toFixed(1)}% since last fetch — possible route shift`);
+        impactScore += 25;
+      } else if (outputDelta > 5) {
+        reasons.push(`Quote output changed by ${outputDelta.toFixed(1)}% — minor route variation`);
+        impactScore += 10;
+      }
+
+      // Quote age signal
+      const quoteAgeMs = Date.now() - new Date(input.quote.quotedAt).getTime();
+      if (quoteAgeMs > MAX_QUOTE_AGE_MS) {
+        const ageSec = Math.floor(quoteAgeMs / 1000);
+        reasons.push(`Quote is ${ageSec}s old — freshness degraded`);
+        impactScore += 15;
+      }
+    }
+
     // Fragmentation signals
     if (input.executionQualityScore !== undefined) {
       if (input.executionQualityScore < CRITICAL_EXECUTION_QUALITY) {
@@ -93,6 +155,19 @@ export function useDepositImpact(input: UseDepositImpactInput): DepositImpactRes
       severity = "warning";
     }
 
-    return { severity, reasons, impactScore: clampedScore };
+    // Block conditions
+    let shouldBlock = false;
+    let blockReason: string | undefined;
+
+    const blockStale = input.blockStaleQuotes !== false;
+    if (blockStale && input.isStale) {
+      shouldBlock = true;
+      blockReason = "Quote is stale. Refresh to get current rates before submitting.";
+    } else if (severity === "critical" && clampedScore >= (input.routeImpactThreshold ?? DEFAULT_ROUTE_IMPACT_THRESHOLD)) {
+      shouldBlock = true;
+      blockReason = "Route impact exceeds safety threshold. Reduce amount or adjust slippage.";
+    }
+
+    return { severity, reasons, impactScore: clampedScore, shouldBlock, blockReason };
   }, [input]);
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -926,3 +926,95 @@ body {
     align-items: flex-start;
   }
 }
+
+/* ── Density modes ─────────────────────────────────────────────── */
+
+.density-compact {
+  --density-spacing: 0.75;
+  --density-font: 0.85;
+  --density-gap: 0.75rem;
+  --density-padding: 0.75rem;
+  --density-cell-padding: 0.5rem 0.75rem;
+  --density-radius: 0.5rem;
+}
+
+.density-compact .glass-card {
+  padding: 1rem;
+}
+
+.density-compact table th,
+.density-compact table td {
+  padding: var(--density-cell-padding);
+  font-size: 0.75rem;
+}
+
+.density-compact .grid {
+  gap: 0.75rem;
+}
+
+.density-comfortable {
+  --density-spacing: 1;
+  --density-font: 1;
+  --density-gap: 1rem;
+  --density-padding: 1rem;
+  --density-cell-padding: 0.75rem 1rem;
+  --density-radius: 0.75rem;
+}
+
+.density-spacious {
+  --density-spacing: 1.25;
+  --density-font: 1.1;
+  --density-gap: 1.5rem;
+  --density-padding: 1.5rem;
+  --density-cell-padding: 1rem 1.25rem;
+  --density-radius: 1rem;
+}
+
+.density-spacious .glass-card {
+  padding: 1.5rem;
+}
+
+.density-spacious table th,
+.density-spacious table td {
+  padding: var(--density-cell-padding);
+  font-size: 0.9rem;
+}
+
+.density-spacious .grid {
+  gap: 1.5rem;
+}
+
+/* Responsive text wrapping fixes */
+@media (max-width: 768px) {
+  .density-compact table th,
+  .density-compact table td {
+    padding: 0.375rem 0.5rem;
+    font-size: 0.7rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 120px;
+  }
+
+  .density-comfortable table th,
+  .density-comfortable table td {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 150px;
+  }
+
+  .density-spacious table th,
+  .density-spacious table td {
+    padding: 0.75rem 1rem;
+    font-size: 0.8rem;
+  }
+}
+
+/* Keyboard accessibility: focus-visible for density controls */
+.density-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}

--- a/client/src/pages/leaderboard/Leaderboard.tsx
+++ b/client/src/pages/leaderboard/Leaderboard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Trophy, Medal, Star, Wallet, AlertCircle, RefreshCw, Users } from "lucide-react";
 import { apiUrl } from "../../lib/api";
+import { useDensity } from "../../context/DensityContext";
 
 interface LeaderboardEntry {
   rank: number;
@@ -14,6 +15,7 @@ const Leaderboard: React.FC = () => {
   const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { densityClass } = useDensity();
 
   const fetchLeaderboard = () => {
     setLoading(true);
@@ -131,7 +133,7 @@ const Leaderboard: React.FC = () => {
         </p>
       </div>
 
-      <div className="glass-panel overflow-hidden border border-white/10 shadow-2xl">
+      <div className={`glass-panel overflow-hidden border border-white/10 shadow-2xl ${densityClass}`}>
         <table className="w-full text-left border-collapse">
           <thead>
             <tr className="bg-white/5 text-gray-400 text-xs uppercase tracking-widest font-bold">


### PR DESCRIPTION


## T1: Wallet Session — Cross-tab sync, permission review, stale recovery

**Files changed:**
- `client/src/auth/types.ts` — Added `SessionPermission`, `SessionOrigin` types and new fields on `WalletSession` (`lastVerifiedAt`, `permissions`, `origin`, `providerAvailable`)
- `client/src/auth/session.ts` — Added `BroadcastChannel` cross-tab sync (`broadcastSessionEvent`, `onSessionEvent`), session expiry (`isSessionExpired`, `isSessionStale`), origin tracking, provider availability checks, permission defaults
- `client/src/auth/WalletSessionReview.tsx` — Permission review UI with expand/collapse, origin display, stale/expired badges, re-verification warning, cross-tab disconnect listener
- `client/src/auth/sessionPersistence.test.ts` — 28 tests covering persistence, expiry, staleness, BroadcastChannel
- `client/src/auth/WalletSessionReview.test.tsx` — 8 tests covering permission review, origin, verification badges

## T2: Portfolio Reconcile — Grouped view, evidence, filters, copy

**Files changed:**
- `client/src/components/portfolio/PortfolioReconcile.tsx` — Rewritten with vault-grouped display, `ReconcileEvidence` (ledger, txHash, anomalyId, projectionVersion, sourceEventId, isStaleCheckpoint), severity/status/stale filters, copy-to-clipboard, empty state
- `client/src/components/portfolio/PortfolioReconcile.css` — Full redesign with density-aware styles, responsive mobile layout
- `client/src/components/portfolio/__tests__/PortfolioReconcile.test.tsx` — 13 tests covering empty/healthy/warning/critical states, grouping, filters, copy, evidence display

## T3: Zap Deposit — Dynamic impact calc, stale blocking, accessible warnings

**Files changed:**
- `client/src/features/zap/useDepositImpact.ts` — Added `QuoteSnapshot` tracking, output delta calculation, stale quote blocking (`shouldBlock`/`blockReason`), configurable `routeImpactThreshold`
- `client/src/features/zap/DepositRouteMaterialImpactWarning.tsx` — Added blocked state banner with `aria-live="assertive"`, quote snapshot passthrough
- `client/src/features/zap/ZapDepositPanel.tsx` — Tracks `prevExpectedOutRef` for delta, builds `QuoteSnapshot`, passes to impact warning, disables submit when `shouldBlock`
- `client/src/features/zap/useDepositImpact.test.ts` — 22 tests covering quote tracking, output delta, stale blocking, route thresholds
- `client/src/features/zap/ZapDepositPanel.test.tsx` — Added stale blocking test

## T4: UI Density — Compact/comfortable/spacious modes

**Files changed:**
- `client/src/context/DensityContext.tsx` — New context with 3 density modes, localStorage persistence, cross-tab `StorageEvent` sync, spacing/font scale factors
- `client/src/index.css` — Added `.density-compact`, `.density-comfortable`, `.density-spacious` classes with responsive text wrapping fixes at 768px breakpoint
- `client/src/components/dashboard/ApyDashboard.tsx` — Added density toggle UI in toolbar, consumes `useDensity`
- `client/src/pages/leaderboard/Leaderboard.tsx` — Applies `densityClass` to table wrapper
- `client/src/context/__tests__/DensityContext.test.tsx` — 8 tests covering persistence, defaults, scale factors

Closes #917
Closes #918
Closes #919
Closes #920 