### PR TITLE
feat: add contributor setup doctor for Node, Rust, Soroban CLI, and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ git clone https://github.com/YOUR_GITHUB_NAME/StellarYield.git
 cd StellarYield
 ```
 
+### Setup Doctor
+
+After cloning (and again any time something feels off before running tests), run the setup doctor to check your toolchain and workspace in one pass:
+
+```bash
+node scripts/setup-doctor.js
+# or
+npm run setup:doctor
+```
+
+It checks Node.js, npm, Rust, cargo, and the Stellar/Soroban CLI; whether each workspace (`client/`, `server/`, `contracts/`, `backend/keepers/`, `backend/rewards/`, `packages/sdk/`) has its dependencies installed; and whether each workspace's `.env.example` has been copied to a real env file — printing a concise remediation command for anything missing. See [docs/contributor-guide.md](./docs/contributor-guide.md#setup-doctor) for what each check means and how to read the output.
+
 ### Frontend Setup
 
 ```bash

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -4,6 +4,26 @@ This document maps [GitHub Actions workflows](../.github/workflows/) to what the
 
 ---
 
+## Setup Doctor
+
+Before debugging a confusing local test or build failure, run the setup doctor:
+
+```bash
+node scripts/setup-doctor.js
+# or
+npm run setup:doctor
+```
+
+It checks three things and prints a remediation command for anything it finds missing:
+
+1. **Toolchain** — Node.js 20+, npm 10+ (blocking: nothing in this repo runs without them), and Rust/cargo/the Stellar (or Soroban) CLI (recommended, only needed for `contracts/` work).
+2. **Workspace dependencies** — whether `node_modules` exists in each npm workspace (`client/`, `server/`, `contracts/`, `backend/keepers/`, `backend/rewards/`, `packages/sdk/`). Missing ones print the exact `cd <dir> && npm ci` to run.
+3. **Environment files** — whether each workspace's `.env.example` is present (its absence is a blocking, corrupted-checkout signal) and whether the real `.env`/`.env.local` derived from it exists yet.
+
+Output uses `✅` for OK, `⚠️` for a non-blocking gap relevant only to certain workspaces, and `❌` for a blocking issue. The script exits non-zero only when a `❌` is present — a fresh clone with no `node_modules` installed anywhere is expected to show several `⚠️` lines and still exit `0`; that's the tool telling you what to run next, not that anything is broken. See [docs/deployment-environment-matrix.md](./deployment-environment-matrix.md) for what to put in each `.env` file once it's copied.
+
+---
+
 ## Quick reference: blocking vs advisory
 
 The table below reflects **`continue-on-error`**, conditional `if:` steps, and job-level settings in the workflow files—not the Vercel dashboard or optional org-level rules.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "smoke-test:node": "node scripts/smoke-test.js",
     "smoke-test:portable": "node scripts/smoke-test.js",
     "validate-workspace": "node scripts/validate-workspace.js",
