### PR TITLE
SDK transaction lifecycle, client tx timeline, and keeper signer/audit hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ frontend-build.log
 
 # ── Runtime data ─────────────────────────────────────────────────────────────
 server/audit-logs/
+backend/keepers/audit-logs/
 
 # ── Local env overrides ───────────────────────────────────────────────────────
 .env.local

--- a/backend/keepers/package-lock.json
+++ b/backend/keepers/package-lock.json
@@ -29,13 +29,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -54,21 +54,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -95,14 +95,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -112,14 +112,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -139,9 +139,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -149,29 +149,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -191,9 +191,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -211,9 +211,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -221,27 +221,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -306,13 +306,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -348,13 +348,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -474,13 +474,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -490,33 +490,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -524,14 +524,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -569,21 +569,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -592,9 +592,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -603,9 +603,9 @@
       }
     },
     "node_modules/@ioredis/commands": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
       "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
@@ -644,9 +644,9 @@
       }
     },
     "node_modules/@istanbuljs/schema": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -654,17 +654,17 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.3.0.tgz",
-      "integrity": "sha512-PAwCvFJ4696XP2qZj+LAn1BWjZaJ6RjG6c7/lkMaUJnkyMS34ucuIsfqYvfskVNvUI27R/u4P1HMYFnlVXG/Ww==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-30.4.1.tgz",
+      "integrity": "sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -672,38 +672,39 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.3.0.tgz",
-      "integrity": "sha512-U5mVPsBxLSO6xYbf+tgkymLx+iAhvZX43/xI1+ej2ZOPnPdkdO1CzDmFKh2mZBn2s4XZixszHeQnzp1gm/DIxw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
+      "integrity": "sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/reporters": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/pattern": "30.4.0",
+        "@jest/reporters": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "exit-x": "^0.2.2",
+        "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-changed-files": "30.3.0",
-        "jest-config": "30.3.0",
-        "jest-haste-map": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-resolve-dependencies": "30.3.0",
-        "jest-runner": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
-        "jest-watcher": "30.3.0",
-        "pretty-format": "30.3.0",
+        "jest-changed-files": "30.4.1",
+        "jest-config": "30.4.2",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-resolve-dependencies": "30.4.2",
+        "jest-runner": "30.4.2",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -719,9 +720,9 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.3.0.tgz",
-      "integrity": "sha512-cG51MVnLq1ecVUaQ3fr6YuuAOitHK1S4WUJHnsPFE/quQr33ADUx1FfrTCpMCRxvy0Yr9BThKpDjSlcTi91tMA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -729,39 +730,39 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-      "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+      "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.3.0"
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-76Nlh4xJxk2D/9URCn3wFi98d2hb19uWE1idLsTt2ywhvdOldbw3S570hBgn25P4ICUZ/cBjybrBex2g17IDbg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "expect": "30.3.0",
-        "jest-snapshot": "30.3.0"
+        "expect": "30.4.1",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.3.0.tgz",
-      "integrity": "sha512-j0+W5iQQ8hBh7tHZkTQv3q2Fh/M7Je72cIsYqC4OaktgtO7v1So9UTjp6uPBHIaB6beoF/RRsCgMJKvti0wADA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
+      "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -772,18 +773,18 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-      "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+      "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
-        "@sinonjs/fake-timers": "^15.0.0",
+        "@jest/types": "30.4.1",
+        "@sinonjs/fake-timers": "^15.4.0",
         "@types/node": "*",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -800,47 +801,47 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.3.0.tgz",
-      "integrity": "sha512-+owLCBBdfpgL3HU+BD5etr1SvbXpSitJK0is1kiYjJxAAJggYMRQz5hSdd5pq1sSggfxPbw2ld71pt4x5wwViA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.4.1.tgz",
+      "integrity": "sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/expect": "30.3.0",
-        "@jest/types": "30.3.0",
-        "jest-mock": "30.3.0"
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/types": "30.4.1",
+        "jest-mock": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
+      "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.0.1"
+        "jest-regex-util": "30.4.0"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.3.0.tgz",
-      "integrity": "sha512-a09z89S+PkQnL055bVj8+pe2Caed2PBOaczHcXCykW5ngxX9EWx/1uAwncxc/HiU0oZqfwseMjyhxgRjS49qPw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-30.4.1.tgz",
+      "integrity": "sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "@types/node": "*",
         "chalk": "^4.1.2",
@@ -853,9 +854,9 @@
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^5.0.0",
         "istanbul-reports": "^3.1.3",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "slash": "^3.0.0",
         "string-length": "^4.0.2",
         "v8-to-istanbul": "^9.0.1"
@@ -873,9 +874,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -886,13 +887,13 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.3.0.tgz",
-      "integrity": "sha512-ORbRN9sf5PP82v3FXNSwmO1OTDR2vzR2YTaR+E3VkSBZ8zadQE6IqYdYEeFH1NIkeB2HIGdF02dapb6K0Mj05g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.4.1.tgz",
+      "integrity": "sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -917,14 +918,14 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.3.0.tgz",
-      "integrity": "sha512-e/52nJGuD74AKTSe0P4y5wFRlaXP0qmrS17rqOMHeSwm278VyNyXE3gFO/4DTGF9w+65ra3lo3VKj0LBrzmgdQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-30.4.1.tgz",
+      "integrity": "sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "collect-v8-coverage": "^1.0.2"
       },
@@ -933,15 +934,15 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.3.0.tgz",
-      "integrity": "sha512-dgbWy9b8QDlQeRZcv7LNF+/jFiiYHTKho1xirauZ7kVwY7avjFF6uTT0RqlgudB5OuIPagFdVtfFMosjVbk1eA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-30.4.1.tgz",
+      "integrity": "sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.3.0",
+        "@jest/test-result": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
+        "jest-haste-map": "30.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -949,23 +950,23 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.4.1.tgz",
+      "integrity": "sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "babel-plugin-istanbul": "^7.0.1",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
+        "jest-haste-map": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
         "write-file-atomic": "^5.0.1"
@@ -975,14 +976,14 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
+      "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/pattern": "30.0.1",
-        "@jest/schemas": "30.0.5",
+        "@jest/pattern": "30.4.0",
+        "@jest/schemas": "30.4.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1044,9 +1045,9 @@
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
-      "integrity": "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
       "cpu": [
         "arm64"
       ],
@@ -1057,9 +1058,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.3.tgz",
-      "integrity": "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
       "cpu": [
         "x64"
       ],
@@ -1070,9 +1071,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.3.tgz",
-      "integrity": "sha512-fg0uy/dG/nZEXfYilKoRe7yALaNmHoYeIoJuJ7KJ+YyU2bvY8vPv27f7UKhGRpY6euFYqEVhxCFZgAUNQBM3nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
       "cpu": [
         "arm"
       ],
@@ -1083,9 +1084,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.3.tgz",
-      "integrity": "sha512-YxQL+ax0XqBJDZiKimS2XQaf+2wDGVa1enVRGzEvLLVFeqa5kx2bWbtcSXgsxjQB7nRqqIGFIcLteF/sHeVtQg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
       "cpu": [
         "arm64"
       ],
@@ -1096,9 +1097,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.3.tgz",
-      "integrity": "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
       "cpu": [
         "x64"
       ],
@@ -1109,9 +1110,9 @@
       ]
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.3.tgz",
-      "integrity": "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
       "cpu": [
         "x64"
       ],
@@ -1122,16 +1123,22 @@
       ]
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@noble/curves": {
@@ -1179,22 +1186,22 @@
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1209,9 +1216,9 @@
       }
     },
     "node_modules/@sinonjs/fake-timers": {
-      "version": "15.1.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.1.1.tgz",
-      "integrity": "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw==",
+      "version": "15.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.4.0.tgz",
+      "integrity": "sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1228,6 +1235,7 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
       "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.6",
@@ -1293,9 +1301,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1379,9 +1387,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.2.tgz",
+      "integrity": "sha512-d3KvEXBSo/lOAMc2u6fkyDHBvetBHeqD7wm/AcXfLpSOQwlmG9D/aQ0SFswVjv05p7ullQS7Mjohj6/VdbZuTg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1435,9 +1443,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
-      "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1513,16 +1521,16 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
       "cpu": [
         "arm"
       ],
@@ -1534,9 +1542,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-android-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1548,9 +1556,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
       "cpu": [
         "arm64"
       ],
@@ -1562,9 +1570,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
       "cpu": [
         "x64"
       ],
@@ -1576,9 +1584,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-freebsd-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
       "cpu": [
         "x64"
       ],
@@ -1590,9 +1598,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
       "cpu": [
         "arm"
       ],
@@ -1604,9 +1612,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
       "cpu": [
         "arm"
       ],
@@ -1618,9 +1626,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
       "cpu": [
         "arm64"
       ],
@@ -1632,9 +1640,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
       "cpu": [
         "arm64"
       ],
@@ -1645,10 +1653,38 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
       "cpu": [
         "ppc64"
       ],
@@ -1660,9 +1696,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
       "cpu": [
         "riscv64"
       ],
@@ -1674,9 +1710,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
       "cpu": [
         "riscv64"
       ],
@@ -1688,9 +1724,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
       "cpu": [
         "s390x"
       ],
@@ -1702,9 +1738,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
       "cpu": [
         "x64"
       ],
@@ -1716,9 +1752,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
       "cpu": [
         "x64"
       ],
@@ -1729,10 +1765,24 @@
         "linux"
       ]
     },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
       "cpu": [
         "wasm32"
       ],
@@ -1740,16 +1790,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^0.2.11"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
       "cpu": [
         "arm64"
       ],
@@ -1761,9 +1813,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
       "cpu": [
         "ia32"
       ],
@@ -1775,9 +1827,9 @@
       ]
     },
     "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
       "cpu": [
         "x64"
       ],
@@ -1801,35 +1853,10 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1850,6 +1877,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1972,27 +2011,28 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
-      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.4.1.tgz",
+      "integrity": "sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/transform": "30.3.0",
+        "@jest/transform": "30.4.1",
         "@types/babel__core": "^7.20.5",
         "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
+        "babel-preset-jest": "30.4.0",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "slash": "^3.0.0"
@@ -2025,9 +2065,9 @@
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.4.0.tgz",
+      "integrity": "sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2065,13 +2105,13 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.4.0.tgz",
+      "integrity": "sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.3.0",
+        "babel-plugin-jest-hoist": "30.4.0",
         "babel-preset-current-node-syntax": "^1.2.0"
       },
       "engines": {
@@ -2118,9 +2158,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.12",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.12.tgz",
-      "integrity": "sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==",
+      "version": "2.11.3",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.3.tgz",
+      "integrity": "sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2190,9 +2230,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
-      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2213,9 +2253,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -2233,11 +2273,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2301,18 +2341,28 @@
       "license": "MIT"
     },
     "node_modules/bullmq": {
-      "version": "5.71.1",
-      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.71.1.tgz",
-      "integrity": "sha512-kOBfdcsHmO6wwmIjpersoVdYQ7jkjTgky4Yop0loc7QwSdgxliSzD69U9ijZuRrkyCJwz5p5eqxeGeQkJ0YGZQ==",
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/bullmq/-/bullmq-5.81.2.tgz",
+      "integrity": "sha512-Hi9GaVCC6HE9bQP65j/FNv1aL1fcEukTF99ezS5pl1Ud+joCFpNWiPCV45mWdkEmpuacS0XJdMMFGKPIHCwoPg==",
       "license": "MIT",
       "dependencies": {
         "cron-parser": "4.9.0",
-        "ioredis": "5.10.1",
-        "msgpackr": "1.11.5",
+        "ioredis": "5.11.1",
+        "msgpackr": "2.0.4",
         "node-abort-controller": "3.1.1",
-        "semver": "7.7.4",
-        "tslib": "2.8.1",
-        "uuid": "11.1.0"
+        "semver": "7.8.5",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "peerDependencies": {
+        "redis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "redis": {
+          "optional": true
+        }
       }
     },
     "node_modules/bytes": {
@@ -2325,14 +2375,14 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -2392,9 +2442,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2575,9 +2625,9 @@
       }
     },
     "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
-      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10.0"
@@ -2911,9 +2961,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.396",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+      "integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2984,9 +3034,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3110,29 +3160,93 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-30.3.0.tgz",
-      "integrity": "sha512-1zQrciTiQfRdo7qJM1uG4navm8DayFa2TgCSRlzUyNkhcJ6XUZF3hjnpkyr3VhAqPH7i/9GkG7Tv5abz6fqz0Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
+      "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/expect-utils": "30.3.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0"
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
     },
     "node_modules/fast-copy": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.2.tgz",
-      "integrity": "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-4.0.4.tgz",
+      "integrity": "sha512-eVAiWVNPSEGIzDl5yPuLrx8fNMogScXvD9xp1Kzd41FjRIz2I3sSIcxsFeM5EzFfHAfobdvs8ZySffUopljvIA==",
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3216,9 +3330,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3268,19 +3382,40 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/forwarded": {
@@ -3538,9 +3673,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3582,6 +3717,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -3593,9 +3741,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3677,20 +3825,18 @@
       "license": "ISC"
     },
     "node_modules/ioredis": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
-      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
       "license": "MIT",
       "dependencies": {
-        "@ioredis/commands": "1.5.1",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
       },
       "engines": {
         "node": ">=12.22.0"
@@ -3742,13 +3888,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3957,16 +4103,16 @@
       }
     },
     "node_modules/jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-30.3.0.tgz",
-      "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-30.4.2.tgz",
+      "integrity": "sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/core": "30.4.2",
+        "@jest/types": "30.4.1",
         "import-local": "^3.2.0",
-        "jest-cli": "30.3.0"
+        "jest-cli": "30.4.2"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -3984,14 +4130,14 @@
       }
     },
     "node_modules/jest-changed-files": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.3.0.tgz",
-      "integrity": "sha512-B/7Cny6cV5At6M25EWDgf9S617lHivamL8vl6KEpJqkStauzcG4e+WPfDgMMF+H4FVH4A2PLRyvgDJan4441QA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-30.4.1.tgz",
+      "integrity": "sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.1.1",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0"
       },
       "engines": {
@@ -3999,29 +4145,29 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.3.0.tgz",
-      "integrity": "sha512-PyXq5szeSfR/4f1lYqCmmQjh0vqDkURUYi9N6whnHjlRz4IUQfMcXkGLeEoiJtxtyPqgUaUUfyQlApXWBSN1RA==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
+      "integrity": "sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/expect": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/expect": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "co": "^4.6.0",
         "dedent": "^1.6.0",
         "is-generator-fn": "^2.1.0",
-        "jest-each": "30.3.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-each": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "p-limit": "^3.1.0",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "pure-rand": "^7.0.0",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
@@ -4030,22 +4176,39 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
+    "node_modules/jest-circus/node_modules/pure-rand": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
+      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/jest-cli": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.3.0.tgz",
-      "integrity": "sha512-l6Tqx+j1fDXJEW5bqYykDQQ7mQg+9mhWXtnj+tQZrTWYHyHoi6Be8HPumDSA+UiX2/2buEgjA58iJzdj146uCw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-30.4.2.tgz",
+      "integrity": "sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/core": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/core": "30.4.2",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
         "exit-x": "^0.2.2",
         "import-local": "^3.2.0",
-        "jest-config": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-config": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4064,33 +4227,33 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.3.0.tgz",
-      "integrity": "sha512-WPMAkMAtNDY9P/oKObtsRG/6KTrhtgPJoBTmk20uDn4Uy6/3EJnnaZJre/FMT1KVRx8cve1r7/FlMIOfRVWL4w==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-30.4.2.tgz",
+      "integrity": "sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@jest/get-type": "30.1.0",
-        "@jest/pattern": "30.0.1",
-        "@jest/test-sequencer": "30.3.0",
-        "@jest/types": "30.3.0",
-        "babel-jest": "30.3.0",
+        "@jest/pattern": "30.4.0",
+        "@jest/test-sequencer": "30.4.1",
+        "@jest/types": "30.4.1",
+        "babel-jest": "30.4.1",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
         "deepmerge": "^4.3.1",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-circus": "30.3.0",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-runner": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-circus": "30.4.2",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-runner": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "parse-json": "^5.2.0",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "strip-json-comments": "^3.1.1"
       },
@@ -4115,25 +4278,25 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.3.0.tgz",
-      "integrity": "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.3.0",
+        "@jest/diff-sequences": "30.4.0",
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-docblock": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.2.0.tgz",
-      "integrity": "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-30.4.0.tgz",
+      "integrity": "sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4144,56 +4307,56 @@
       }
     },
     "node_modules/jest-each": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.3.0.tgz",
-      "integrity": "sha512-V8eMndg/aZ+3LnCJgSm13IxS5XSBM22QSZc9BtPK8Dek6pm+hfUNfwBdvsB3d342bo1q7wnSkC38zjX259qZNA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-30.4.1.tgz",
+      "integrity": "sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "chalk": "^4.1.2",
-        "jest-util": "30.3.0",
-        "pretty-format": "30.3.0"
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.3.0.tgz",
-      "integrity": "sha512-4i6HItw/JSiJVsC5q0hnKIe/hbYfZLVG9YJ/0pU9Hz2n/9qZe3Rhn5s5CUZA5ORZlcdT/vmAXRMyONXJwPrmYQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-30.4.1.tgz",
+      "integrity": "sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/fake-timers": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-mock": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0"
+        "jest-mock": "30.4.1",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
+      "integrity": "sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-regex-util": "30.4.0",
+        "jest-util": "30.4.1",
+        "jest-worker": "30.4.1",
         "picomatch": "^4.0.3",
         "walker": "^1.0.8"
       },
@@ -4205,49 +4368,50 @@
       }
     },
     "node_modules/jest-leak-detector": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.3.0.tgz",
-      "integrity": "sha512-cuKmUUGIjfXZAiGJ7TbEMx0bcqNdPPI6P1V+7aF+m/FUJqFDxkFR4JqkTu8ZOiU5AaX/x0hZ20KaaIPXQzbMGQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.4.1.tgz",
+      "integrity": "sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.3.0.tgz",
-      "integrity": "sha512-HEtc9uFQgaUHkC7nLSlQL3Tph4Pjxt/yiPvkIrrDCt9jhoLIgxaubo1G+CFOnmHYMxHwwdaSN7mkIFs6ZK8OhA==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
         "chalk": "^4.1.2",
-        "jest-diff": "30.3.0",
-        "pretty-format": "30.3.0"
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-      "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+      "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
+        "jest-util": "30.4.1",
         "picomatch": "^4.0.3",
-        "pretty-format": "30.3.0",
+        "pretty-format": "30.4.1",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -4256,15 +4420,15 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-      "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+      "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
-        "jest-util": "30.3.0"
+        "jest-util": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4289,9 +4453,9 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+      "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4299,18 +4463,18 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.3.0.tgz",
-      "integrity": "sha512-NRtTAHQlpd15F9rUR36jqwelbrDV/dY4vzNte3S2kxCKUJRYNd5/6nTSbYiak1VX5g8IoFF23Uj5TURkUW8O5g==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-30.4.1.tgz",
+      "integrity": "sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
+        "jest-haste-map": "30.4.1",
         "jest-pnp-resolver": "^1.2.3",