-    "test:provenance": "vitest run tests/services/provenance.test.ts --coverage"
+    "test:provenance": "vitest run tests/services/provenance.test.ts --coverage",
+    "setup:doctor": "node scripts/setup-doctor.js"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/scripts/setup-doctor.js
+++ b/scripts/setup-doctor.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Contributor Setup Doctor  (Issue #966)
+ *
+ * Checks the local toolchain and workspace setup and prints concise,
+ * actionable remediation for anything missing — so contributors find out
+ * about a missing toolchain or env file immediately, instead of after a
+ * confusing test/build failure.
+ *
+ * Checks:
+ *   - Node.js and npm versions (blocking — nothing in this repo runs without them)
+ *   - Rust, cargo, and the Stellar/Soroban CLI (recommended — only needed for contracts/ work)
+ *   - `node_modules` present in each npm workspace (client, server, contracts,
+ *     backend/keepers, backend/rewards, packages/sdk)
+ *   - Each workspace's `.env.example` is present (blocking — its absence means
+ *     the checkout itself is broken) and whether the real `.env`/`.env.local`
+ *     derived from it exists yet (informational — normal before first setup)
+ *
+ * Usage: node scripts/setup-doctor.js
+ * Exit code 0: no blocking issues. Exit code 1: at least one blocking issue.
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+const ROOT = path.resolve(__dirname, "..");
+
+const MIN_NODE_MAJOR = 20;
+const MIN_NPM_MAJOR = 10;
+
+const WORKSPACES = [
+  { dir: "client", envExample: ".env.example", envFile: ".env.local" },
+  { dir: "server", envExample: ".env.example", envFile: ".env" },
+  { dir: "contracts", envExample: null, envFile: null },
+  { dir: "backend/keepers", envExample: ".env.example", envFile: ".env" },
+  { dir: "backend/rewards", envExample: null, envFile: null },
+  { dir: "packages/sdk", envExample: null, envFile: null },
+];
+
+let blockingFailures = 0;
+
+function absPath(...segments) {
+  return path.join(ROOT, ...segments);
+}
+
+function tryCommand(command) {
+  try {
+    const out = execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] });
+    return out.trim().split("\n")[0];
+  } catch {
+    return null;
+  }
+}
+
+function printOk(label, detail) {
+  console.log(`  ✅ ${label}${detail ? ` — ${detail}` : ""}`);
+}
+
+function printWarn(label, detail, remediation) {
+  console.log(`  ⚠️  ${label}${detail ? ` — ${detail}` : ""}`);
+  if (remediation) console.log(`     → ${remediation}`);
+}
+
+function printFail(label, detail, remediation) {
+  blockingFailures += 1;
+  console.log(`  ❌ ${label}${detail ? ` — ${detail}` : ""}`);
+  if (remediation) console.log(`     → ${remediation}`);
+}
+
+// --- Toolchain checks --------------------------------------------------------
+
+function checkNode() {
+  const version = process.version; // e.g. "v20.11.0" — always available, no subprocess needed
+  const major = parseInt(version.slice(1), 10);
+  if (major >= MIN_NODE_MAJOR) {
+    printOk("Node.js", version);
+  } else {
+    printFail(
+      "Node.js",
+      `${version} found, need ${MIN_NODE_MAJOR}+`,
+      `Install Node.js ${MIN_NODE_MAJOR}+ from https://nodejs.org or via nvm: nvm install ${MIN_NODE_MAJOR} && nvm use ${MIN_NODE_MAJOR}`,
+    );
+  }
+}
+
+function checkNpm() {
+  const version = tryCommand("npm --version");
+  if (!version) {
+    printFail("npm", "not found on PATH", "npm ships with Node.js — reinstall Node.js from https://nodejs.org");
+    return;
+  }
+  const major = parseInt(version.split(".")[0], 10);
+  if (major >= MIN_NPM_MAJOR) {
+    printOk("npm", version);
+  } else {
+    printFail("npm", `${version} found, need ${MIN_NPM_MAJOR}+`, "Upgrade npm: npm install -g npm@latest");
+  }
+}
+
+function checkRust() {
+  const version = tryCommand("rustc --version");
+  if (version) {
+    printOk("Rust (rustc)", version);
+  } else {
+    printWarn(
+      "Rust (rustc)",
+      "not found on PATH",
+      "Only required for contracts/ work. Install via rustup: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
+    );
+  }
+}
+
+function checkCargo() {
+  const version = tryCommand("cargo --version");
+  if (version) {
+    printOk("cargo", version);
+  } else {
+    printWarn(
+      "cargo",
+      "not found on PATH",
+      "Only required for contracts/ work. Installed automatically alongside Rust via rustup: https://rustup.rs",
+    );
+  }
+}
+
+function checkSorobanCli() {
+  const stellarVersion = tryCommand("stellar --version");
+  if (stellarVersion) {
+    printOk("Stellar CLI", stellarVersion);
+    return;
+  }
+  const sorobanVersion = tryCommand("soroban --version");
+  if (sorobanVersion) {
+    printOk("Soroban CLI", sorobanVersion);
+    return;
+  }
+  printWarn(
+    "Stellar/Soroban CLI",
+    "not found on PATH",
+    "Only required for contract deployment/testing. Install: cargo install --locked stellar-cli",
+  );
+}
+
+// --- Workspace checks --------------------------------------------------------
+
+function checkWorkspaceInstalled(workspace) {
+  const nodeModulesPath = absPath(workspace.dir, "node_modules");
+  if (fs.existsSync(nodeModulesPath)) {
+    printOk(`${workspace.dir}/node_modules`, "installed");
+  } else {
+    printWarn(
+      `${workspace.dir}/node_modules`,
+      "not installed",
+      `cd ${workspace.dir} && npm ci`,
+    );
+  }
+}
+
+function checkWorkspaceEnv(workspace) {
+  if (!workspace.envExample) return;
+
+  const examplePath = absPath(workspace.dir, workspace.envExample);
+  if (!fs.existsSync(examplePath)) {
+    printFail(
+      `${workspace.dir}/${workspace.envExample}`,
+      "missing from the repository",
+      "This file should be committed — re-clone the repository or run: git checkout -- " +
+        path.join(workspace.dir, workspace.envExample),
+    );
+    return;
+  }
+  printOk(`${workspace.dir}/${workspace.envExample}`, "present");
+
+  const envPath = absPath(workspace.dir, workspace.envFile);
+  if (fs.existsSync(envPath)) {
+    printOk(`${workspace.dir}/${workspace.envFile}`, "present");
+  } else {
+    printWarn(
+      `${workspace.dir}/${workspace.envFile}`,
+      "not created yet",
+      `cp ${workspace.dir}/${workspace.envExample} ${workspace.dir}/${workspace.envFile} — then fill in your values (see docs/deployment-environment-matrix.md)`,
+    );
+  }
+}
+
+function main() {
+  console.log("=== StellarYield Contributor Setup Doctor ===\n");
+
+  console.log("Toolchain:");
+  checkNode();
+  checkNpm();
+  checkRust();
+  checkCargo();
+  checkSorobanCli();
+
+  console.log("\nWorkspace dependencies:");
+  for (const workspace of WORKSPACES) {
+    checkWorkspaceInstalled(workspace);
+  }
+
+  console.log("\nEnvironment files:");
+  for (const workspace of WORKSPACES) {
+    checkWorkspaceEnv(workspace);
+  }
+
+  console.log("");
+  if (blockingFailures > 0) {
+    console.log(
+      `❌ ${blockingFailures} blocking issue${blockingFailures === 1 ? "" : "s"} found — fix the ❌ items above before running tests or the build.\n`,
+    );
+    process.exit(1);
+  }
+
+  console.log("✅ No blocking issues. Any ⚠️ items above are only needed for the areas you plan to work on.\n");
+  process.exit(0);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  checkNode,
+  checkNpm,
+  checkRust,
+  checkCargo,
+  checkSorobanCli,
+  checkWorkspaceInstalled,
+  checkWorkspaceEnv,
+  WORKSPACES,
+};