-        "jest-util": "30.3.0",
-        "jest-validate": "30.3.0",
+        "jest-util": "30.4.1",
+        "jest-validate": "30.4.1",
         "slash": "^3.0.0",
         "unrs-resolver": "^1.7.11"
       },
@@ -4319,46 +4483,46 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.3.0.tgz",
-      "integrity": "sha512-9ev8s3YN6Hsyz9LV75XUwkCVFlwPbaFn6Wp75qnI0wzAINYWY8Fb3+6y59Rwd3QaS3kKXffHXsZMziMavfz/nw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-30.4.2.tgz",
+      "integrity": "sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "jest-regex-util": "30.0.1",
-        "jest-snapshot": "30.3.0"
+        "jest-regex-util": "30.4.0",
+        "jest-snapshot": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.3.0.tgz",
-      "integrity": "sha512-gDv6C9LGKWDPLia9TSzZwf4h3kMQCqyTpq+95PODnTRDO0g9os48XIYYkS6D236vjpBir2fF63YmJFtqkS5Duw==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
+      "integrity": "sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/console": "30.3.0",
-        "@jest/environment": "30.3.0",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/console": "30.4.1",
+        "@jest/environment": "30.4.1",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
         "exit-x": "^0.2.2",
         "graceful-fs": "^4.2.11",
-        "jest-docblock": "30.2.0",
-        "jest-environment-node": "30.3.0",
-        "jest-haste-map": "30.3.0",
-        "jest-leak-detector": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-resolve": "30.3.0",
-        "jest-runtime": "30.3.0",
-        "jest-util": "30.3.0",
-        "jest-watcher": "30.3.0",
-        "jest-worker": "30.3.0",
+        "jest-docblock": "30.4.0",
+        "jest-environment-node": "30.4.1",
+        "jest-haste-map": "30.4.1",
+        "jest-leak-detector": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-resolve": "30.4.1",
+        "jest-runtime": "30.4.2",
+        "jest-util": "30.4.1",
+        "jest-watcher": "30.4.1",
+        "jest-worker": "30.4.1",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -4367,32 +4531,32 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.3.0.tgz",
-      "integrity": "sha512-CgC+hIBJbuh78HEffkhNKcbXAytQViplcl8xupqeIWyKQF50kCQA8J7GeJCkjisC6hpnC9Muf8jV5RdtdFbGng==",
+      "version": "30.4.2",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-30.4.2.tgz",
+      "integrity": "sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/environment": "30.3.0",
-        "@jest/fake-timers": "30.3.0",
-        "@jest/globals": "30.3.0",
+        "@jest/environment": "30.4.1",
+        "@jest/fake-timers": "30.4.1",
+        "@jest/globals": "30.4.1",
         "@jest/source-map": "30.0.1",
-        "@jest/test-result": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "cjs-module-lexer": "^2.1.0",
         "collect-v8-coverage": "^1.0.2",
         "glob": "^10.5.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-mock": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-resolve": "30.3.0",
-        "jest-snapshot": "30.3.0",
-        "jest-util": "30.3.0",
+        "jest-haste-map": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-mock": "30.4.1",
+        "jest-regex-util": "30.4.0",
+        "jest-resolve": "30.4.1",
+        "jest-snapshot": "30.4.1",
+        "jest-util": "30.4.1",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       },
@@ -4401,9 +4565,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.3.0.tgz",
-      "integrity": "sha512-f14c7atpb4O2DeNhwcvS810Y63wEn8O1HqK/luJ4F6M4NjvxmAKQwBUWjbExUtMxWJQ0wVgmCKymeJK6NZMnfQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
+      "integrity": "sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4412,20 +4576,20 @@
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.3.0",
+        "@jest/expect-utils": "30.4.1",
         "@jest/get-type": "30.1.0",
-        "@jest/snapshot-utils": "30.3.0",
-        "@jest/transform": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/snapshot-utils": "30.4.1",
+        "@jest/transform": "30.4.1",
+        "@jest/types": "30.4.1",
         "babel-preset-current-node-syntax": "^1.2.0",
         "chalk": "^4.1.2",
-        "expect": "30.3.0",
+        "expect": "30.4.1",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.3.0",
-        "jest-matcher-utils": "30.3.0",
-        "jest-message-util": "30.3.0",
-        "jest-util": "30.3.0",
-        "pretty-format": "30.3.0",
+        "jest-diff": "30.4.1",
+        "jest-matcher-utils": "30.4.1",
+        "jest-message-util": "30.4.1",
+        "jest-util": "30.4.1",
+        "pretty-format": "30.4.1",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -4434,13 +4598,13 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+      "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -4452,18 +4616,18 @@
       }
     },
     "node_modules/jest-validate": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.3.0.tgz",
-      "integrity": "sha512-I/xzC8h5G+SHCb2P2gWkJYrNiTbeL47KvKeW5EzplkyxzBRBw1ssSHlI/jXec0ukH2q7x2zAWQm7015iusg62Q==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-30.4.1.tgz",
+      "integrity": "sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jest/get-type": "30.1.0",
-        "@jest/types": "30.3.0",
+        "@jest/types": "30.4.1",
         "camelcase": "^6.3.0",
         "chalk": "^4.1.2",
         "leven": "^3.1.0",
-        "pretty-format": "30.3.0"
+        "pretty-format": "30.4.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -4483,19 +4647,19 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.3.0.tgz",
-      "integrity": "sha512-PJ1d9ThtTR8aMiBWUdcownq9mDdLXsQzJayTk4kmaBRHKvwNQn+ANveuhEBUyNI2hR1TVhvQ8D5kHubbzBHR/w==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-30.4.1.tgz",
+      "integrity": "sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/test-result": "30.3.0",
-        "@jest/types": "30.3.0",
+        "@jest/test-result": "30.4.1",
+        "@jest/types": "30.4.1",
         "@types/node": "*",
         "ansi-escapes": "^4.3.2",
         "chalk": "^4.1.2",
         "emittery": "^0.13.1",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "string-length": "^4.0.2"
       },
       "engines": {
@@ -4503,15 +4667,15 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
+      "integrity": "sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.3.0",
+        "jest-util": "30.4.1",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -4552,9 +4716,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4628,18 +4792,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -4709,12 +4861,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -4737,24 +4893,28 @@
       "license": "MIT"
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -4822,18 +4982,18 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.5",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.5.tgz",
-      "integrity": "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
       "license": "MIT",
       "optionalDependencies": {
-        "msgpackr-extract": "^3.0.2"
+        "msgpackr-extract": "^3.0.4"
       }
     },
     "node_modules/msgpackr-extract": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.3.tgz",
-      "integrity": "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4844,12 +5004,12 @@
         "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
       },
       "optionalDependencies": {
-        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3",
-        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3"
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
       }
     },
     "node_modules/napi-postinstall": {
@@ -4932,11 +5092,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+      "integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -5188,9 +5351,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5315,15 +5478,16 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-      "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
+        "@jest/schemas": "30.4.1",
         "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5391,9 +5555,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
-      "integrity": "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
       "dev": true,
       "funding": [
         {
@@ -5466,10 +5630,19 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/react-is": {
+    "node_modules/react-is-18": {
+      "name": "react-is",
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5540,12 +5713,13 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
@@ -5598,9 +5772,9 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5711,9 +5885,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5742,31 +5916,6 @@
       },
       "engines": {
         "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "type": "opencollective",
@@ -6228,13 +6377,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -6259,9 +6408,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6305,9 +6454,9 @@
       }
     },
     "node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
+      "integrity": "sha512-zLBvqpwr4Esa0kRjcrzGU6zL25lePWaCLMx0RQFrmteozIfeNdaMLpG5U7PeHzvlFkAWaRKA9/KVW4F60iB+qw==",
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -6373,19 +6522,19 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.4.6",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
-      "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
+      "version": "29.4.12",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.12.tgz",
+      "integrity": "sha512-Ov6ClY53Fflh6BGAnY2DlTq1hYDrTycz2PVTXBWFW2CU+9zrEqAp9fWdGXl42EXO5RLSFAcAZ2JFKbP+zBTFfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
-        "handlebars": "^4.7.8",
+        "handlebars": "^4.7.9",
         "json5": "^2.2.3",
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
-        "semver": "^7.7.3",
+        "semver": "^7.8.5",
         "type-fest": "^4.41.0",
         "yargs-parser": "^21.1.1"
       },
@@ -6402,7 +6551,7 @@
         "babel-jest": "^29.0.0 || ^30.0.0",
         "jest": "^29.0.0 || ^30.0.0",
         "jest-util": "^29.0.0 || ^30.0.0",
-        "typescript": ">=4.3 <6"
+        "typescript": ">=4.3 <7"
       },
       "peerDependenciesMeta": {
         "@babel/core": {
@@ -6610,31 +6759,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/type-is/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/type-is/node_modules/mime-types": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -6693,38 +6817,41 @@
       }
     },
     "node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "napi-postinstall": "^0.3.0"
+        "napi-postinstall": "^0.3.4"
       },
       "funding": {
         "url": "https://opencollective.com/unrs-resolver"
       },
       "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -6763,19 +6890,6 @@
       "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
       "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/esm/bin/uuid"
-      }
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -6835,13 +6949,13 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "for-each": "^0.3.5",
         "get-proto": "^1.0.1",
@@ -7005,9 +7119,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/backend/keepers/src/__tests__/CompoundWorker.test.ts
+++ b/backend/keepers/src/__tests__/CompoundWorker.test.ts
@@ -61,6 +61,7 @@ describe('CompoundWorker', () => {
       sampleJobData.vaultContractId,
       'harvest',
       expect.arrayContaining([expect.anything(), expect.anything()]),
+      expect.objectContaining({ workerName: 'CompoundWorker', jobId: 'job-cmp-1' }),
     );
     expect(result).toEqual({ txHash: 'COMPOUND_TX_HASH' });
   });

--- a/backend/keepers/src/__tests__/KeeperAuditLog.test.ts
+++ b/backend/keepers/src/__tests__/KeeperAuditLog.test.ts
@@ -1,0 +1,151 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { createKeeperAuditLog } from '../audit/KeeperAuditLog';
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'keeper-audit-test-'));
+}
+
+describe('KeeperAuditLog', () => {
+  let dir: string;
+  let auditLog: ReturnType<typeof createKeeperAuditLog>;
+
+  beforeEach(() => {
+    dir = makeTempDir();
+    auditLog = createKeeperAuditLog(dir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  function appendSample(overrides: Partial<Parameters<typeof auditLog.appendDecision>[1]> = {}) {
+    return auditLog.appendDecision('compound', {
+      workerName: 'CompoundWorker',
+      jobId: 'job-1',
+      policyVersion: 'v1',
+      contractId: 'CVAULT',
+      method: 'harvest',
+      inputs: { amount: '1000' },
+      decision: 'invoke harvest on CVAULT',
+      simulationResult: { minResourceFee: '100' },
+      ...overrides,
+    });
+  }
+
+  test('appends hash-chained records with an increasing seq', () => {
+    const first = appendSample();
+    const second = appendSample({ jobId: 'job-2' });
+
+    expect(first.seq).toBe(0);
+    expect(second.seq).toBe(1);
+    expect(second.previousHash).toBe(first.hash);
+  });
+
+  test('verifyStreamIntegrity passes for an untouched stream', () => {
+    appendSample();
+    appendSample({ jobId: 'job-2' });
+
+    const result = auditLog.verifyStreamIntegrity('compound');
+    expect(result).toEqual({ isValid: true, brokenAtIndex: null });
+  });
+
+  test('detects tampering: mutating a historical record breaks verification', () => {
+    appendSample();
+    appendSample({ jobId: 'job-2' });
+
+    const file = path.join(dir, 'compound.jsonl');
+    const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+    const mutated = JSON.parse(lines[0]);
+    mutated.decision = 'invoke a different method entirely';
+    lines[0] = JSON.stringify(mutated);
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+
+    const result = auditLog.verifyStreamIntegrity('compound');
+    expect(result.isValid).toBe(false);
+    expect(result.brokenAtIndex).toBe(0);
+    expect(result.reason).toBe('hash-mismatch');
+  });
+
+  test('detects reordering: swapping two records breaks the sequence chain', () => {
+    appendSample();
+    appendSample({ jobId: 'job-2' });
+    appendSample({ jobId: 'job-3' });
+
+    const file = path.join(dir, 'compound.jsonl');
+    const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+    [lines[0], lines[1]] = [lines[1], lines[0]];
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+
+    const result = auditLog.verifyStreamIntegrity('compound');
+    expect(result.isValid).toBe(false);
+    expect(result.brokenAtIndex).toBe(0);
+  });
+
+  test('detects a missing/deleted record as a sequence gap', () => {
+    appendSample();
+    appendSample({ jobId: 'job-2' });
+    appendSample({ jobId: 'job-3' });
+
+    const file = path.join(dir, 'compound.jsonl');
+    const lines = fs.readFileSync(file, 'utf-8').trim().split('\n');
+    lines.splice(1, 1); // delete the middle record
+    fs.writeFileSync(file, lines.join('\n') + '\n');
+
+    const result = auditLog.verifyStreamIntegrity('compound');
+    expect(result.isValid).toBe(false);
+    expect(['sequence-gap', 'chain-break']).toContain(result.reason);
+  });
+
+  test('exportStream returns only records within the given time range', () => {
+    jest.useFakeTimers();
+    try {
+      jest.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+      const first = appendSample();
+
+      jest.setSystemTime(new Date('2026-01-01T00:10:00.000Z'));
+      appendSample({ jobId: 'job-2' });
+
+      const all = auditLog.exportStream('compound');
+      expect(all).toHaveLength(2);
+
+      const onlyFirst = auditLog.exportStream('compound', undefined, first.timestamp);
+      expect(onlyFirst.map((r) => r.jobId)).toEqual(['job-1']);
+
+      const onlySecond = auditLog.exportStream('compound', '2026-01-01T00:05:00.000Z');
+      expect(onlySecond.map((r) => r.jobId)).toEqual(['job-2']);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('redacts a Bearer token and a Stellar secret key before they are persisted', () => {
+    appendSample({
+      inputs: {
+        note: 'Authorization: Bearer abc123.def456-ghi',
+        secret: 'S' + 'A'.repeat(55),
+      },
+    });
+
+    const file = path.join(dir, 'compound.jsonl');
+    const raw = fs.readFileSync(file, 'utf-8');
+    expect(raw).not.toContain('abc123.def456-ghi');
+    expect(raw).not.toContain('S' + 'A'.repeat(55));
+    expect(raw).toContain('[REDACTED]');
+  });
+
+  test('appendDecision creates the stream directory on first write', () => {
+    const freshDir = path.join(dir, 'nested', 'audit-dir');
+    const scopedLog = createKeeperAuditLog(freshDir);
+    scopedLog.appendDecision('liquidation', {
+      workerName: 'LiquidationWorker',
+      policyVersion: 'v1',
+      contractId: 'CSTABLE',
+      method: 'liquidate',
+      decision: 'invoke liquidate on CSTABLE',
+    });
+
+    expect(fs.existsSync(path.join(freshDir, 'liquidation.jsonl'))).toBe(true);
+  });
+});

--- a/backend/keepers/src/__tests__/KeeperSigner.test.ts
+++ b/backend/keepers/src/__tests__/KeeperSigner.test.ts
@@ -1,4 +1,10 @@
-import { KeeperSigner } from '../signer/KeeperSigner';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { KeeperSigner, UnauthorizedOperationError } from '../signer/KeeperSigner';
+import { LocalSignerProvider } from '../signer/SignerProvider';
+import { createKeeperAuditLog } from '../audit/KeeperAuditLog';
+import { logger } from '../utils/logger';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 // IMPORTANT: jest.mock() is hoisted to the top of the file by Babel/ts-jest,
@@ -218,6 +224,12 @@ describe('KeeperSigner', () => {
     const signer = new KeeperSigner(FAKE_SECRET);
     const promise = signer.invokeContract('CCONTRACT', 'harvest', []);
 
+    // Flush the microtask chain up through simulate/sign/send before the
+    // first poll `sleep()` registers its timer.
+    for (let i = 0; i < 3; i++) {
+      await Promise.resolve();
+    }
+
     // Advance fake timers to flush the polling sleep calls
     for (let i = 0; i < 5; i++) {
       await Promise.resolve();
@@ -257,5 +269,85 @@ describe('KeeperSigner', () => {
 
     await expect(promise).rejects.toThrow('did not confirm within timeout');
     jest.useRealTimers();
+  });
+
+  // ── #911: operation allowlist ─────────────────────────────────────────────
+
+  test('invokeContract rejects an unauthorized operation before any account/transaction work', async () => {
+    const signer = new KeeperSigner(FAKE_SECRET);
+
+    await expect(
+      signer.invokeContract('CCONTRACT', 'admin_withdraw', []),
+    ).rejects.toBeInstanceOf(UnauthorizedOperationError);
+
+    const server = getMockServer();
+    expect(server.getAccount).not.toHaveBeenCalled();
+    expect(server.simulateTransaction).not.toHaveBeenCalled();
+  });
+
+  test('a custom provider can authorize a narrower operation set than the default', async () => {
+    const provider = new LocalSignerProvider(FAKE_SECRET, ['harvest']);
+    const signer = new KeeperSigner(provider);
+
+    await expect(
+      signer.invokeContract('CCONTRACT', 'liquidate', []),
+    ).rejects.toBeInstanceOf(UnauthorizedOperationError);
+
+    // The allowed operation still succeeds.
+    const hash = await signer.invokeContract('CCONTRACT', 'harvest', []);
+    expect(hash).toBe('TXHASH123');
+  });
+
+  // ── #911: no key material in logs ─────────────────────────────────────────
+
+  test('no substring of the secret key ever appears in a logger call across a full invoke cycle', async () => {
+    const infoSpy = jest.spyOn(logger, 'info');
+    const errorSpy = jest.spyOn(logger, 'error');
+
+    const signer = new KeeperSigner(FAKE_SECRET);
+    await signer.invokeContract('CCONTRACT', 'liquidate', []);
+
+    const allCallArgs = [...infoSpy.mock.calls, ...errorSpy.mock.calls];
+    const serialized = JSON.stringify(allCallArgs);
+
+    expect(serialized).not.toContain(FAKE_SECRET);
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  // ── #912: audit hook integration ──────────────────────────────────────────
+
+  test('when an auditLog and auditContext are supplied, invokeContract records a decision and a success outcome', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'keeper-signer-audit-'));
+    const auditLog = createKeeperAuditLog(dir);
+    const signer = new KeeperSigner(FAKE_SECRET, { auditLog });
+
+    const hash = await signer.invokeContract('CCONTRACT', 'liquidate', [], {
+      workerName: 'LiquidationWorker',
+      jobId: 'job-42',
+      policyVersion: 'v1',
+    });
+
+    expect(hash).toBe('TXHASH123');
+
+    const records = auditLog.exportStream('LiquidationWorker');
+    expect(records).toHaveLength(2);
+    expect(records[0].txOutcome).toBeNull();
+    expect(records[0].simulationResult).toBeDefined();
+    expect(records[1].txOutcome).toEqual({ status: 'success', hash: 'TXHASH123' });
+    expect(auditLog.verifyStreamIntegrity('LiquidationWorker').isValid).toBe(true);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('invokeContract without an auditContext performs no audit writes even when auditLog is supplied', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'keeper-signer-audit-noop-'));
+    const auditLog = createKeeperAuditLog(dir);
+    const signer = new KeeperSigner(FAKE_SECRET, { auditLog });
+
+    await signer.invokeContract('CCONTRACT', 'liquidate', []);
+
+    expect(fs.existsSync(dir) && fs.readdirSync(dir).length).toBe(0);
+    fs.rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/backend/keepers/src/__tests__/KeeperSignerRegistry.test.ts
+++ b/backend/keepers/src/__tests__/KeeperSignerRegistry.test.ts
@@ -1,0 +1,71 @@
+jest.mock('../utils/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+import { KeeperSignerRegistry } from '../signer/KeeperSignerRegistry';
+import { logger } from '../utils/logger';
+import type { SignerProvider } from '../signer/SignerProvider';
+
+function fakeProvider(id: string, publicKey: string): SignerProvider {
+  return {
+    id,
+    publicKey,
+    allowedOperations: new Set(['harvest', 'liquidate']),
+    sign: jest.fn().mockResolvedValue({} as any),
+  };
+}
+
+describe('KeeperSignerRegistry', () => {
+  test('currentProvider returns the initial provider', () => {
+    const providerA = fakeProvider('local:GAAA', 'GAAA');
+    const registry = new KeeperSignerRegistry(providerA);
+    expect(registry.currentProvider).toBe(providerA);
+  });
+
+  test('rotate() swaps the active provider for subsequent reads', () => {
+    const providerA = fakeProvider('local:GAAA', 'GAAA');
+    const providerB = fakeProvider('local:GBBB', 'GBBB');
+    const registry = new KeeperSignerRegistry(providerA);
+
+    registry.rotate(providerB, 'scheduled key rotation');
+
+    expect(registry.currentProvider).toBe(providerB);
+  });
+
+  test('a job that already captured the pre-rotation provider keeps using it; only new reads see the rotated provider', () => {
+    const providerA = fakeProvider('local:GAAA', 'GAAA');
+    const providerB = fakeProvider('local:GBBB', 'GBBB');
+    const registry = new KeeperSignerRegistry(providerA);
+
+    // Simulate a job dispatched before rotation: it captures the provider
+    // reference at dispatch time, exactly as a worker's process() should.
+    const inFlightProvider = registry.currentProvider;
+
+    registry.rotate(providerB, 'rotation mid-flight');
+
+    // The in-flight job's captured reference is unaffected by the rotation.
+    expect(inFlightProvider).toBe(providerA);
+    expect(inFlightProvider.publicKey).toBe('GAAA');
+
+    // A new job dispatched after rotation reads the rotated provider.
+    const nextJobProvider = registry.currentProvider;
+    expect(nextJobProvider).toBe(providerB);
+    expect(nextJobProvider.publicKey).toBe('GBBB');
+  });
+
+  test('rotate() logs only non-secret provider ids, never key material', () => {
+    const providerA = fakeProvider('local:GAAA', 'GAAA');
+    const providerB = fakeProvider('local:GBBB', 'GBBB');
+    const registry = new KeeperSignerRegistry(providerA);
+
+    registry.rotate(providerB, 'manual rotation');
+
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({ oldProviderId: 'local:GAAA', newProviderId: 'local:GBBB' }),
+      expect.any(String),
+    );
+
+    const loggedPayload = JSON.stringify((logger.info as jest.Mock).mock.calls[0]);
+    expect(loggedPayload).not.toContain('S' + 'A'.repeat(55));
+  });
+});

--- a/backend/keepers/src/__tests__/LiquidationWorker.test.ts
+++ b/backend/keepers/src/__tests__/LiquidationWorker.test.ts
@@ -60,6 +60,7 @@ describe('LiquidationWorker', () => {
       expect.any(String), // contract ID from config
       'liquidate',
       expect.arrayContaining([expect.anything(), expect.anything()]),
+      expect.objectContaining({ workerName: 'LiquidationWorker', jobId: '1' }),
     );
     expect(result).toEqual({ txHash: 'TX_HASH_ABC123' });
   });

--- a/backend/keepers/src/__tests__/SignerProvider.test.ts
+++ b/backend/keepers/src/__tests__/SignerProvider.test.ts
@@ -1,0 +1,105 @@
+jest.mock('@stellar/stellar-sdk', () => {
+  const actual = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actual,
+    Keypair: {
+      fromSecret: jest.fn().mockReturnValue({
+        publicKey: jest.fn().mockReturnValue('GPROVIDER_PUBLIC'),
+        sign: jest.fn(),
+      }),
+    },
+    TransactionBuilder: {
+      ...actual.TransactionBuilder,
+      fromXDR: jest.fn().mockReturnValue({ toXDR: () => 'reconstructed-signed-xdr' }),
+    },
+  };
+});
+
+import {
+  LocalSignerProvider,
+  EnvSignerProvider,
+  ExternalSignerProvider,
+  NotImplementedError,
+  DEFAULT_ALLOWED_OPERATIONS,
+} from '../signer/SignerProvider';
+
+describe('LocalSignerProvider', () => {
+  const FAKE_SECRET = 'SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+
+  test('exposes a non-secret id and the keypair public key', () => {
+    const provider = new LocalSignerProvider(FAKE_SECRET);
+    expect(provider.publicKey).toBe('GPROVIDER_PUBLIC');
+    expect(provider.id).toBe('local:GPROVIDER_PUBLIC');
+    expect(provider.id).not.toContain(FAKE_SECRET);
+  });
+
+  test('defaults to the standard keeper operation allowlist', () => {
+    const provider = new LocalSignerProvider(FAKE_SECRET);
+    for (const op of DEFAULT_ALLOWED_OPERATIONS) {
+      expect(provider.allowedOperations.has(op)).toBe(true);
+    }
+    expect(provider.allowedOperations.has('admin_withdraw')).toBe(false);
+  });
+
+  test('accepts a custom operation allowlist', () => {
+    const provider = new LocalSignerProvider(FAKE_SECRET, ['harvest']);
+    expect(provider.allowedOperations.has('harvest')).toBe(true);
+    expect(provider.allowedOperations.has('liquidate')).toBe(false);
+  });
+
+  test('sign() signs the transaction with the keypair and returns it', async () => {
+    const provider = new LocalSignerProvider(FAKE_SECRET);
+    const tx = { sign: jest.fn() } as any;
+    const result = await provider.sign(tx, 'Test SDF Network ; September 2015');
+    expect(tx.sign).toHaveBeenCalled();
+    expect(result).toBe(tx);
+  });
+});
+
+describe('EnvSignerProvider', () => {
+  const ENV_VAR = 'TEST_KEEPER_SECRET_KEY';
+
+  afterEach(() => {
+    delete process.env[ENV_VAR];
+  });
+
+  test('id is prefixed with "env:" to distinguish it from local providers', () => {
+    const provider = new EnvSignerProvider('SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX');
+    expect(provider.id).toBe('env:GPROVIDER_PUBLIC');
+  });
+
+  test('fromEnvVar reads the secret from the named environment variable', () => {
+    process.env[ENV_VAR] = 'SXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+    const provider = EnvSignerProvider.fromEnvVar(ENV_VAR);
+    expect(provider.publicKey).toBe('GPROVIDER_PUBLIC');
+  });
+
+  test('fromEnvVar throws when the environment variable is unset', () => {
+    expect(() => EnvSignerProvider.fromEnvVar(ENV_VAR)).toThrow(`${ENV_VAR} is not set`);
+  });
+});
+
+describe('ExternalSignerProvider', () => {
+  test('throws NotImplementedError when no sign callback is supplied', async () => {
+    const provider = new ExternalSignerProvider('GEXTERNAL', ['harvest']);
+    const tx = { toXDR: () => 'unsigned-xdr' } as any;
+    await expect(provider.sign(tx, 'passphrase')).rejects.toBeInstanceOf(NotImplementedError);
+  });
+
+  test('delegates to the injected callback and reconstructs the signed transaction', async () => {
+    const signCallback = jest.fn().mockResolvedValue('signed-xdr-from-kms');
+    const provider = new ExternalSignerProvider('GEXTERNAL', ['harvest'], signCallback);
+    const tx = { toXDR: () => 'unsigned-xdr' } as any;
+
+    const result: any = await provider.sign(tx, 'Test SDF Network ; September 2015');
+
+    expect(signCallback).toHaveBeenCalledWith('unsigned-xdr', 'Test SDF Network ; September 2015');
+    expect(result.toXDR()).toBe('reconstructed-signed-xdr');
+  });
+
+  test('never exposes key material through id or publicKey', () => {
+    const provider = new ExternalSignerProvider('GEXTERNAL', ['harvest']);
+    expect(provider.id).toBe('external:GEXTERNAL');
+    expect(provider.publicKey).toBe('GEXTERNAL');
+  });
+});

--- a/backend/keepers/src/__tests__/keeperHealthServer.test.ts
+++ b/backend/keepers/src/__tests__/keeperHealthServer.test.ts
@@ -115,4 +115,44 @@ describe('startKeeperHealthServer', () => {
     const { status } = await httpGet(port, '/unknown');
     expect(status).toBe(404);
   });
+
+  describe('GET /audit/export', () => {
+    it('returns 400 when the "stream" query parameter is missing', async () => {
+      server = startKeeperHealthServer([], 0);
+      const port = await startAndGetPort(server);
+
+      const { status, body } = await httpGet(port, '/audit/export');
+
+      expect(status).toBe(400);
+      expect((body as any).error).toBeDefined();
+    });
+
+    it('returns 200 with the bounded records from the injected audit log', async () => {
+      const exportStream = jest.fn().mockReturnValue([{ id: 'r1', seq: 0 }]);
+
+      server = startKeeperHealthServer([], 0, { exportStream });
+      const port = await startAndGetPort(server);
+
+      const { status, body } = await httpGet(port, '/audit/export?stream=compound&from=2026-01-01&to=2026-02-01');
+
+      expect(status).toBe(200);
+      expect(exportStream).toHaveBeenCalledWith('compound', '2026-01-01', '2026-02-01');
+      expect((body as any).count).toBe(1);
+      expect((body as any).records).toEqual([{ id: 'r1', seq: 0 }]);
+    });
+
+    it('returns 500 when the audit log throws', async () => {
+      const exportStream = jest.fn().mockImplementation(() => {
+        throw new Error('disk error');
+      });
+
+      server = startKeeperHealthServer([], 0, { exportStream });
+      const port = await startAndGetPort(server);
+
+      const { status, body } = await httpGet(port, '/audit/export?stream=compound');
+
+      expect(status).toBe(500);
+      expect((body as any).error).toBeDefined();
+    });
+  });
 });

--- a/backend/keepers/src/api/queueHealth.ts
+++ b/backend/keepers/src/api/queueHealth.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import type { Queue } from 'bullmq';
 import { getQueueHealth } from '../queues';
 import { logger } from '../utils/logger';
+import { keeperAuditLog } from '../audit/KeeperAuditLog';
 
 /**
  * Starts a minimal HTTP server exposing keeper queue health.
@@ -9,6 +10,8 @@ import { logger } from '../utils/logger';
  * GET /health        — liveness probe: always 200 while the process is alive.
  * GET /health/queues — queue depth and failure counts; 200 on success, 503 on error.
  *                      Body `overallStatus` field distinguishes "healthy" from "warning".
+ * GET /audit/export?stream=&from=&to= — bounded export of a keeper decision audit
+ *                      stream (see issue #912); 400 if `stream` is missing, 500 on error.
  *
  * Returns the http.Server instance so callers can close it during graceful shutdown.
  * Port defaults to KEEPER_HEALTH_PORT env var or 3002.
@@ -16,6 +19,7 @@ import { logger } from '../utils/logger';
 export function startKeeperHealthServer(
   queues: Queue[],
   port = Number(process.env.KEEPER_HEALTH_PORT ?? 3002),
+  auditLog: Pick<typeof keeperAuditLog, 'exportStream'> = keeperAuditLog,
 ): http.Server {
   const server = http.createServer((req, res) => {
     const url = req.url ?? '';
@@ -23,6 +27,30 @@ export function startKeeperHealthServer(
     if (req.method === 'GET' && url === '/health') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ status: 'ok', uptime: process.uptime() }));
+      return;
+    }
+
+    if (req.method === 'GET' && url.startsWith('/audit/export')) {
+      const requestUrl = new URL(url, 'http://localhost');
+      const stream = requestUrl.searchParams.get('stream');
+      const from = requestUrl.searchParams.get('from') ?? undefined;
+      const to = requestUrl.searchParams.get('to') ?? undefined;
+
+      if (!stream) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Missing required query parameter "stream"' }));
+        return;
+      }
+
+      try {
+        const records = auditLog.exportStream(stream, from, to);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ stream, count: records.length, records }));
+      } catch (err) {
+        logger.error({ err, stream }, 'Keeper audit export failed');
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Audit export failed' }));
+      }
       return;
     }
 

--- a/backend/keepers/src/audit/KeeperAuditLog.ts
+++ b/backend/keepers/src/audit/KeeperAuditLog.ts
@@ -1,0 +1,238 @@
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { redactSensitive } from './redact';
+
+/**
+ * Tamper-evident, hash-chained audit trail for keeper decisions.
+ *
+ * Each worker "stream" (e.g. `compound`, `liquidation`) gets its own
+ * append-only JSONL file. Every record embeds the SHA-256 hash of the
+ * previous record in that stream (`previousHash`) plus its own content hash
+ * (`hash`) and an HMAC `signature` over that hash — mutating, reordering, or
+ * deleting a historical record breaks the chain for everything after it,
+ * which `verifyStreamIntegrity` detects. This mirrors the hash-chain
+ * algorithm already used for admin-action audit logs in
+ * `server/src/middleware/audit.ts`, adapted for keeper decision records and
+ * extended with a monotonic `seq` field so reordering/missing records (which
+ * that admin-log variant doesn't need to detect) are also caught here.
+ *
+ * Persisted as local JSONL files (no DB dependency) since keepers has no
+ * database client today and cross-service querying isn't required by the
+ * issue this satisfies.
+ */
+
+export interface KeeperTxOutcome {
+  status: 'success' | 'failure';
+  hash?: string;
+  error?: string;
+}
+
+export interface KeeperDecisionInput {
+  workerName: string;
+  jobId?: string;
+  policyVersion: string;
+  contractId: string;
+  method: string;
+  inputs?: unknown;
+  decision: string;
+  simulationResult?: unknown;
+  txOutcome?: KeeperTxOutcome;
+}
+
+export interface KeeperDecisionRecord extends KeeperDecisionInput {
+  id: string;
+  seq: number;
+  timestamp: string;
+  stream: string;
+  previousHash: string;
+  hash: string;
+  signature: string;
+}
+
+export type IntegrityFailureReason =
+  | 'hash-mismatch'
+  | 'signature-mismatch'
+  | 'chain-break'
+  | 'sequence-gap'
+  | 'sequence-reordered';
+
+export interface IntegrityResult {
+  isValid: boolean;
+  brokenAtIndex: number | null;
+  reason?: IntegrityFailureReason;
+}
+
+const GENESIS_HASH = crypto.createHash('sha256').update('GENESIS').digest('hex');
+
+function generateHash(entry: Omit<KeeperDecisionRecord, 'hash' | 'signature'>): string {
+  const data = JSON.stringify({
+    id: entry.id,
+    seq: entry.seq,
+    timestamp: entry.timestamp,
+    stream: entry.stream,
+    workerName: entry.workerName,
+    jobId: entry.jobId ?? null,
+    policyVersion: entry.policyVersion,
+    contractId: entry.contractId,
+    method: entry.method,
+    inputs: entry.inputs ?? null,
+    decision: entry.decision,
+    simulationResult: entry.simulationResult ?? null,
+    txOutcome: entry.txOutcome ?? null,
+    previousHash: entry.previousHash,
+  });
+  return crypto.createHash('sha256').update(data).digest('hex');
+}
+
+function generateSignature(hash: string, signingKey?: string): string {
+  const key = signingKey ?? process.env.KEEPER_AUDIT_SIGNING_KEY ?? process.env.AUDIT_SIGNING_KEY ?? 'default-key';
+  return crypto.createHmac('sha256', key).update(hash).digest('hex');
+}
+
+function verifyRecord(record: KeeperDecisionRecord): { hashOk: boolean; signatureOk: boolean } {
+  const { hash, signature, ...rest } = record;
+  const expectedHash = generateHash(rest as Omit<KeeperDecisionRecord, 'hash' | 'signature'>);
+  const expectedSignature = generateSignature(expectedHash);
+  return {
+    hashOk: expectedHash === hash,
+    signatureOk: expectedSignature === signature,
+  };
+}
+
+interface StreamState {
+  previousHash: string;
+  seq: number;
+}
+
+/**
+ * Creates an audit log bound to a specific directory. Production code uses
+ * the default export (`keeperAuditLog`, rooted at `KEEPER_AUDIT_LOG_DIR` or
+ * `./audit-logs`); tests create their own instance pointed at a temp dir so
+ * runs never share or pollute state.
+ */
+export function createKeeperAuditLog(baseDir?: string) {
+  const dir = baseDir ?? process.env.KEEPER_AUDIT_LOG_DIR ?? './audit-logs';
+  const stateCache = new Map<string, StreamState>();
+
+  function filePathFor(stream: string): string {
+    return path.join(dir, `${stream}.jsonl`);
+  }
+
+  function readAllRecords(stream: string): KeeperDecisionRecord[] {
+    const file = filePathFor(stream);
+    if (!fs.existsSync(file)) return [];
+    const content = fs.readFileSync(file, 'utf-8').trim();
+    if (!content) return [];
+    return content.split('\n').map((line) => JSON.parse(line) as KeeperDecisionRecord);
+  }
+
+  function loadState(stream: string): StreamState {
+    const cached = stateCache.get(stream);
+    if (cached) return cached;
+
+    const records = readAllRecords(stream);
+    const state: StreamState = records.length
+      ? { previousHash: records[records.length - 1].hash, seq: records[records.length - 1].seq }
+      : { previousHash: GENESIS_HASH, seq: -1 };
+    stateCache.set(stream, state);
+    return state;
+  }
+
+  /** Appends a new, redacted, hash-chained decision record to `stream`. */
+  function appendDecision(stream: string, input: KeeperDecisionInput): KeeperDecisionRecord {
+    fs.mkdirSync(dir, { recursive: true });
+    const state = loadState(stream);
+
+    const seq = state.seq + 1;
+    const id = crypto.randomUUID();
+    const timestamp = new Date().toISOString();
+
+    const redactedInputs = redactSensitive(input.inputs ?? null);
+    const redactedSimResult = redactSensitive(input.simulationResult ?? null);
+    const redactedOutcome = redactSensitive(input.txOutcome ?? null);
+    const redactedDecision = redactSensitive(input.decision);
+
+    const base: Omit<KeeperDecisionRecord, 'hash' | 'signature'> = {
+      id,
+      seq,
+      timestamp,
+      stream,
+      workerName: input.workerName,
+      jobId: input.jobId,
+      policyVersion: input.policyVersion,
+      contractId: input.contractId,
+      method: input.method,
+      inputs: redactedInputs,
+      decision: redactedDecision,
+      simulationResult: redactedSimResult,
+      txOutcome: redactedOutcome as KeeperTxOutcome | undefined,
+      previousHash: state.previousHash,
+    };
+
+    const hash = generateHash(base);
+    const signature = generateSignature(hash);
+    const record: KeeperDecisionRecord = { ...base, hash, signature };
+
+    fs.appendFileSync(filePathFor(stream), JSON.stringify(record) + '\n');
+    stateCache.set(stream, { previousHash: hash, seq });
+
+    return record;
+  }
+
+  /**
+   * Walks a stream's records verifying: per-record hash/signature integrity,
+   * hash-chain continuity (each `previousHash` matches the prior record's
+   * `hash`), and a strictly increasing, gap-free `seq` (catches reordering
+   * and missing/deleted records, not just tampering).
+   */
+  function verifyStreamIntegrity(stream: string): IntegrityResult {
+    const records = readAllRecords(stream);
+    let expectedPreviousHash = GENESIS_HASH;
+    let expectedSeq = 0;
+
+    for (let i = 0; i < records.length; i++) {
+      const record = records[i];
+      const { hashOk, signatureOk } = verifyRecord(record);
+
+      if (!hashOk) {
+        return { isValid: false, brokenAtIndex: i, reason: 'hash-mismatch' };
+      }
+      if (!signatureOk) {
+        return { isValid: false, brokenAtIndex: i, reason: 'signature-mismatch' };
+      }
+      if (record.previousHash !== expectedPreviousHash) {
+        return { isValid: false, brokenAtIndex: i, reason: 'chain-break' };
+      }
+      if (record.seq < expectedSeq) {
+        return { isValid: false, brokenAtIndex: i, reason: 'sequence-reordered' };
+      }
+      if (record.seq > expectedSeq) {
+        return { isValid: false, brokenAtIndex: i, reason: 'sequence-gap' };
+      }
+
+      expectedPreviousHash = record.hash;
+      expectedSeq = record.seq + 1;
+    }
+
+    return { isValid: true, brokenAtIndex: null };
+  }
+
+  /** Returns records in `stream` whose timestamp falls within [from, to] (inclusive, both optional). */
+  function exportStream(stream: string, from?: string, to?: string): KeeperDecisionRecord[] {
+    let records = readAllRecords(stream);
+    if (from) {
+      const fromMs = new Date(from).getTime();
+      records = records.filter((r) => new Date(r.timestamp).getTime() >= fromMs);
+    }
+    if (to) {
+      const toMs = new Date(to).getTime();
+      records = records.filter((r) => new Date(r.timestamp).getTime() <= toMs);
+    }
+    return records;
+  }
+
+  return { appendDecision, verifyStreamIntegrity, exportStream, readAllRecords };
+}
+
+export const keeperAuditLog = createKeeperAuditLog();

--- a/backend/keepers/src/audit/redact.ts
+++ b/backend/keepers/src/audit/redact.ts
@@ -1,0 +1,36 @@
+const BEARER_TOKEN_RE = /Bearer\s+[a-zA-Z0-9_\-.]+/gi;
+const KEY_PARAM_RE = /\b(api_key|apikey|key)=[a-zA-Z0-9_\-.]+/gi;
+const STELLAR_SECRET_RE = /^S[A-Z0-9]{55}$/;
+
+const REDACTED = "[REDACTED]";
+
+function redactString(value: string): string {
+  if (STELLAR_SECRET_RE.test(value)) {
+    return REDACTED;
+  }
+  return value
+    .replace(BEARER_TOKEN_RE, `Bearer ${REDACTED}`)
+    .replace(KEY_PARAM_RE, (_match, param: string) => `${param}=${REDACTED}`);
+}
+
+/**
+ * Deep-walks a value (string/array/object), redacting Stellar secret keys and
+ * common credential patterns (Bearer tokens, `key=`/`api_key=`/`apikey=`
+ * query params) before it is persisted or hashed into an audit record.
+ */
+export function redactSensitive<T>(value: T): T {
+  if (typeof value === "string") {
+    return redactString(value) as unknown as T;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSensitive(item)) as unknown as T;
+  }
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      out[key] = redactSensitive(val);
+    }
+    return out as unknown as T;
+  }
+  return value;
+}

--- a/backend/keepers/src/index.ts
+++ b/backend/keepers/src/index.ts
@@ -8,6 +8,7 @@ import { LiquidationWorker } from './workers/LiquidationWorker';
 import { CompoundWorker } from './workers/CompoundWorker';
 import { KeeperSigner } from './signer/KeeperSigner';
 import { startKeeperHealthServer } from './api/queueHealth';
+import { keeperAuditLog } from './audit/KeeperAuditLog';
 
 /**
  * StellarYield Keeper Bot — main entry point.
@@ -40,7 +41,7 @@ async function main(): Promise<void> {
   const healthServer = startKeeperHealthServer([liquidationQueue, compoundQueue]);
 
   // 4. Start workers
-  const signer = new KeeperSigner();
+  const signer = new KeeperSigner(undefined, { auditLog: keeperAuditLog });
   logger.info({ publicKey: signer.publicKey }, 'Keeper bot public key');
 
   const liquidationWorker = new LiquidationWorker(signer);

--- a/backend/keepers/src/signer/KeeperSigner.ts
+++ b/backend/keepers/src/signer/KeeperSigner.ts
@@ -1,39 +1,76 @@
 import {
   rpc,
-  Keypair,
-  TransactionBuilder,
   Networks,
   xdr,
   Contract,
-  Address,
+  TransactionBuilder,
 } from '@stellar/stellar-sdk';
 import { config } from '../config';
 import { logger } from '../utils/logger';
+import {
+  LocalSignerProvider,
+  UnauthorizedOperationError,
+  type SignerProvider,
+} from './SignerProvider';
+import { createKeeperAuditLog } from '../audit/KeeperAuditLog';
+
+export type { SignerProvider } from './SignerProvider';
+export { UnauthorizedOperationError } from './SignerProvider';
+
+export interface KeeperAuditContext {
+  workerName: string;
+  jobId?: string;
+  policyVersion?: string;
+}
+
+export interface KeeperSignerOptions {
+  /** Opt-in tamper-evident audit logging (see issue #912). No-op when omitted. */
+  auditLog?: ReturnType<typeof createKeeperAuditLog>;
+}
+
+function safeArgsSummary(args: xdr.ScVal[]): string[] {
+  return args.map((arg) => {
+    try {
+      return arg.toXDR('base64');
+    } catch {
+      return String(arg);
+    }
+  });
+}
 
 /**
- * KeeperSigner manages the keeper bot's signing keypair and handles the
+ * KeeperSigner manages the keeper bot's signing authority and handles the
  * complete Soroban transaction lifecycle:
  *   1. Build a TransactionBuilder with the current sequence number
  *   2. Simulate the transaction to get resource fees
- *   3. Sign the transaction with the keeper's secret key
+ *   3. Sign the transaction via the active SignerProvider
  *   4. Submit and poll for confirmation
  *
- * Security note: In production, replace `Keypair.fromSecret()` with a KMS
- * adapter that never exposes the raw private key in-process.
+ * Signing itself is delegated to a `SignerProvider` (local secret, env
+ * secret, or an external/KMS-backed callback — see `./SignerProvider.ts`),
+ * which also declares which contract methods it is allowed to authorize.
+ * `invokeContract` rejects any other method before building a transaction.
  */
 export class KeeperSigner {
-  private readonly keypair: Keypair;
+  private readonly provider: SignerProvider;
   private readonly server: rpc.Server;
   private readonly networkPassphrase: string;
+  private readonly auditLog?: ReturnType<typeof createKeeperAuditLog>;
 
-  constructor(secretKey?: string) {
-    const key = secretKey ?? config.stellar.keeperSecretKey;
-    if (!key) {
-      throw new Error(
-        'KEEPER_SECRET_KEY is not set. Provide a valid Stellar secret key.',
-      );
+  constructor(secretKeyOrProvider?: string | SignerProvider, options?: KeeperSignerOptions) {
+    if (secretKeyOrProvider && typeof secretKeyOrProvider === 'object') {
+      this.provider = secretKeyOrProvider;
+    } else {
+      const key = secretKeyOrProvider ?? config.stellar.keeperSecretKey;
+      if (!key) {
+        throw new Error(
+          'KEEPER_SECRET_KEY is not set. Provide a valid Stellar secret key.',
+        );
+      }
+      this.provider = new LocalSignerProvider(key);
     }
-    this.keypair = Keypair.fromSecret(key);
+
+    this.auditLog = options?.auditLog;
     this.server = new rpc.Server(config.stellar.sorobanRpcUrl, {
       allowHttp: true,
     });
@@ -43,9 +80,29 @@ export class KeeperSigner {
         : Networks.TESTNET;
   }
 
-  /** Public key of the keeper bot account */
+  /** Public key of the currently active signer */
   get publicKey(): string {
-    return this.keypair.publicKey();
+    return this.provider.publicKey;
+  }
+
+  private recordDecision(
+    auditContext: KeeperAuditContext | undefined,
+    contractId: string,
+    method: string,
+    args: xdr.ScVal[],
+    extra: { simulationResult?: unknown; txOutcome?: { status: 'success' | 'failure'; hash?: string; error?: string } },
+  ): void {
+    if (!this.auditLog || !auditContext) return;
+    this.auditLog.appendDecision(auditContext.workerName, {
+      workerName: auditContext.workerName,
+      jobId: auditContext.jobId,
+      policyVersion: auditContext.policyVersion ?? 'unversioned',
+      contractId,
+      method,
+      inputs: { contractId, method, args: safeArgsSummary(args) },
+      decision: `invoke ${method} on ${contractId}`,
+      ...extra,
+    });
   }
 
   /**
@@ -55,15 +112,28 @@ export class KeeperSigner {
    * @param contractId - The Soroban contract C-address
    * @param method     - The contract function name to invoke
    * @param args       - xdr.ScVal arguments to pass
+   * @param auditContext - Optional worker/job metadata for the tamper-evident
+   *                       audit trail (see issue #912); no-op if `auditLog`
+   *                       wasn't supplied to this instance.
    * @returns The transaction hash on success
-   * @throws  On simulation error, auth failure, or submission failure
+   * @throws  On unauthorized operation, simulation error, auth failure, or submission failure
    */
   async invokeContract(
     contractId: string,
     method: string,
     args: xdr.ScVal[] = [],
+    auditContext?: KeeperAuditContext,
   ): Promise<string> {
-    const account = await this.server.getAccount(this.keypair.publicKey());
+    if (!this.provider.allowedOperations.has(method)) {
+      throw new UnauthorizedOperationError(method, this.provider.id);
+    }
+
+    logger.info(
+      { providerId: this.provider.id, publicKey: this.provider.publicKey, method, contractId },
+      '[KeeperSigner] Signer selected for job',
+    );
+
+    const account = await this.server.getAccount(this.provider.publicKey);
 
     const contract = new Contract(contractId);
     const op = contract.call(method, ...args);
@@ -97,18 +167,37 @@ export class KeeperSigner {
 
     // Prepare (inflate) with resource fees from simulation
     const preparedTx = rpc.assembleTransaction(tx, sim).build();
-    preparedTx.sign(this.keypair);
+    const signedTx = await this.provider.sign(preparedTx, this.networkPassphrase);
 
-    const sendResult = await this.server.sendTransaction(preparedTx);
+    this.recordDecision(auditContext, contractId, method, args, {
+      simulationResult: { minResourceFee: (sim as any).minResourceFee ?? null },
+    });
+
+    const sendResult = await this.server.sendTransaction(signedTx);
     if (sendResult.status === 'ERROR') {
-      throw new Error(`sendTransaction failed: ${sendResult.errorResult?.toXDR('base64')}`);
+      const errorMessage = `sendTransaction failed: ${sendResult.errorResult?.toXDR('base64')}`;
+      this.recordDecision(auditContext, contractId, method, args, {
+        txOutcome: { status: 'failure', error: errorMessage },
+      });
+      throw new Error(errorMessage);
     }
 
     const hash = sendResult.hash;
     logger.info({ hash, method, contractId }, 'Transaction submitted');
 
-    // Poll for confirmation
-    await this.pollForConfirmation(hash);
+    try {
+      await this.pollForConfirmation(hash);
+    } catch (err) {
+      this.recordDecision(auditContext, contractId, method, args, {
+        txOutcome: { status: 'failure', hash, error: err instanceof Error ? err.message : String(err) },
+      });
+      throw err;
+    }
+
+    this.recordDecision(auditContext, contractId, method, args, {
+      txOutcome: { status: 'success', hash },
+    });
+
     return hash;
   }
 

--- a/backend/keepers/src/signer/KeeperSignerRegistry.ts
+++ b/backend/keepers/src/signer/KeeperSignerRegistry.ts
@@ -1,0 +1,36 @@
+import { logger } from '../utils/logger';
+import type { SignerProvider } from './SignerProvider';
+
+/**
+ * Holds the "currently active" signer provider so it can be rotated without
+ * restarting workers. Workers should read `currentProvider` fresh at the top
+ * of each job's `process()` call (not cache it in a constructor field) — that
+ * way an in-flight invocation keeps using the provider it was dispatched
+ * with, while the *next* job picks up whatever `rotate()` most recently set.
+ */
+export class KeeperSignerRegistry {
+  private current: SignerProvider;
+
+  constructor(initialProvider: SignerProvider) {
+    this.current = initialProvider;
+  }
+
+  get currentProvider(): SignerProvider {
+    return this.current;
+  }
+
+  /** Swaps the active provider. Never logs key material — only provider ids. */
+  rotate(newProvider: SignerProvider, reason?: string): void {
+    const oldProviderId = this.current.id;
+    this.current = newProvider;
+    logger.info(
+      {
+        oldProviderId,
+        newProviderId: newProvider.id,
+        reason: reason ?? 'unspecified',
+        rotatedAt: new Date().toISOString(),
+      },
+      '[KeeperSignerRegistry] Signer rotated',
+    );
+  }
+}

--- a/backend/keepers/src/signer/SignerProvider.ts
+++ b/backend/keepers/src/signer/SignerProvider.ts
@@ -1,0 +1,118 @@
+import { Keypair, Transaction, TransactionBuilder } from '@stellar/stellar-sdk';
+
+/** Default operation allowlist for keeper-controlled hot keys. */
+export const DEFAULT_ALLOWED_OPERATIONS = ['harvest', 'liquidate', 'rebalance'] as const;
+
+export class NotImplementedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotImplementedError';
+  }
+}
+
+export class UnauthorizedOperationError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly providerId: string,
+  ) {
+    super(`Signer "${providerId}" is not authorized to perform operation "${method}"`);
+    this.name = 'UnauthorizedOperationError';
+  }
+}
+
+/**
+ * Least-privilege abstraction over "something that can sign a Soroban
+ * transaction". `id` and `publicKey` are safe, non-secret identifiers used
+ * for audit logging — implementations must never expose key material through
+ * any other member.
+ */
+export interface SignerProvider {
+  /** Non-secret label identifying this provider instance (safe to log). */
+  readonly id: string;
+  readonly publicKey: string;
+  /** Contract method names this signer is allowed to authorize. */
+  readonly allowedOperations: ReadonlySet<string>;
+  /** Signs (and may mutate) `tx` in place, returning the signed transaction. */
+  sign(tx: Transaction, networkPassphrase: string): Promise<Transaction>;
+}
+
+/**
+ * Signs with a `Keypair` constructed directly from a secret string.
+ * Equivalent to the keeper's original (pre-#911) hardcoded behavior.
+ */
+export class LocalSignerProvider implements SignerProvider {
+  readonly id: string;
+  readonly publicKey: string;
+  readonly allowedOperations: ReadonlySet<string>;
+  private readonly keypair: Keypair;
+
+  constructor(
+    secretKey: string,
+    allowedOperations: readonly string[] = DEFAULT_ALLOWED_OPERATIONS,
+    idPrefix = 'local',
+  ) {
+    this.keypair = Keypair.fromSecret(secretKey);
+    this.publicKey = this.keypair.publicKey();
+    this.id = `${idPrefix}:${this.publicKey}`;
+    this.allowedOperations = new Set(allowedOperations);
+  }
+
+  async sign(tx: Transaction, _networkPassphrase: string): Promise<Transaction> {
+    tx.sign(this.keypair);
+    return tx;
+  }
+}
+
+/**
+ * Same signing behavior as `LocalSignerProvider`, but sources its secret from
+ * a named environment variable rather than a caller-supplied string — the
+ * "environment" backend called for in issue #911's scope. Kept as a thin
+ * subclass (not a separate signing implementation) since the two are
+ * functionally identical today and differ only in secret provenance.
+ */
+export class EnvSignerProvider extends LocalSignerProvider {
+  constructor(secretKey: string, allowedOperations: readonly string[] = DEFAULT_ALLOWED_OPERATIONS) {
+    super(secretKey, allowedOperations, 'env');
+  }
+
+  static fromEnvVar(envVarName: string, allowedOperations?: readonly string[]): EnvSignerProvider {
+    const secret = process.env[envVarName];
+    if (!secret) {
+      throw new Error(`Environment variable ${envVarName} is not set`);
+    }
+    return new EnvSignerProvider(secret, allowedOperations);
+  }
+}
+
+/**
+ * Delegates signing to an injectable async callback (e.g. a remote KMS/HSM
+ * client), mirroring the SDK's `CustomSigner` pattern. Throws
+ * `NotImplementedError` if no callback is supplied, so it can stand in as a
+ * documented extension point without a real remote signer integration.
+ */
+export class ExternalSignerProvider implements SignerProvider {
+  readonly id: string;
+  readonly allowedOperations: ReadonlySet<string>;
+
+  constructor(
+    public readonly publicKey: string,
+    allowedOperations: readonly string[],
+    private readonly signCallback?: (
+      unsignedXdr: string,
+      networkPassphrase: string,
+    ) => Promise<string>,
+  ) {
+    this.id = `external:${publicKey}`;
+    this.allowedOperations = new Set(allowedOperations);
+  }
+
+  async sign(tx: Transaction, networkPassphrase: string): Promise<Transaction> {
+    if (!this.signCallback) {
+      throw new NotImplementedError(
+        'ExternalSignerProvider requires an injectable sign callback; none was provided.',
+      );
+    }
+    const signedXdr = await this.signCallback(tx.toXDR(), networkPassphrase);
+    return TransactionBuilder.fromXDR(signedXdr, networkPassphrase) as Transaction;
+  }
+}

--- a/backend/keepers/src/workers/CompoundWorker.ts
+++ b/backend/keepers/src/workers/CompoundWorker.ts
@@ -63,6 +63,7 @@ export class CompoundWorker {
       vaultContractId,
       'harvest',
       [keeperScVal, minAmtXdr],
+      { workerName: 'CompoundWorker', jobId: job.id, policyVersion: 'v1' },
     );
 
     logger.info(

--- a/backend/keepers/src/workers/LiquidationWorker.ts
+++ b/backend/keepers/src/workers/LiquidationWorker.ts
@@ -66,6 +66,7 @@ export class LiquidationWorker {
       config.contracts.stablecoinManager,
       'liquidate',
       [liquidatorScVal, userScVal],
+      { workerName: 'LiquidationWorker', jobId: job.id, policyVersion: 'v1' },
     );
 
     logger.info(

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "@react-three/fiber": "^9.5.0",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.6.1",
+        "@stellaryield/sdk": "file:../packages/sdk",
         "@types/d3": "^7.4.3",
         "@types/three": "^0.183.1",
         "buffer": "^6.0.3",
@@ -50,6 +51,21 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.56.1",
         "vite": "^6.3.5",
+        "vitest": "^3.0.5"
+      }
+    },
+    "../packages/sdk": {
+      "name": "@stellaryield/sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^14.6.1",
+        "buffer": "^6.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
         "vitest": "^3.0.5"
       }
     },
@@ -1927,6 +1943,10 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@stellaryield/sdk": {
+      "resolved": "../packages/sdk",
+      "link": true
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "@react-three/fiber": "^9.5.0",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.6.1",
+    "@stellaryield/sdk": "file:../packages/sdk",
     "@types/d3": "^7.4.3",
     "@types/three": "^0.183.1",
     "buffer": "^6.0.3",

--- a/client/src/components/Vault.tsx
+++ b/client/src/components/Vault.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Landmark, Loader2, AlertCircle, ArrowLeft } from "lucide-react";
 import { ZapDepositPanel } from "../features/zap";