### PR DESCRIPTION
Closes #967 
Closes #968 
Closes #969 
Closes #966 


# Summary

scripts/ci-summarize-failure.sh (new) — greps a job's log(s) for common failure markers (FAIL, ✕, error[...], panicked at, etc.) and appends a markdown block to $GITHUB_STEP_SUMMARY with a direct artifact link.
.github/workflows/ci.yml:

backend (server): now captures test output to a log, uploads it on failure, and posts a summary (previously had no artifact capture at all).
frontend: existing log upload now exposes artifact-url; added a summary step.
contracts: added fuzz-log upload (previously only the test log was uploaded) and summary steps for both test and fuzz failures.
keeper and rewards: brand-new CI jobs — these packages (backend/keepers, backend/rewards) had test suites but weren't run in CI before. Added with the same log-capture/upload/summary pattern, non-blocking (continue-on-error at job level, matching the existing contracts job style).
docs/contributor-guide.md and CONTRIBUTING.md: documented the new job summary behavior and how maintainers should read failure artifacts, including new sections for Keeper Bot and Rewards Service checks.
client/src/hooks/useLeaderboardFilters.ts: added a sortView filter (ray | apy | risk, persisted like the existing filters) plus pure, unit-testable helpers — getFreshnessStatus() (fresh/stale/missing based on a 1-hour threshold) and sortStrategiesForView(), which always ranks fresh rows above stale rows above missing-data rows, and only breaks ties by the selected metric (APY, risk score, or RAY).

client/src/pages/leaderboard/StrategyLeaderboard.tsx: added lastUpdatedAt freshness metadata to the row type, a new Freshness column rendering a StatusBadge ("Live"/"Stale"/"No Data") with a native tooltip explaining the status, and Sort by: RAY / APY / Risk controls that re-sort the table using the stale-aware comparator (row rank numbers/medals now reflect the sorted position).

client/src/pages/leaderboard/StrategyLeaderboard.test.tsx: added 15 new tests covering the pure freshness/sorting logic and component rendering — fresh/stale/missing badge rendering with tooltips, and end-to-end proof that a stale row with a much higher APY/risk score still sorts below a fresh row with a lower score.


Adds scripts/setup-doctor.js, which checks Node.js/npm versions (blocking), Rust/cargo/the Stellar (or Soroban) CLI (recommended, for contracts/ work), whether each npm workspace (client, server, contracts, backend/keepers, backend/rewards, packages/sdk) has node_modules installed, and whether each workspace's .env.example is present and has been copied to a real env file — printing a concise remediation command for anything missing.

Wires it up as `npm run setup:doctor` and documents it in README.md's Getting Started section and a new "Setup Doctor" section in docs/contributor-guide.md.
tests including unauthorized callers