+import { WithdrawPanel } from "../features/withdraw";
 import { useWallet } from "../context/useWallet";
 import { useVaultOgMeta } from "../hooks/useVaultOgMeta";
 import { RecoveryAdvisor } from "./AIAdvisor/RecoveryAdvisor";
@@ -32,6 +33,7 @@ export default function Vault() {
   const [stats, setStats] = useState<VaultStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(!isSlugValid);
+  const [vaultAction, setVaultAction] = useState<"deposit" | "withdraw">("deposit");
 
   const meta = useVaultOgMeta(activeSlug);
 
@@ -164,7 +166,36 @@ export default function Vault() {
       </div>
 
       <div className="glass-panel p-8 mt-8 max-w-3xl w-full text-left">
-        <ZapDepositPanel walletAddress={walletAddress} />
+        <div className="flex items-center justify-center gap-2 mb-6">
+          <button
+            type="button"
+            onClick={() => setVaultAction("deposit")}
+            className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+              vaultAction === "deposit"
+                ? "bg-green-500/20 text-green-400"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            Deposit
+          </button>
+          <button
+            type="button"
+            onClick={() => setVaultAction("withdraw")}
+            className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+              vaultAction === "withdraw"
+                ? "bg-green-500/20 text-green-400"
+                : "text-gray-400 hover:text-white"
+            }`}
+          >
+            Withdraw
+          </button>
+        </div>
+
+        {vaultAction === "deposit" ? (
+          <ZapDepositPanel walletAddress={walletAddress} />
+        ) : (
+          <WithdrawPanel walletAddress={walletAddress} />
+        )}
       </div>
     </div>
   );

--- a/client/src/components/transaction/TxStatusTimeline.test.tsx
+++ b/client/src/components/transaction/TxStatusTimeline.test.tsx
@@ -58,6 +58,19 @@ describe("TxStatusTimeline", () => {
     expect(screen.getByText("Some unexpected connection reset error from the router")).toBeInTheDocument();
   });
 
+  it("renders the recovering phase within a custom step list", () => {
+    const stepsWithRecovery: readonly TxPhase[] = ["polling", "recovering"];
+    render(
+      <TxStatusTimeline
+        steps={stepsWithRecovery}
+        phase="recovering"
+      />
+    );
+
+    expect(screen.getByText("Confirming on network")).toBeInTheDocument();
+    expect(screen.getByText("Recovering transaction status")).toBeInTheDocument();
+  });
+
   it("calls onRetry when retry button is clicked", () => {
     const onRetry = vi.fn();
     render(

--- a/client/src/features/rewards/ClaimRewards.tsx
+++ b/client/src/features/rewards/ClaimRewards.tsx
@@ -3,6 +3,12 @@ import { useWallet } from "../../context/useWallet";
 import { Gift, CheckCircle, Loader2 } from "lucide-react";
 import { getApiBaseUrl } from "../../lib/api";
 import ApiErrorBanner from "../../components/ApiErrorBanner/ApiErrorBanner";
+import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
+import TransactionFailedModal from "../../components/transaction/TransactionFailedModal";
+import { decodeTransactionError } from "../../utils/errorDecoder";
+import type { TxPhase } from "../../services/transactionPhase";
+
+const CLAIM_PHASE_STEPS: readonly TxPhase[] = ["building", "submitting"];
 
 interface ClaimData {
   index: number;
@@ -31,6 +37,8 @@ export default function ClaimRewards() {
   const [claiming, setClaiming] = useState(false);
   const [claimed, setClaimed] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [claimPhase, setClaimPhase] = useState<TxPhase>("idle");
+  const [showFailedModal, setShowFailedModal] = useState(false);
 
   const fetchClaimData = useCallback(async () => {
     if (!walletAddress) return;
@@ -70,8 +78,11 @@ export default function ClaimRewards() {
     if (!claimData || !walletAddress) return;
     setClaiming(true);
     setError(null);
+    setShowFailedModal(false);
+    setClaimPhase("building");
 
     try {
+      setClaimPhase("submitting");
       const res = await fetch(`${getApiBase()}/api/rewards/claim`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -90,11 +101,14 @@ export default function ClaimRewards() {
         );
       }
 
+      setClaimPhase("success");
       setClaimed(true);
     } catch (err) {
+      setClaimPhase("failure");
       setError(
         err instanceof Error ? err.message : "Claim transaction failed",
       );
+      setShowFailedModal(true);
     } finally {
       setClaiming(false);
     }
@@ -140,7 +154,20 @@ export default function ClaimRewards() {
         <h2 className="text-xl font-bold">Claim Your $YIELD Rewards</h2>
       </div>
 
-      {error && (
+      {showFailedModal && error && (
+        <TransactionFailedModal
+          error={decodeTransactionError(error)}
+          onClose={() => setShowFailedModal(false)}
+          onRetry={() => {
+            setShowFailedModal(false);
+            void handleClaim();
+          }}
+          failurePhase="submitting"
+          walletConnected={Boolean(walletAddress)}
+        />
+      )}
+
+      {error && claimPhase === "idle" && (
         <ApiErrorBanner message={error} onRetry={fetchClaimData} className="mb-6" />
       )}
 
@@ -185,6 +212,14 @@ export default function ClaimRewards() {
               </>
             )}
           </button>
+
+          <TxStatusTimeline
+            steps={CLAIM_PHASE_STEPS}
+            phase={claimPhase}
+            errorMessage={claimPhase === "failure" ? error : null}
+            failedAtPhase={claimPhase === "failure" ? "submitting" : null}
+            onRetry={claimPhase === "failure" ? () => void handleClaim() : undefined}
+          />
         </div>
       )}
     </div>

--- a/client/src/features/withdraw/WithdrawPanel.test.tsx
+++ b/client/src/features/withdraw/WithdrawPanel.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import WithdrawPanel from "./WithdrawPanel";
+import { withdraw, getUserShares } from "../../services/soroban";
+
+vi.mock("../../services/soroban", () => ({
+  withdraw: vi.fn(),
+  getUserShares: vi.fn(),
+}));
+
+vi.mock("../zap/assets", () => ({
+  getVaultTokenFromEnv: () => ({
+    symbol: "yVault",
+    name: "Yield Vault",
+    contractId: "CVAULT",
+    decimals: 7,
+  }),
+}));
+
+const mockWithdraw = vi.mocked(withdraw);
+const mockGetUserShares = vi.mocked(getUserShares);
+
+describe("WithdrawPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUserShares.mockResolvedValue(500_0000000n);
+  });
+
+  it("prompts for wallet connection when no wallet address is provided", () => {
+    render(<WithdrawPanel walletAddress={null} />);
+    expect(screen.getByText(/Connect your wallet/i)).toBeInTheDocument();
+  });
+
+  it("loads and displays the user's share balance as the max amount", async () => {
+    render(<WithdrawPanel walletAddress="GABCDEF123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max: 500/)).toBeInTheDocument();
+    });
+  });
+
+  it("drives the shared TxStatusTimeline through onPhase callbacks on success", async () => {
+    mockWithdraw.mockImplementation(async (_addr, _shares, onPhase) => {
+      onPhase?.("simulating");
+      onPhase?.("waiting_for_wallet");
+      onPhase?.("submitting");
+      onPhase?.("polling");
+      onPhase?.("success");
+      return { success: true, hash: "deadbeef" };
+    });
+
+    render(<WithdrawPanel walletAddress="GABCDEF123" />);
+
+    const input = screen.getByPlaceholderText("0.00");
+    await userEvent.type(input, "10");
+
+    const button = screen.getByRole("button", { name: /withdraw/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockWithdraw).toHaveBeenCalledWith(
+        "GABCDEF123",
+        100_000_000n,
+        expect.any(Function),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/deadbeef/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows the failure modal with recovery guidance when withdraw fails", async () => {
+    mockWithdraw.mockImplementation(async (_addr, _shares, onPhase) => {
+      onPhase?.("simulating");
+      onPhase?.("failure");
+      return { success: false, error: "Error(Contract, #4)" };
+    });
+
+    render(<WithdrawPanel walletAddress="GABCDEF123" />);
+
+    const input = screen.getByPlaceholderText("0.00");
+    await userEvent.type(input, "10");
+    fireEvent.click(screen.getByRole("button", { name: /withdraw/i }));
+
+    let dialog: HTMLElement;
+    await waitFor(() => {
+      dialog = screen.getByRole("dialog");
+      expect(dialog).toBeInTheDocument();
+    });
+    expect(within(dialog!).getByText(/Insufficient Shares/i)).toBeInTheDocument();
+  });
+
+  it("rejects an amount exceeding the loaded share balance without calling withdraw", async () => {
+    render(<WithdrawPanel walletAddress="GABCDEF123" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Max: 500/)).toBeInTheDocument();
+    });
+
+    const input = screen.getByPlaceholderText("0.00");
+    await userEvent.type(input, "999999");
+    fireEvent.click(screen.getByRole("button", { name: /withdraw/i }));
+
+    expect(screen.getByText(/exceeds your share balance/i)).toBeInTheDocument();
+    expect(mockWithdraw).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/features/withdraw/WithdrawPanel.tsx
+++ b/client/src/features/withdraw/WithdrawPanel.tsx
@@ -1,0 +1,199 @@
+import { useCallback, useEffect, useState } from "react";
+import { ArrowUpFromLine, Loader2 } from "lucide-react";
+import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
+import TransactionFailedModal from "../../components/transaction/TransactionFailedModal";
+import { decodeTransactionError } from "../../utils/errorDecoder";
+import { withdraw, getUserShares } from "../../services/soroban";
+import { TX_PHASE_PIPELINE, type TxPhase } from "../../services/transactionPhase";
+import { parseDecimalToStroops, formatStroopsToDecimal } from "../zap/amount";
+import { getVaultTokenFromEnv } from "../zap/assets";
+
+export interface WithdrawPanelProps {
+  walletAddress: string | null;
+}
+
+export default function WithdrawPanel({ walletAddress }: WithdrawPanelProps) {
+  const vaultToken = getVaultTokenFromEnv();
+
+  const [shareBalance, setShareBalance] = useState<bigint | null>(null);
+  const [balanceError, setBalanceError] = useState<string | null>(null);
+  const [amount, setAmount] = useState("");
+  const [txPhase, setTxPhase] = useState<TxPhase>("idle");
+  const [lastProgressPhase, setLastProgressPhase] = useState<TxPhase>("idle");
+  const [txHash, setTxHash] = useState<string | null>(null);
+  const [error, setError] = useState("");
+  const [showFailedModal, setShowFailedModal] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const refreshBalance = useCallback(async () => {
+    if (!walletAddress) return;
+    try {
+      const shares = await getUserShares(walletAddress);
+      setShareBalance(shares);
+      setBalanceError(null);
+    } catch (err) {
+      setBalanceError(err instanceof Error ? err.message : "Could not load share balance");
+    }
+  }, [walletAddress]);
+
+  useEffect(() => {
+    void refreshBalance();
+  }, [refreshBalance]);
+
+  const emitPhase = useCallback((p: TxPhase) => {
+    setTxPhase(p);
+    if (p !== "success" && p !== "failure") {
+      setLastProgressPhase(p);
+    }
+  }, []);
+
+  const handleWithdraw = useCallback(async () => {
+    if (!walletAddress) return;
+    let shares: bigint;
+    try {
+      shares = parseDecimalToStroops(amount, vaultToken.decimals);
+    } catch {
+      setError("Enter a valid amount");
+      return;
+    }
+    if (shares <= 0n) return;
+    if (shareBalance !== null && shares > shareBalance) {
+      setError("Amount exceeds your share balance");
+      return;
+    }
+
+    setLastProgressPhase("idle");
+    setTxPhase("idle");
+    setTxHash(null);
+    setError("");
+    setShowFailedModal(false);
+    setSubmitting(true);
+
+    try {
+      const result = await withdraw(walletAddress, shares, emitPhase);
+      if (!result.success) {
+        throw new Error(result.error || "Withdrawal failed");
+      }
+      setTxHash(result.hash ?? null);
+      setAmount("");
+      void refreshBalance();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Withdrawal failed");
+      setShowFailedModal(true);
+    } finally {
+      setSubmitting(false);
+    }
+  }, [walletAddress, amount, vaultToken.decimals, shareBalance, emitPhase, refreshBalance]);
+
+  const retryWithdraw = useCallback(() => {
+    setError("");
+    void handleWithdraw();
+  }, [handleWithdraw]);
+
+  const setMax = useCallback(() => {
+    if (shareBalance === null) return;
+    setAmount(formatStroopsToDecimal(shareBalance, vaultToken.decimals));
+  }, [shareBalance, vaultToken.decimals]);
+
+  if (!walletAddress) {
+    return (
+      <div className="bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 p-8 text-center">
+        <ArrowUpFromLine className="w-12 h-12 text-yellow-400 mx-auto mb-4" />
+        <h3 className="text-xl font-bold text-white mb-2">Withdraw from vault</h3>
+        <p className="text-gray-400">Connect your wallet to redeem shares for the underlying asset</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/5 backdrop-blur-xl rounded-2xl border border-white/10 p-6 max-w-md mx-auto">
+      {showFailedModal && error && (
+        <TransactionFailedModal
+          error={decodeTransactionError(error)}
+          onClose={() => setShowFailedModal(false)}
+          onRetry={() => {
+            setShowFailedModal(false);
+            retryWithdraw();
+          }}
+          failurePhase={
+            lastProgressPhase !== "idle" &&
+            lastProgressPhase !== "success" &&
+            lastProgressPhase !== "failure"
+              ? lastProgressPhase
+              : "polling"
+          }
+        />
+      )}
+
+      <div className="flex items-center gap-2 mb-6">
+        <ArrowUpFromLine className="w-5 h-5 text-yellow-400" />
+        <h3 className="text-lg font-bold text-white">Withdraw</h3>
+      </div>
+
+      {balanceError && (
+        <p className="text-xs text-amber-300 mb-3">{balanceError}</p>
+      )}
+
+      <div className="bg-white/5 rounded-xl p-4 mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-sm text-gray-400">Shares to redeem</label>
+          <button
+            type="button"
+            onClick={setMax}
+            disabled={shareBalance === null}
+            className="text-xs text-indigo-300 hover:text-indigo-200 disabled:opacity-50"
+          >
+            Max: {shareBalance !== null ? formatStroopsToDecimal(shareBalance, vaultToken.decimals) : "…"}
+          </button>
+        </div>
+        <input
+          type="text"
+          inputMode="decimal"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder="0.00"
+          className="w-full bg-transparent text-white text-2xl outline-none"
+        />
+      </div>
+
+      {error && txPhase !== "failure" && (
+        <p className="text-sm text-red-400 mb-4">{error}</p>
+      )}
+
+      <TxStatusTimeline
+        steps={TX_PHASE_PIPELINE}
+        phase={txPhase}
+        errorMessage={txPhase === "failure" ? error : null}
+        txHash={txHash}
+        failedAtPhase={
+          txPhase === "failure"
+            ? lastProgressPhase !== "idle"
+              ? lastProgressPhase
+              : "polling"
+            : null
+        }
+        onRetry={txPhase === "failure" ? retryWithdraw : undefined}
+        className="mb-4"
+      />
+
+      <button
+        type="button"
+        onClick={() => void handleWithdraw()}
+        disabled={submitting || !amount}
+        className="w-full py-3 rounded-xl font-semibold text-white bg-gradient-to-r from-yellow-500 to-orange-500 hover:from-yellow-600 hover:to-orange-600 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+      >
+        {submitting ? (
+          <>
+            <Loader2 className="w-4 h-4 animate-spin" />
+            Processing…
+          </>
+        ) : (
+          <>
+            <ArrowUpFromLine className="w-4 h-4" />
+            Withdraw
+          </>
+        )}
+      </button>
+    </div>
+  );
+}

--- a/client/src/features/withdraw/index.ts
+++ b/client/src/features/withdraw/index.ts
@@ -1,0 +1,2 @@
+export { default as WithdrawPanel } from "./WithdrawPanel";
+export type { WithdrawPanelProps } from "./WithdrawPanel";

--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, Zap, Loader2, AlertTriangle, RefreshCw, Clock, Info } from "lucide-react";
 import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
+import TransactionFailedModal from "../../components/transaction/TransactionFailedModal";
+import { decodeTransactionError } from "../../utils/errorDecoder";
 import { zapDeposit } from "../../services/soroban";
 import type { TxPhase } from "../../services/transactionPhase";
 import { TX_PHASE_PIPELINE } from "../../services/transactionPhase";
@@ -84,6 +86,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
   const [lastProgressPhase, setLastProgressPhase] = useState<TxPhase>("idle");
   const [txHash, setTxHash] = useState<string | null>(null);
   const [error, setError] = useState("");
+  const [showFailedModal, setShowFailedModal] = useState(false);
   const [quoteLoading, setQuoteLoading] = useState(false);
   const [expectedOut, setExpectedOut] = useState<bigint | null>(null);
   const [quotePath, setQuotePath] = useState<string>("");
@@ -200,6 +203,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     setTxHash(null);
     setStatus("loading");
     setError("");
+    setShowFailedModal(false);
     try {
       const result = await zapDeposit(
         walletAddress,
@@ -224,6 +228,7 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     } catch (err) {
       setStatus("error");
       setError(err instanceof Error ? err.message : "Transaction failed");
+      setShowFailedModal(true);
     }
   }, [
     walletAddress,
@@ -482,6 +487,24 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
           <AlertTriangle className="w-4 h-4 shrink-0" />
           {error}
         </div>
+      )}
+
+      {showFailedModal && txPhase === "failure" && error && (
+        <TransactionFailedModal
+          error={decodeTransactionError(error)}
+          onClose={() => setShowFailedModal(false)}
+          onRetry={() => {
+            setShowFailedModal(false);
+            retryZap();
+          }}
+          failurePhase={
+            lastProgressPhase !== "idle" &&
+            lastProgressPhase !== "success" &&
+            lastProgressPhase !== "failure"
+              ? lastProgressPhase
+              : "polling"
+          }
+        />
       )}
 
       <TxStatusTimeline

--- a/client/src/pages/governance/TransactionBuilder.tsx
+++ b/client/src/pages/governance/TransactionBuilder.tsx
@@ -6,6 +6,12 @@ import type { AdminAction, PendingTransaction } from "./types";
 import { AlertTriangle, CheckCircle, XCircle } from "lucide-react";
 import { validateTransactionBuilder } from "./validation";
 import { validateContractRegistryEntry } from "../../services/contractRegistry";
+import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
+import TransactionFailedModal from "../../components/transaction/TransactionFailedModal";
+import { decodeTransactionError } from "../../utils/errorDecoder";
+import type { TxPhase } from "../../services/transactionPhase";
+
+const BUILD_PHASE_STEPS: readonly TxPhase[] = ["building", "simulating"];
 
 interface TransactionBuilderProps {
   threshold: number;
@@ -43,6 +49,8 @@ export default function TransactionBuilder({
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({});
   const [building, setBuilding] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [phase, setPhase] = useState<TxPhase>("idle");
+  const [showFailedModal, setShowFailedModal] = useState(false);
 
   const action = ADMIN_ACTIONS.find((a) => a.method === selectedAction);
 
@@ -56,6 +64,8 @@ export default function TransactionBuilder({
 
     setBuilding(true);
     setError(null);
+    setShowFailedModal(false);
+    setPhase("building");
 
     try {
       validateContractRegistryEntry("vault", contractId);
@@ -74,6 +84,7 @@ export default function TransactionBuilder({
         if (field.required && !value) {
           setError(`${field.label} is required`);
           setBuilding(false);
+          setPhase("idle");
           return;
         }
         if (field.type === "address") {
@@ -93,6 +104,7 @@ export default function TransactionBuilder({
         .setTimeout(86400) // 24h expiry for multi-sig collection
         .build();
 
+      setPhase("simulating");
       const simulated = await server.simulateTransaction(tx);
 
       if (StellarSdk.rpc.Api.isSimulationError(simulated)) {
@@ -121,11 +133,14 @@ export default function TransactionBuilder({
         status: "pending",
       };
 
+      setPhase("success");
       onTransactionCreated(pendingTx);
       setSelectedAction("");
       setFieldValues({});
     } catch (err) {
+      setPhase("failure");
       setError(err instanceof Error ? err.message : String(err));
+      setShowFailedModal(true);
     } finally {
       setBuilding(false);
     }
@@ -133,12 +148,27 @@ export default function TransactionBuilder({
 
   return (
     <div className="glass-card p-6">
+      {showFailedModal && error && (
+        <TransactionFailedModal
+          error={decodeTransactionError(error)}
+          onClose={() => setShowFailedModal(false)}
+          onRetry={() => {
+            setShowFailedModal(false);
+            void handleBuild();
+          }}
+          failurePhase="simulating"
+          walletConnected={Boolean(walletAddress)}
+        />
+      )}
+
       <h3 className="text-lg font-bold mb-4">Propose Admin Action</h3>
 
       <div className="space-y-4">
         <div>
-          <label className="block text-sm text-gray-400 mb-1">Action</label>
+          <label htmlFor="admin-action-select" className="block text-sm text-gray-400 mb-1">Action</label>
           <select
+            id="admin-action-select"
+            aria-label="Action"
             value={selectedAction}
             onChange={(e) => {
               setSelectedAction(e.target.value as AdminAction);
@@ -180,9 +210,14 @@ export default function TransactionBuilder({
               </div>
             ))}
 
-            {error && (
-              <p className="text-sm text-red-400">{error}</p>
-            )}
+            <TxStatusTimeline
+              steps={BUILD_PHASE_STEPS}
+              phase={phase}
+              errorMessage={phase === "failure" ? error : null}
+              failedAtPhase={phase === "failure" ? "simulating" : null}
+              onRetry={phase === "failure" ? () => void handleBuild() : undefined}
+              className="mb-2"
+            />
 
             {validationSummary && (
               <div

--- a/client/src/services/soroban.ts
+++ b/client/src/services/soroban.ts
@@ -15,6 +15,7 @@ import {
   CustomSigner,
   FreighterSigner,
   parseContractError,
+  SubmissionTimeoutError,
   YIELD_VAULT_SPEC_HASH,
 } from "@stellaryield/sdk";
 import type { TxPhase } from "./transactionPhase";
@@ -68,6 +69,32 @@ function getVaultClient(contractId?: string): VaultClient {
     rpcUrl: RPC_URL,
     specHash: YIELD_VAULT_SPEC_HASH,
   });
+}
+
+/** Current vault share balance for a user, for populating withdraw UI. */
+export async function getUserShares(userAddress: string): Promise<bigint> {
+  const vaultClient = getVaultClient();
+  return vaultClient.getShares(userAddress);
+}
+
+/**
+ * After a poll timeout, re-checks finality by transaction hash instead of
+ * treating the timeout as a hard failure — the transaction may still land.
+ * Emits the "recovering" phase while doing so.
+ */
+async function attemptRecovery(
+  vaultClient: VaultClient,
+  txHash: string,
+  onPhase?: TxPhaseCallback,
+): Promise<{ success: true; hash: string } | { success: false }> {
+  onPhase?.("recovering");
+  try {
+    const recovered = vaultClient.recoverTransaction<bigint>(txHash);
+    const confirmed = await recovered.wait({ timeoutMs: POLL_TIMEOUT_MS, pollIntervalMs: POLL_INTERVAL_MS });
+    return { success: true, hash: confirmed.hash };
+  } catch {
+    return { success: false };
+  }
 }
 
 async function getRecommendedBaseFee(priority: FeePriority = "average"): Promise<string> {
@@ -411,6 +438,13 @@ export async function deposit(
     onPhase?.("success");
     return { success: true, hash: confirmed.hash };
   } catch (err) {
+    if (err instanceof SubmissionTimeoutError) {
+      const recovery = await attemptRecovery(getVaultClient(), err.txHash, onPhase);
+      if (recovery.success) {
+        onPhase?.("success");
+        return { success: true, hash: recovery.hash };
+      }
+    }
     onPhase?.("failure");
     const parsed = parseContractError(err);
     return {
@@ -452,6 +486,13 @@ export async function withdraw(
     onPhase?.("success");
     return { success: true, hash: confirmed.hash };
   } catch (err) {
+    if (err instanceof SubmissionTimeoutError) {
+      const recovery = await attemptRecovery(getVaultClient(), err.txHash, onPhase);
+      if (recovery.success) {
+        onPhase?.("success");
+        return { success: true, hash: recovery.hash };
+      }
+    }
     onPhase?.("failure");
     const parsed = parseContractError(err);
     return {

--- a/client/src/services/transactionPhase.test.ts
+++ b/client/src/services/transactionPhase.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from "vitest";
 import {
   TX_PHASE_PIPELINE,
   TX_PHASE_SUBMIT_POLL,
+  TX_PHASE_RECOVERY,
+  TX_PHASE_LABELS,
   stepIndexIn,
   isStepCompleted,
   isStepActive,
@@ -49,5 +51,15 @@ describe("transactionPhase helpers", () => {
     expect(isTerminalPhase("success")).toBe(true);
     expect(isTerminalPhase("failure")).toBe(true);
     expect(isTerminalPhase("polling")).toBe(false);
+  });
+
+  it("treats 'recovering' as a non-terminal phase with a label", () => {
+    expect(isTerminalPhase("recovering")).toBe(false);
+    expect(TX_PHASE_LABELS.recovering).toBeTruthy();
+  });
+
+  it("exposes a single-step recovery pipeline", () => {
+    expect(TX_PHASE_RECOVERY).toEqual(["recovering"]);
+    expect(stepIndexIn(TX_PHASE_RECOVERY, "recovering")).toBe(0);
   });
 });

--- a/client/src/services/transactionPhase.ts
+++ b/client/src/services/transactionPhase.ts
@@ -8,6 +8,7 @@ export type TxPhase =
   | "waiting_for_wallet"
   | "submitting"
   | "polling"
+  | "recovering"
   | "success"
   | "failure";
 
@@ -75,6 +76,10 @@ export const TX_PHASE_LABELS: Record<TxPhase, string> = {
   waiting_for_wallet: "Waiting for wallet",
   submitting: "Submitting",
   polling: "Confirming on network",
+  recovering: "Recovering transaction status",
   success: "Success",
   failure: "Failed",
 };
+
+/** Recovery pipeline shown after a poll timeout while checking finality by hash. */
+export const TX_PHASE_RECOVERY: readonly TxPhase[] = ["recovering"];

--- a/client/src/utils/errorDecoder.test.ts
+++ b/client/src/utils/errorDecoder.test.ts
@@ -143,6 +143,30 @@ describe("decodeTransactionError", () => {
         expect(result.title).toBe("Network Error");
     });
 
+    it("handles unknown finality after a poll timeout (partial submission)", () => {
+        const result = decodeTransactionError(
+            "Transaction 'abc123' pending inclusion timed out after 30000ms. Transaction may still land on-chain; use recoverTransaction() to check.",
+        );
+        expect(result.title).toBe("Submission Status Unknown");
+        expect(result.suggestion).toContain("explorer");
+    });
+
+    it("handles the submitAndPoll generic timeout message (partial submission)", () => {
+        const result = decodeTransactionError("Transaction timed out");
+        expect(result.title).toBe("Submission Status Unknown");
+    });
+
+    it("handles a finalization failure (FAILED status reached on-chain)", () => {
+        const result = decodeTransactionError("Transaction failed on ledger 918273");
+        expect(result.title).toBe("Transaction Failed On-Chain");
+        expect(result.suggestion).toBeTruthy();
+    });
+
+    it("handles a finalization failure with hyphenated on-chain wording", () => {
+        const result = decodeTransactionError("Contract Execution Error [999 GenericSorobanError]: Transaction failed on-chain");
+        expect(result.title).toBe("Transaction Failed On-Chain");
+    });
+
     it("returns generic fallback for unrecognised error", () => {
         const result = decodeTransactionError("some completely unknown problem");
         expect(result.title).toBe("Transaction Failed");

--- a/client/src/utils/errorDecoder.ts
+++ b/client/src/utils/errorDecoder.ts
@@ -234,6 +234,31 @@ export function decodeTransactionError(raw: string): DecodedError {
         };
     }
 
+    // Partial submission / unknown finality: the transaction was sent (it has
+    // a hash) but polling never observed a terminal SUCCESS/FAILED status
+    // before the deadline. It may still land on-chain, so resubmitting is
+    // unsafe until finality is confirmed.
+    if (/pending inclusion timed out|may still land on-chain|transaction timed out/i.test(safeRaw)) {
+        return {
+            title: "Submission Status Unknown",
+            message: "Your transaction was submitted but its final status could not be confirmed in time.",
+            suggestion: "Check the transaction hash on an explorer before retrying, to avoid submitting a duplicate.",
+            raw: safeRaw,
+        };
+    }
+
+    // Finalization failure: the network reached a terminal FAILED status for
+    // a transaction that was actually included in a ledger (as opposed to a
+    // simulation-time contract error, which is decoded above via its error code).
+    if (/transaction failed on[\s-](ledger|chain)/i.test(safeRaw)) {
+        return {
+            title: "Transaction Failed On-Chain",
+            message: "The transaction was included in a ledger but did not succeed.",
+            suggestion: "Review the developer log for the failure reason, then retry with fresh simulation data.",
+            raw: safeRaw,
+        };
+    }
+
     if (/timeout|network|fetch/i.test(safeRaw)) {
         return {
             title: "Network Error",

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -12,8 +12,10 @@ npm install @stellaryield/sdk
 
 ### Vault Operations
 
+Every state-changing call (`deposit`, `withdraw`, `harvest`, `rebalance`, `emergencyWithdraw`) returns a `PreparedTransaction`, not a resolved value — drive it through the transaction lifecycle yourself (`simulate` happens during `prepare()`, then `sign` -> `submit` -> `poll`/`wait`):
+
 ```typescript
-import { VaultClient } from '@stellaryield/sdk';
+import { VaultClient, ServerKeypairSigner } from '@stellaryield/sdk';
 
 const vault = new VaultClient({
   contractId: 'CACT...',
@@ -21,22 +23,30 @@ const vault = new VaultClient({
   rpcUrl: 'https://soroban-testnet.stellar.org',
 });
 
+const signer = ServerKeypairSigner.fromSecret('S...');
+const from = await signer.getPublicKey();
+
 // Deposit tokens into the vault
-const shares = await vault.deposit({
-  from: 'GB...',
-  amount: '1000000000',
-  minSharesOut: '990000000', // 1% slippage tolerance
+const prepared = await vault.deposit.prepare({
+  from,
+  amount: 1_000_000_000n,
+  min_shares_out: 990_000_000n, // 1% slippage tolerance
 });
+const signed = await prepared.sign(signer);
+const submitted = await signed.submit(vault.rpcUrl);
+const confirmed = await submitted.wait();
+console.log(`Minted ${confirmed.result} shares in ledger ${confirmed.ledger}`);
 
 // Check your balance
-const myShares = await vault.getShares('GB...');
+const myShares = await vault.getShares(from);
 
 // Withdraw by burning shares
-const amount = await vault.withdraw({
-  to: 'GB...',
-  shares: '500000000',
-});
+const withdrawal = await (await vault.withdraw.prepare({ to: from, shares: myShares }))
+  .sign(signer);
+const withdrawn = await (await withdrawal.submit(vault.rpcUrl)).wait();
 ```
+
+If a simulation reports expired ledger entries, it throws `RestoreRequiredError` (`error.restorePreamble`) — pass that into the exported `restoreAndRetry()` helper, then retry `prepare()`. See `src/examples/basic.ts` for a full worked example including the restore path.
 
 ### API Client
 
@@ -60,12 +70,13 @@ const vaultData = await api.getVaultData('vault-contract-id');
 ## Features
 
 - **VaultClient**: Interact with YieldVault Soroban contract
-  - `deposit()`: Deposit tokens and receive shares
-  - `withdraw()`: Burn shares to receive tokens
+  - `deposit.prepare()`, `withdraw.prepare()`, `harvest.prepare()`, `rebalance.prepare()`, `emergencyWithdraw.prepare()`: build+simulate a `PreparedTransaction`
   - `getShares()`: Check user share balance
   - `totalShares()`, `totalAssets()`: Vault metrics
-  - `convertToShares()`, `convertToAssets()`: Price conversions
-  - `previewDeposit()`: Preview deposit outcome
+  - `getAdmin()`, `getToken()`, `getFlashLoanFee()`: Read-only contract state
+  - `recoverTransaction(hash)`: Resume polling a previously submitted transaction
+
+- **Lifecycle helpers**: `PreparedTransaction` -> `.sign()` -> `SignedTransaction` -> `.submit()` -> `SubmittedTransaction` -> `.wait()` -> `ConfirmedTransaction`, plus `restoreAndRetry()`/`needsRestore()` for the Soroban footprint-restore path. Errors carry a `phase` (`simulate`/`sign`/`submit`/`poll`/`restore`) and `retryable` flag.
 
 - **ApiClient**: Fetch vault metrics from backend
   - `getCurrentAPY()`: Get current APY

--- a/packages/sdk/package-lock.json
+++ b/packages/sdk/package-lock.json
@@ -1,0 +1,2813 @@
+{
+  "name": "@stellaryield/sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stellaryield/sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@stellar/stellar-sdk": "^14.6.1",
+        "buffer": "^6.0.3"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.0.0",
+        "vitest": "^3.0.5"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@stellar/js-xdr": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
+      "integrity": "sha512-VVolPL5goVEIsvuGqDc5uiKxV03lzfWdvYg1KikvwheDmTBO68CKDji3bAZ/kppZrx5iTA8z3Ld5yuytcvhvOQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@stellar/stellar-base": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-14.1.0.tgz",
+      "integrity": "sha512-A8kFli6QGy22SRF45IjgPAJfUNGjnI+R7g4DF5NZYVsD1kGf7B4ITyc4OPclLV9tqNI4/lXxafGEw0JEUbHixw==",
+      "deprecated": "This package is now rolled into @stellar/stellar-sdk. Please use @stellar/stellar-sdk to continue receiving updates and support.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/curves": "^1.9.6",
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.3.1",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.4.12"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@stellar/stellar-sdk": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-sdk/-/stellar-sdk-14.6.1.tgz",
+      "integrity": "sha512-A1rQWDLdUasXkMXnYSuhgep+3ZZzyuXJKdt5/KAIc0gkmSp906HTvUpbT4pu+bVr41tu0+J4Ugz9J4BQAGGytg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@stellar/stellar-base": "^14.1.0",
+        "axios": "^1.13.3",
+        "bignumber.js": "^9.3.1",
+        "commander": "^14.0.2",
+        "eventsource": "^2.0.2",
+        "feaxios": "^0.0.23",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      },
+      "bin": {
+        "stellar-js": "bin/stellar-js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/bundle-require": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
+      "integrity": "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "load-tsconfig": "^0.2.3"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "esbuild": ">=0.18"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/consola": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
+      "integrity": "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.18.0 || >=16.10.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/feaxios": {
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/feaxios/-/feaxios-0.0.23.tgz",
+      "integrity": "sha512-eghR0A21fvbkcQBgZuMfQhrXxJzC0GNUGC9fXhBge33D+mFDTwl0aJ35zoQQn575BhyjQitRc5N4f+L4cP708g==",
+      "license": "MIT",
+      "dependencies": {
+        "is-retry-allowed": "^3.0.0"
+      }
+    },
+    "node_modules/fix-dts-default-cjs-exports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
+      "integrity": "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.17",
+        "mlly": "^1.7.4",
+        "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-3.0.0.tgz",
+      "integrity": "sha512-9xH0xvoggby+u0uGF7cZXdrutWiBiaFG8ZT4YFPXL8NzkyAwX3AKGLeFQLvzDpM430+nDFBZ1LHkie/8ocL06A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/load-tsconfig": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/load-tsconfig/-/load-tsconfig-0.2.5.tgz",
+      "integrity": "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
+    },
+    "node_modules/tree-kill": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/urijs": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
+      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/packages/sdk/src/errors.ts
+++ b/packages/sdk/src/errors.ts
@@ -1,5 +1,11 @@
 import { VaultError } from "./generated/yield_vault";
 
+/**
+ * Lifecycle phase in which an SDK error originated. Lets callers branch on
+ * "where did this fail" instead of parsing error messages/class names alone.
+ */
+export type SdkErrorPhase = "simulate" | "sign" | "submit" | "poll" | "restore";
+
 export const VAULT_ERROR_MESSAGES: Record<number, string> = {
   1: "Contract not initialized",
   2: "Contract already initialized",
@@ -17,9 +23,16 @@ export const VAULT_ERROR_MESSAGES: Record<number, string> = {
 };
 
 export abstract class SorobanSdkError extends Error {
-  constructor(message: string) {
+  /** Lifecycle phase in which this error was raised, when known. */
+  public readonly phase?: SdkErrorPhase;
+  /** Whether retrying the operation that produced this error may succeed. */
+  public readonly retryable: boolean;
+
+  constructor(message: string, phase?: SdkErrorPhase, retryable = false) {
     super(message);
     this.name = this.constructor.name;
+    this.phase = phase;
+    this.retryable = retryable;
     Object.setPrototypeOf(this, new.target.prototype);
   }
 }
@@ -35,9 +48,10 @@ export class ContractExecutionError extends SorobanSdkError {
     errorName: string,
     message: string,
     rawResultXdr?: string,
-    diagnosticEvents?: string[]
+    diagnosticEvents?: string[],
+    phase: SdkErrorPhase = "submit"
   ) {
-    super(`Contract Execution Error [${errorCode} ${errorName}]: ${message}`);
+    super(`Contract Execution Error [${errorCode} ${errorName}]: ${message}`, phase, false);
     this.errorCode = errorCode;
     this.errorName = errorName;
     this.rawResultXdr = rawResultXdr;
@@ -51,7 +65,9 @@ export class WrongNetworkError extends SorobanSdkError {
 
   constructor(expectedNetwork: string, actualNetwork: string) {
     super(
-      `Network passphrase mismatch: expected '${expectedNetwork}', received '${actualNetwork}'`
+      `Network passphrase mismatch: expected '${expectedNetwork}', received '${actualNetwork}'`,
+      "sign",
+      false
     );
     this.expectedNetwork = expectedNetwork;
     this.actualNetwork = actualNetwork;
@@ -64,7 +80,9 @@ export class SpecMismatchError extends SorobanSdkError {
 
   constructor(expectedHash: string, actualHash: string) {
     super(
-      `Contract spec hash mismatch: expected '${expectedHash}', got '${actualHash}'`
+      `Contract spec hash mismatch: expected '${expectedHash}', got '${actualHash}'`,
+      "simulate",
+      false
     );
     this.expectedHash = expectedHash;
     this.actualHash = actualHash;
@@ -77,7 +95,9 @@ export class StaleSimulationError extends SorobanSdkError {
 
   constructor(currentLedger: number, validUntilLedger: number) {
     super(
-      `Simulation snapshot is stale (valid until ledger ${validUntilLedger}, current ledger ${currentLedger})`
+      `Simulation snapshot is stale (valid until ledger ${validUntilLedger}, current ledger ${currentLedger})`,
+      "simulate",
+      true
     );
     this.currentLedger = currentLedger;
     this.validUntilLedger = validUntilLedger;
@@ -90,7 +110,9 @@ export class SubmissionTimeoutError extends SorobanSdkError {
 
   constructor(txHash: string, timeoutMs: number) {
     super(
-      `Transaction '${txHash}' pending inclusion timed out after ${timeoutMs}ms. Transaction may still land on-chain; use recoverTransaction() to check.`
+      `Transaction '${txHash}' pending inclusion timed out after ${timeoutMs}ms. Transaction may still land on-chain; use recoverTransaction() to check.`,
+      "poll",
+      true
     );
     this.txHash = txHash;
     this.timeoutMs = timeoutMs;
@@ -99,7 +121,11 @@ export class SubmissionTimeoutError extends SorobanSdkError {
 
 export class WalletRejectedError extends SorobanSdkError {
   constructor(reason?: string) {
-    super(reason ? `Wallet rejected signature: ${reason}` : "Wallet rejected signature");
+    super(
+      reason ? `Wallet rejected signature: ${reason}` : "Wallet rejected signature",
+      "sign",
+      true
+    );
   }
 }
 
@@ -107,7 +133,7 @@ export class InvalidXdrError extends SorobanSdkError {
   public readonly rawXdr: string;
 
   constructor(rawXdr: string, details?: string) {
-    super(`Failed to parse or validate XDR string: ${details || "Invalid XDR"}`);
+    super(`Failed to parse or validate XDR string: ${details || "Invalid XDR"}`, "sign", false);
     this.rawXdr = rawXdr;
   }
 }
@@ -117,10 +143,63 @@ export class MissingAuthError extends SorobanSdkError {
 
   constructor(requiredAddress: string) {
     super(
-      `Transaction simulation requires authorization entry for '${requiredAddress}'`
+      `Transaction simulation requires authorization entry for '${requiredAddress}'`,
+      "simulate",
+      false
     );
     this.requiredAddress = requiredAddress;
   }
+}
+
+/**
+ * Restore preamble data returned by a `SimulateTransactionRestoreResponse`.
+ * `transactionData` is a `SorobanDataBuilder` instance from `@stellar/stellar-sdk`
+ * (kept as `unknown` here so `errors.ts` has no dependency on that package's types).
+ */
+export interface RestorePreambleInfo {
+  minResourceFee: string;
+  transactionData: unknown;
+}
+
+export class RestoreRequiredError extends SorobanSdkError {
+  public readonly minResourceFee: string;
+  public readonly restorePreamble?: RestorePreambleInfo;
+
+  constructor(minResourceFee: string, restorePreamble?: RestorePreambleInfo) {
+    super(
+      `Simulation indicates expired ledger entries requiring a restore footprint operation (min resource fee ${minResourceFee})`,
+      "restore",
+      true
+    );
+    this.minResourceFee = minResourceFee;
+    this.restorePreamble = restorePreamble;
+  }
+}
+
+/**
+ * Normalized finality classification for a submitted transaction's poll
+ * result, so callers can branch on a small stable set of outcomes instead of
+ * raw RPC status strings.
+ */
+export interface FinalityResult {
+  status: "success" | "failed" | "timeout" | "unknown";
+  retryable: boolean;
+}
+
+export function classifyFinality(
+  rpcStatus: string | undefined,
+  timedOut: boolean
+): FinalityResult {
+  if (rpcStatus === "SUCCESS") {
+    return { status: "success", retryable: false };
+  }
+  if (rpcStatus === "FAILED") {
+    return { status: "failed", retryable: false };
+  }
+  if (rpcStatus === "NOT_FOUND" && timedOut) {
+    return { status: "timeout", retryable: true };
+  }
+  return { status: "unknown", retryable: true };
 }
 
 export function decodeVaultError(code: number): { name: string; message: string } {
@@ -133,7 +212,8 @@ export function decodeVaultError(code: number): { name: string; message: string 
 export function parseContractError(
   error: unknown,
   rawResultXdr?: string,
-  diagnosticEvents?: string[]
+  diagnosticEvents?: string[],
+  phase: SdkErrorPhase = "submit"
 ): SorobanSdkError {
   if (error instanceof SorobanSdkError) {
     return error;
@@ -145,7 +225,7 @@ export function parseContractError(
   if (codeMatch) {
     const codeNum = parseInt(codeMatch[1] || codeMatch[2] || codeMatch[3], 10);
     const { name, message } = decodeVaultError(codeNum);
-    return new ContractExecutionError(codeNum, name, message, rawResultXdr, diagnosticEvents);
+    return new ContractExecutionError(codeNum, name, message, rawResultXdr, diagnosticEvents, phase);
   }
 
   return new ContractExecutionError(
@@ -153,6 +233,7 @@ export function parseContractError(
     "GenericSorobanError",
     errString || "Unknown Soroban contract execution failure",
     rawResultXdr,
-    diagnosticEvents
+    diagnosticEvents,
+    phase
   );
 }

--- a/packages/sdk/src/examples/basic.ts
+++ b/packages/sdk/src/examples/basic.ts
@@ -1,28 +1,105 @@
-import { VaultClient, ApiClient } from "../index";
+import { rpc } from "@stellar/stellar-sdk";
+import {
+  VaultClient,
+  ApiClient,
+  ServerKeypairSigner,
+  RestoreRequiredError,
+  restoreAndRetry,
+} from "../index";
 
 /**
- * Example: Basic vault operations
+ * Example: full deposit lifecycle (simulate -> sign -> submit -> poll -> confirm).
+ *
+ * Every state-changing VaultClient method (deposit/withdraw/harvest/rebalance/
+ * emergencyWithdraw) returns a `PreparedTransaction`, not a resolved value —
+ * you drive it through `.sign()` -> `.submit()` -> `.wait()` yourself so any
+ * wallet (a raw secret key here, Freighter, or a custom signer) can be used.
  */
-async function basicVaultExample() {
+async function depositExample() {
+  const rpcUrl = "https://soroban-testnet.stellar.org";
+  const networkPassphrase = "Test SDF Network ; September 2015";
+
   const vaultClient = new VaultClient({
     contractId: "CACTXW...(your vault contract ID)",
-    networkPassphrase: "Test SDF Network ; September 2015",
-    rpcUrl: "https://soroban-testnet.stellar.org",
+    networkPassphrase,
+    rpcUrl,
   });
 
-  const shares = await vaultClient.deposit({
-    from: "GB...(your wallet address)",
-    amount: "1000000000", // 100 units (7 decimals stroops)
-    minSharesOut: "990000000", // Accept 1% slippage
+  const signer = ServerKeypairSigner.fromSecret("S...(your secret key)");
+  const from = await signer.getPublicKey();
+
+  let prepared = await vaultClient.deposit.prepare({
+    from,
+    amount: 1_000_000_000n, // 100 units (7-decimal stroops)
+    min_shares_out: 990_000_000n, // accept up to 1% slippage
   });
 
-  console.log(`Deposited and received ${shares} shares`);
+  const signed = await prepared.sign(signer);
+  const submitted = await signed.submit(rpcUrl);
 
-  const userShares = await vaultClient.getShares("GB...(your wallet address)");
-  console.log(`User has ${userShares} shares`);
+  try {
+    const confirmed = await submitted.wait();
+    console.log(`Deposit confirmed in ledger ${confirmed.ledger}, minted ${confirmed.result} shares`);
+  } catch (error) {
+    if (error instanceof RestoreRequiredError && error.restorePreamble) {
+      // Some ledger entries the deposit touches have expired; restore them
+      // and then retry the original prepare/sign/submit/wait sequence.
+      const server = new rpc.Server(rpcUrl);
+      const account = await server.getAccount(from);
+      await restoreAndRetry({
+        restorePreamble: error.restorePreamble as {
+          minResourceFee: string;
+          transactionData: { build(): unknown };
+        },
+        sourceAccount: account,
+        networkPassphrase,
+        signer,
+        server,
+        contractId: vaultClient.contractId,
+      });
 
-  const vaultInfo = await vaultClient.getInfo();
-  console.log("Vault info:", vaultInfo);
+      prepared = await vaultClient.deposit.prepare({ from, amount: 1_000_000_000n });
+      const retrySigned = await prepared.sign(signer);
+      const retrySubmitted = await retrySigned.submit(rpcUrl);
+      const confirmed = await retrySubmitted.wait();
+      console.log(`Deposit confirmed after restore in ledger ${confirmed.ledger}`);
+    } else {
+      throw error;
+    }
+  }
+
+  const userShares = await vaultClient.getShares(from);
+  console.log(`User now has ${userShares} shares`);
+}
+
+/**
+ * Example: full withdrawal lifecycle (simulate -> sign -> submit -> poll -> confirm).
+ */
+async function withdrawExample() {
+  const rpcUrl = "https://soroban-testnet.stellar.org";
+  const networkPassphrase = "Test SDF Network ; September 2015";
+
+  const vaultClient = new VaultClient({
+    contractId: "CACTXW...(your vault contract ID)",
+    networkPassphrase,
+    rpcUrl,
+  });
+
+  const signer = ServerKeypairSigner.fromSecret("S...(your secret key)");
+  const to = await signer.getPublicKey();
+
+  const sharesToRedeem = await vaultClient.getShares(to);
+
+  const prepared = await vaultClient.withdraw.prepare({
+    to,
+    shares: sharesToRedeem,
+  });
+
+  const signed = await prepared.sign(signer);
+  const submitted = await signed.submit(rpcUrl);
+  const confirmed = await submitted.wait();
+
+  console.log(`Withdrawal confirmed in ledger ${confirmed.ledger}, returned ${confirmed.result} asset units`);
 }
 
 /**
@@ -44,21 +121,18 @@ async function apiExample() {
 }
 
 /**
- * Example: Share price calculations
+ * Example: read-only vault view calls
  */
-async function shareCalculationsExample() {
+async function readOnlyExample() {
   const vaultClient = new VaultClient({
-    contractId: "CACT...",
+    contractId: "CACTXW...(your vault contract ID)",
     networkPassphrase: "Test SDF Network ; September 2015",
     rpcUrl: "https://soroban-testnet.stellar.org",
   });
 
-  const assets = "1000000000";
-  const shares = await vaultClient.convertToShares(assets);
-  console.log(`${assets} assets = ${shares} shares`);
-
-  const previewShares = await vaultClient.previewDeposit(assets);
-  console.log(`Preview: depositing ${assets} would mint ${previewShares} shares`);
+  const totalAssets = await vaultClient.totalAssets();
+  const totalShares = await vaultClient.totalShares();
+  console.log(`Vault holds ${totalAssets} asset units backing ${totalShares} shares`);
 }
 
-export { basicVaultExample, apiExample, shareCalculationsExample };
+export { depositExample, withdrawExample, apiExample, readOnlyExample };

--- a/packages/sdk/src/lifecycle.ts
+++ b/packages/sdk/src/lifecycle.ts
@@ -1,14 +1,10 @@
-import { rpc, TransactionBuilder, Networks } from "@stellar/stellar-sdk";
+import { rpc, TransactionBuilder, Operation, Account } from "@stellar/stellar-sdk";
 import type { SignerAdapter } from "./signers";
 import {
-  WrongNetworkError,
   SpecMismatchError,
-  StaleSimulationError,
   SubmissionTimeoutError,
-  ContractExecutionError,
   InvalidXdrError,
   parseContractError,
-  decodeVaultError,
 } from "./errors";
 import { YIELD_VAULT_SPEC_HASH } from "./generated/yield_vault";
 
@@ -158,6 +154,7 @@ export class SignedTransaction<T = unknown> {
       response.hash,
       {
         rpcUrl,
+        rpcServer: typeof serverOrUrl !== "string" && !("rpcUrl" in serverOrUrl) ? server : undefined,
         networkPassphrase: this.meta.networkPassphrase,
         preparedMeta: this.meta,
       }
@@ -169,6 +166,8 @@ export interface SubmittedOpts<T> {
   rpcUrl: string;
   networkPassphrase: string;
   preparedMeta?: PreparedTransactionMeta<T>;
+  /** Optional pre-constructed/injectable RPC client, e.g. a test double. Falls back to `new rpc.Server(rpcUrl)` when omitted. */
+  rpcServer?: rpc.Server;
 }
 
 export class SubmittedTransaction<T = unknown> {
@@ -198,7 +197,7 @@ export class SubmittedTransaction<T = unknown> {
     const pollInterval = options?.pollIntervalMs ?? 1000;
     const timeout = options?.timeoutMs ?? 30000;
     const startTime = Date.now();
-    const server = new rpc.Server(this.opts.rpcUrl);
+    const server = this.opts.rpcServer ?? new rpc.Server(this.opts.rpcUrl);
 
     while (Date.now() - startTime < timeout) {
       if (options?.signal?.aborted) {
@@ -208,7 +207,7 @@ export class SubmittedTransaction<T = unknown> {
       const txStatus = await server.getTransaction(this.hash);
 
       if (txStatus.status === rpc.Api.GetTransactionStatus.SUCCESS) {
-        let resultValue = this.opts.preparedMeta?.simulationResult as T;
+        const resultValue = this.opts.preparedMeta?.simulationResult as T;
         const resultXdr = txStatus.resultXdr?.toXDR("base64");
 
         return new ConfirmedTransaction<T>(
@@ -223,19 +222,78 @@ export class SubmittedTransaction<T = unknown> {
         const resultXdr = txStatus.resultXdr?.toXDR("base64");
         throw parseContractError(
           new Error(`Transaction failed on ledger ${txStatus.ledger}`),
-          resultXdr
+          resultXdr,
+          undefined,
+          "poll"
         );
       }
 
-      if (txStatus.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
-        // Still pending inclusion
-      }
-
+      // NOT_FOUND (or any other transient status): still pending inclusion, keep polling.
       await new Promise((resolve) => setTimeout(resolve, pollInterval));
     }
 
     throw new SubmissionTimeoutError(this.hash, timeout);
   }
+}
+
+/**
+ * True when a simulation response indicates expired ledger entries in the
+ * transaction's footprint must be restored before the operation can succeed.
+ */
+export function needsRestore(
+  simulation: rpc.Api.SimulateTransactionResponse | undefined
+): simulation is rpc.Api.SimulateTransactionRestoreResponse {
+  return !!simulation && rpc.Api.isSimulationRestore(simulation);
+}
+
+/**
+ * Given a restore preamble from a `SimulateTransactionRestoreResponse`
+ * (surfaced to callers via `RestoreRequiredError.restorePreamble`), builds,
+ * signs, submits, and awaits a `RestoreFootprintOp` transaction that brings
+ * the expired ledger entries back into scope. On success, the caller should
+ * simply retry its original prepare call (`vaultClient.deposit.prepare(...)`,
+ * etc.) — the entries will simulate successfully now.
+ */
+export async function restoreAndRetry(params: {
+  restorePreamble: { minResourceFee: string; transactionData: { build(): unknown } };
+  sourceAccount: Account;
+  networkPassphrase: string;
+  signer: SignerAdapter;
+  server: rpc.Server;
+  contractId?: string;
+}): Promise<ConfirmedTransaction<void>> {
+  const { restorePreamble, sourceAccount, networkPassphrase, signer, server, contractId } = params;
+
+  const restoreTx = new TransactionBuilder(sourceAccount, {
+    fee: restorePreamble.minResourceFee,
+    networkPassphrase,
+  })
+    .addOperation(Operation.restoreFootprint({}))
+    .setSorobanData(restorePreamble.transactionData.build() as any)
+    .setTimeout(30)
+    .build();
+
+  const signedXdr = await signer.signTransaction(restoreTx.toXDR(), {
+    networkPassphrase,
+    contractId,
+  });
+
+  const signed = new SignedTransaction<void>(signedXdr, {
+    simulationResult: undefined as unknown as void,
+    footprint: "",
+    authEntries: [],
+    minResourceFee: restorePreamble.minResourceFee,
+    transactionData: "",
+    latestLedger: 0,
+    validUntilLedger: 0,
+    contractId: contractId ?? "",
+    networkPassphrase,
+    method: "restore_footprint",
+    argsHash: "",
+  });
+
+  const submitted = await signed.submit(server);
+  return submitted.wait();
 }
 
 export class ConfirmedTransaction<T = unknown> {

--- a/packages/sdk/src/vault/VaultClient.ts
+++ b/packages/sdk/src/vault/VaultClient.ts
@@ -1,11 +1,14 @@
-import { rpc, Keypair } from "@stellar/stellar-sdk";
 import {
   Client as GeneratedVaultClient,
   YIELD_VAULT_SPEC_HASH,
-  VaultError,
 } from "../generated/yield_vault";
-import { PreparedTransaction, PreparedTransactionMeta, SubmittedTransaction } from "../lifecycle";
-import { SpecMismatchError, WrongNetworkError, parseContractError } from "../errors";
+import {
+  PreparedTransaction,
+  PreparedTransactionMeta,
+  SubmittedTransaction,
+  needsRestore,
+} from "../lifecycle";
+import { SpecMismatchError, parseContractError, RestoreRequiredError } from "../errors";
 import type { VaultConfig } from "../types";
 
 export interface PreparedMethod<TArgs, TResult> {
@@ -137,6 +140,14 @@ export class VaultClient {
       }
 
       const assembled = await fn.call(this.generatedClient, args);
+
+      if (needsRestore(assembled.simulation)) {
+        throw new RestoreRequiredError(
+          assembled.simulation.restorePreamble.minResourceFee,
+          assembled.simulation.restorePreamble
+        );
+      }
+
       const rawXdr = assembled.built ? assembled.built.toXDR() : assembled.simulation;
 
       const meta: PreparedTransactionMeta<TResult> = {
@@ -156,7 +167,7 @@ export class VaultClient {
 
       return new PreparedTransaction<TResult>(rawXdr, meta);
     } catch (error) {
-      throw parseContractError(error);
+      throw parseContractError(error, undefined, undefined, "simulate");
     }
   }
 

--- a/packages/sdk/test/fixtures/fakeRpc.ts
+++ b/packages/sdk/test/fixtures/fakeRpc.ts
@@ -1,0 +1,122 @@
+/**
+ * Deterministic fake RPC server implementing just the `rpc.Server` surface
+ * the lifecycle helpers actually call (`sendTransaction`, `getTransaction`),
+ * so lifecycle tests can drive success/rejection/timeout/restore scenarios
+ * without touching a real network.
+ */
+
+export interface FakeXdrResult {
+  toXDR(format?: string): string;
+}
+
+export function fakeXdrResult(base64 = "AAAAAAAAAAA="): FakeXdrResult {
+  return { toXDR: () => base64 };
+}
+
+export interface FakeSendTransactionResponse {
+  status: "PENDING" | "DUPLICATE" | "TRY_AGAIN_LATER" | "ERROR";
+  hash: string;
+  latestLedger: number;
+  latestLedgerCloseTime: number;
+  errorResult?: FakeXdrResult;
+  diagnosticEvents?: unknown[];
+}
+
+export function fakeSendPending(hash: string): FakeSendTransactionResponse {
+  return { status: "PENDING", hash, latestLedger: 1000, latestLedgerCloseTime: 0 };
+}
+
+export function fakeSendError(hash = "0000000000000000000000000000000000000000000000000000000000000000"): FakeSendTransactionResponse {
+  return {
+    status: "ERROR",
+    hash,
+    latestLedger: 1000,
+    latestLedgerCloseTime: 0,
+    errorResult: fakeXdrResult(),
+  };
+}
+
+export interface FakeGetTransactionResponse {
+  status: "SUCCESS" | "FAILED" | "NOT_FOUND";
+  txHash: string;
+  latestLedger: number;
+  latestLedgerCloseTime: number;
+  oldestLedger: number;
+  oldestLedgerCloseTime: number;
+  ledger?: number;
+  resultXdr?: FakeXdrResult;
+}
+
+export function fakeGetSuccess(ledger = 4242): FakeGetTransactionResponse {
+  return {
+    status: "SUCCESS",
+    txHash: "success",
+    latestLedger: ledger,
+    latestLedgerCloseTime: 0,
+    oldestLedger: 0,
+    oldestLedgerCloseTime: 0,
+    ledger,
+    resultXdr: fakeXdrResult(),
+  };
+}
+
+export function fakeGetFailed(ledger = 4242): FakeGetTransactionResponse {
+  return {
+    status: "FAILED",
+    txHash: "failed",
+    latestLedger: ledger,
+    latestLedgerCloseTime: 0,
+    oldestLedger: 0,
+    oldestLedgerCloseTime: 0,
+    ledger,
+    resultXdr: fakeXdrResult(),
+  };
+}
+
+export function fakeGetNotFound(): FakeGetTransactionResponse {
+  return {
+    status: "NOT_FOUND",
+    txHash: "pending",
+    latestLedger: 1000,
+    latestLedgerCloseTime: 0,
+    oldestLedger: 0,
+    oldestLedgerCloseTime: 0,
+  };
+}
+
+export interface FakeRpcScript {
+  /** Response(s) returned from `sendTransaction`. A function is invoked fresh each call. */
+  send?: FakeSendTransactionResponse | (() => FakeSendTransactionResponse);
+  /**
+   * Sequence of responses returned from successive `getTransaction` polls.
+   * The last entry repeats once the sequence is exhausted.
+   */
+  pollSequence?: FakeGetTransactionResponse[];
+}
+
+export interface FakeRpcServer {
+  sendTransaction(tx: unknown): Promise<FakeSendTransactionResponse>;
+  getTransaction(hash: string): Promise<FakeGetTransactionResponse>;
+  readonly pollCallCount: number;
+}
+
+export function createFakeRpcServer(script: FakeRpcScript): FakeRpcServer {
+  let pollIndex = 0;
+  const sequence = script.pollSequence ?? [fakeGetSuccess()];
+
+  return {
+    async sendTransaction() {
+      const send = script.send;
+      if (typeof send === "function") return send();
+      return send ?? fakeSendPending("deadbeef");
+    },
+    async getTransaction() {
+      const response = sequence[Math.min(pollIndex, sequence.length - 1)];
+      pollIndex++;
+      return response;
+    },
+    get pollCallCount() {
+      return pollIndex;
+    },
+  };
+}

--- a/packages/sdk/test/lifecycle.test.ts
+++ b/packages/sdk/test/lifecycle.test.ts
@@ -1,20 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { Keypair, TransactionBuilder, Account, Operation, Networks, Asset } from "@stellar/stellar-sdk";
+import { Keypair, TransactionBuilder, Account, Operation, Networks, Asset, SorobanDataBuilder } from "@stellar/stellar-sdk";
 import {
   VaultClient,
   PreparedTransaction,
   SignedTransaction,
   SubmittedTransaction,
+  ConfirmedTransaction,
   ServerKeypairSigner,
   CustomSigner,
   FreighterSigner,
   SpecMismatchError,
   ContractExecutionError,
+  WalletRejectedError,
+  SubmissionTimeoutError,
+  RestoreRequiredError,
   decodeVaultError,
   parseContractError,
+  needsRestore,
+  restoreAndRetry,
   YIELD_VAULT_SPEC_HASH,
   ApiClient,
 } from "../src";
+import {
+  createFakeRpcServer,
+  fakeGetSuccess,
+  fakeGetFailed,
+  fakeGetNotFound,
+  fakeSendPending,
+} from "./fixtures/fakeRpc";
 
 describe("Soroban SDK Bindings & Lifecycle", () => {
   const dummyContractId = "CCW67TSB3SSSBDGRGBXMORAX6P4CBGQLGLKXMFFBVD7OH5VO5BTV6U2M";
@@ -156,6 +169,169 @@ describe("Soroban SDK Bindings & Lifecycle", () => {
       const endpoints = api.getRegisteredEndpoints();
       expect(endpoints.length).toBeGreaterThan(0);
       expect(endpoints.some((e) => e.pathPattern === "/api/yields")).toBe(true);
+    });
+  });
+
+  describe("Full lifecycle: simulate -> sign -> submit -> poll -> confirm", () => {
+    it("resolves a ConfirmedTransaction through a fake RPC, tolerating an initial NOT_FOUND poll", async () => {
+      const unsignedXdr = createUnsignedXdr();
+      const meta = {
+        simulationResult: 250n,
+        footprint: "f",
+        authEntries: [],
+        minResourceFee: "1000",
+        transactionData: "",
+        latestLedger: 1000,
+        validUntilLedger: 1100,
+        contractId: dummyContractId,
+        networkPassphrase: dummyPassphrase,
+        method: "deposit",
+        argsHash: "{}",
+      };
+
+      const prepared = PreparedTransaction.fromXDR<bigint>(unsignedXdr, meta);
+      const signer = new ServerKeypairSigner(sourceKeypair);
+      const signed = await prepared.sign(signer);
+
+      const fakeServer = createFakeRpcServer({
+        send: fakeSendPending("abc123"),
+        pollSequence: [fakeGetNotFound(), fakeGetSuccess(555)],
+      });
+
+      const submitted = await signed.submit(fakeServer as any);
+      expect(submitted.state).toBe("SUBMITTED");
+
+      const confirmed = await submitted.wait({ pollIntervalMs: 1 });
+      expect(confirmed).toBeInstanceOf(ConfirmedTransaction);
+      expect(confirmed.ledger).toBe(555);
+      expect(confirmed.result).toBe(250n);
+    });
+  });
+
+  describe("Rejected-signature flow", () => {
+    it("throws WalletRejectedError with phase 'sign' and retryable true when the wallet rejects", async () => {
+      const unsignedXdr = createUnsignedXdr();
+      const meta = {
+        simulationResult: 1n,
+        footprint: "",
+        authEntries: [],
+        minResourceFee: "100",
+        transactionData: "",
+        latestLedger: 1,
+        validUntilLedger: 100,
+        contractId: dummyContractId,
+        networkPassphrase: dummyPassphrase,
+        method: "deposit",
+        argsHash: "{}",
+      };
+      const prepared = PreparedTransaction.fromXDR<bigint>(unsignedXdr, meta);
+
+      const rejectingSigner = new CustomSigner(sourceKeypair.publicKey(), async () => {
+        throw new Error("User declined the request");
+      });
+
+      await expect(prepared.sign(rejectingSigner)).rejects.toBeInstanceOf(WalletRejectedError);
+      try {
+        await prepared.sign(rejectingSigner);
+        throw new Error("expected rejection");
+      } catch (err) {
+        expect(err).toBeInstanceOf(WalletRejectedError);
+        expect((err as WalletRejectedError).phase).toBe("sign");
+        expect((err as WalletRejectedError).retryable).toBe(true);
+      }
+    });
+  });
+
+  describe("Expired/timeout flow", () => {
+    it("throws SubmissionTimeoutError with retryable=true when the transaction never lands", async () => {
+      const fakeServer = createFakeRpcServer({ pollSequence: [fakeGetNotFound()] });
+      const submitted = SubmittedTransaction.fromHash<bigint>("neverlands", {
+        rpcUrl: dummyRpcUrl,
+        networkPassphrase: dummyPassphrase,
+        rpcServer: fakeServer as any,
+      });
+
+      await expect(
+        submitted.wait({ timeoutMs: 20, pollIntervalMs: 5 })
+      ).rejects.toMatchObject({
+        name: "SubmissionTimeoutError",
+        txHash: "neverlands",
+        phase: "poll",
+        retryable: true,
+      });
+    });
+
+    it("throws a phase='poll' ContractExecutionError when the network reports FAILED", async () => {
+      const fakeServer = createFakeRpcServer({ pollSequence: [fakeGetFailed(999)] });
+      const submitted = SubmittedTransaction.fromHash<bigint>("willfail", {
+        rpcUrl: dummyRpcUrl,
+        networkPassphrase: dummyPassphrase,
+        rpcServer: fakeServer as any,
+      });
+
+      await expect(submitted.wait()).rejects.toMatchObject({
+        phase: "poll",
+        retryable: false,
+      });
+    });
+  });
+
+  describe("Restore path", () => {
+    it("needsRestore() is false for a plain successful simulation", () => {
+      expect(needsRestore({ transactionData: "present" } as any)).toBe(false);
+    });
+
+    it("needsRestore() is true when the simulation carries a restorePreamble", () => {
+      expect(
+        needsRestore({
+          transactionData: "present",
+          restorePreamble: { minResourceFee: "100", transactionData: "needed" },
+        } as any)
+      ).toBe(true);
+    });
+
+    it("restoreAndRetry() builds, signs, submits and confirms a restore-footprint transaction", async () => {
+      const restoreAccount = new Account(sourceKeypair.publicKey(), "100");
+      const fakeServer = createFakeRpcServer({
+        send: fakeSendPending("restoretxhash"),
+        pollSequence: [fakeGetSuccess(777)],
+      });
+
+      const confirmed = await restoreAndRetry({
+        restorePreamble: { minResourceFee: "5000", transactionData: new SorobanDataBuilder() },
+        sourceAccount: restoreAccount,
+        networkPassphrase: dummyPassphrase,
+        signer: new ServerKeypairSigner(sourceKeypair),
+        server: fakeServer as any,
+        contractId: dummyContractId,
+      });
+
+      expect(confirmed).toBeInstanceOf(ConfirmedTransaction);
+      expect(confirmed.ledger).toBe(777);
+    });
+
+    it("VaultClient surfaces RestoreRequiredError (phase='restore', retryable=true) when simulation needs a restore", async () => {
+      const client = new VaultClient({
+        contractId: dummyContractId,
+        networkPassphrase: dummyPassphrase,
+        rpcUrl: dummyRpcUrl,
+      });
+
+      (client as any).generatedClient.deposit = async () => ({
+        simulation: {
+          transactionData: "present",
+          restorePreamble: { minResourceFee: "12345", transactionData: "needed" },
+        },
+      });
+
+      await expect(
+        client.deposit({ from: sourceKeypair.publicKey(), amount: 100n })
+      ).rejects.toMatchObject({
+        name: "RestoreRequiredError",
+        minResourceFee: "12345",
+        phase: "restore",
+        retryable: true,
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #922, #914, #912, #911

- **#922 (SDK)** — `packages/sdk`: `SubmittedTransaction.wait()` now accepts an injectable RPC client; SDK errors carry a `phase` (`simulate`/`sign`/`submit`/`poll`/`restore`) and `retryable` flag; added a normalized finality classifier and a `restoreAndRetry`/`needsRestore` helper for the Soroban restore-footprint path, wired into `VaultClient`. Added a deterministic fake-RPC test fixture and lifecycle tests covering the success, rejected-signature, timeout, and restore paths. Fixed `examples/basic.ts`, which called methods that don't exist on `VaultClient` and predated the current lifecycle API.

- **#914 (client)** — wired the existing `TxPhase`/`TxStatusTimeline`/`TransactionFailedModal` trio into the governance proposal builder and the rewards claim flow (both previously had bespoke status/error handling). Added a withdraw UI (`features/withdraw/WithdrawPanel.tsx`) — the SDK's `withdraw()` in `services/soroban.ts` was fully implemented but had zero UI callers. Added a `recovering` phase for the post-timeout recovery path, and extended the error decoder to recognize partial-submission/unknown-finality and on-chain finalization failures (previously fell through to a generic fallback message).

- **#912 (backend/keepers)** — new hash-chained, tamper-evident audit log for keeper decisions (`audit/KeeperAuditLog.ts`), modeled on the existing hash-chain pattern in `server/src/middleware/audit.ts`: per-worker-stream JSONL files, redaction (`audit/redact.ts`) applied before hashing/persistence, and a monotonic `seq` field so reordered or deleted records are detected in addition to tampering. Exposed via a bounded `GET /audit/export?stream=&from=&to=` endpoint on the keeper's existing lightweight health server.

- **#911 (backend/keepers)** — `signer/SignerProvider.ts` introduces a least-privilege signer abstraction (`LocalSignerProvider`, `EnvSignerProvider`, `ExternalSignerProvider`) each declaring an operation allowlist; `KeeperSigner.invokeContract` now rejects any operation outside that allowlist *before* touching the network (before `getAccount`/`TransactionBuilder`). `signer/KeeperSignerRegistry.ts` allows hot-swapping the active provider — jobs read `registry.currentProvider` fresh at dispatch, so in-flight invocations keep the provider they started with while new jobs pick up a rotation. `KeeperSigner`'s existing constructor and `invokeContract` call sites remain backward compatible (raw secret string still works).

## Notes

- `KeeperSigner.ts` is touched by both #911 and #912 as one coordinated diff (provider refactor + allowlist + audit hook) to avoid double-editing it.
- Audit logging is opt-in via `KeeperSignerOptions.auditLog` — existing tests that construct `KeeperSigner` without it see no behavior change and perform zero file I/O.
- `client/package.json` gains a `file:../packages/sdk` dependency — without it, `client/src/services/soroban.ts`'s existing `@stellaryield/sdk` import (pre-dating this PR) can't resolve at all, which blocked installing/building/testing the client package entirely.
- Fixed a pre-existing accessibility bug (missing accessible name on the governance action `<select>`) while touching `TransactionBuilder.tsx` for its lifecycle wiring — this alone took that test file from 0/30 to 18/30 passing. The remaining 12 failures there are pre-existing and unrelated (contract-ID format validation vs. the test's fixture data), verified via `git stash` against the base commit.

## Test plan

- [x] `cd packages/sdk && npm install && npm run typecheck && npm test` — 17/17 pass
- [x] `cd client && npm install && npx vitest run` — same 27 failing files as the pre-existing baseline (verified via diff), zero regressions; all new/changed tests pass
- [x] `cd backend/keepers && npm install && npx tsc --noEmit && npx jest` — 342/344 pass; the 2 pre-existing failures (`FragmentationCalculator`, `googleSheets.test.ts` syntax error) and 1 pre-existing suite-load failure (`helpers/failureHarness.ts`) are unrelated to this change (confirmed via `git stash`)