### PR TITLE
Reward schedule UTC normalization, claim preview validation, Sheets dry-run, off-ramp resume safety

### DIFF
--- a/backend/rewards/src/__tests__/merkleTree.test.ts
+++ b/backend/rewards/src/__tests__/merkleTree.test.ts
@@ -3,7 +3,10 @@ import {
   verifyProof,
   computeLeaf,
   hashPair,
+  previewRewardClaim,
+  findProofShapeError,
   type RewardEntry,
+  type RewardCampaignInfo,
 } from "../merkleTree";
 
 // ── computeLeaf ─────────────────────────────────────────────────────────
@@ -262,5 +265,155 @@ describe("verifyProof", () => {
       );
       expect(valid).toBe(true);
     }
+  });
+});
+
+// ── findProofShapeError (#964) ─────────────────────────────────────────────
+
+describe("findProofShapeError", () => {
+  const validHash = "a".repeat(64);
+  const otherValidHash = "b".repeat(64);
+
+  it("returns null for a well-formed proof", () => {
+    expect(findProofShapeError([validHash, otherValidHash])).toBeNull();
+  });
+
+  it("returns null for an empty proof", () => {
+    expect(findProofShapeError([])).toBeNull();
+  });
+
+  it("flags a non-hex element as malformed", () => {
+    const error = findProofShapeError(["not-a-hex-string".padEnd(64, "z")]);
+    expect(error).toMatch(/malformed/i);
+  });
+
+  it("flags an element with the wrong length as malformed", () => {
+    const error = findProofShapeError(["ab".repeat(10)]);
+    expect(error).toMatch(/malformed/i);
+  });
+
+  it("flags a duplicate path element", () => {
+    const error = findProofShapeError([validHash, otherValidHash, validHash]);
+    expect(error).toMatch(/duplicate/i);
+  });
+
+  it("flags a proof deeper than MAX_PROOF_DEPTH", () => {
+    const deepProof = Array.from({ length: 21 }, (_, i) =>
+      i.toString(16).padStart(64, "0"),
+    );
+    const error = findProofShapeError(deepProof);
+    expect(error).toMatch(/exceeds/i);
+  });
+});
+
+// ── previewRewardClaim (#964) ──────────────────────────────────────────────
+
+describe("previewRewardClaim", () => {
+  const entries: RewardEntry[] = [
+    { index: 0, address: "GCLAIMANT1", amount: "1000" },
+    { index: 1, address: "GCLAIMANT2", amount: "2000" },
+  ];
+  const tree = generateMerkleTree(entries);
+  const currentCampaign: RewardCampaignInfo = {
+    campaignId: "2026-W22",
+    merkleRoot: tree.root,
+  };
+  const claim = tree.claims["GCLAIMANT1"];
+
+  it("marks a correct claim as valid", () => {
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W22",
+        merkleRoot: tree.root,
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: claim.amount,
+        proof: claim.proof,
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("valid");
+    expect(result.errorCode).toBeUndefined();
+  });
+
+  it("rejects a mismatched campaign ID", () => {
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W21",
+        merkleRoot: tree.root,
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: claim.amount,
+        proof: claim.proof,
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("invalid");
+    expect(result.errorCode).toBe("campaign_id_mismatch");
+  });
+
+  it("rejects a malformed proof path", () => {
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W22",
+        merkleRoot: tree.root,
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: claim.amount,
+        proof: ["not-valid-hex"],
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("invalid");
+    expect(result.errorCode).toBe("malformed_proof");
+  });
+
+  it("rejects a duplicate proof path element", () => {
+    const duplicated = claim.proof.length > 0 ? [claim.proof[0], claim.proof[0]] : ["a".repeat(64), "a".repeat(64)];
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W22",
+        merkleRoot: tree.root,
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: claim.amount,
+        proof: duplicated,
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("invalid");
+    expect(result.errorCode).toBe("malformed_proof");
+  });
+
+  it("marks a claim with a drifted root as stale, not invalid", () => {
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W22",
+        merkleRoot: "f".repeat(64),
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: claim.amount,
+        proof: claim.proof,
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("stale");
+    expect(result.errorCode).toBe("root_mismatch");
+  });
+
+  it("rejects a well-formed proof that fails cryptographic verification", () => {
+    const result = previewRewardClaim(
+      {
+        campaignId: "2026-W22",
+        merkleRoot: tree.root,
+        index: claim.index,
+        address: "GCLAIMANT1",
+        amount: "999999", // wrong amount — proof was generated for a different leaf
+        proof: claim.proof,
+      },
+      currentCampaign,
+    );
+    expect(result.state).toBe("invalid");
+    expect(result.errorCode).toBe("proof_verification_failed");
   });
 });

--- a/backend/rewards/src/__tests__/scheduleHealth.test.ts
+++ b/backend/rewards/src/__tests__/scheduleHealth.test.ts
@@ -1,4 +1,13 @@
-import { summarizeRewardScheduleHealth, type RewardScheduleMonitorInput } from "../scheduleHealth";
+import {
+  summarizeRewardScheduleHealth,
+  wallClockToUtc,
+  renderInTimeZone,
+  normalizeScheduleWindowToUtc,
+  startOfIsoWeekUtc,
+  endOfIsoWeekUtc,
+  isSameIsoWeekUtc,
+  type RewardScheduleMonitorInput,
+} from "../scheduleHealth";
 
 const baseSchedule: RewardScheduleMonitorInput = {
   protocolName: "Blend",
@@ -70,6 +79,180 @@ describe("summarizeRewardScheduleHealth", () => {
     expect(summary.status).toBe("expiring");
     expect(summary.warningLevel).toBe("critical");
     expect(summary.hasRecentClaims).toBe(false);
+  });
+});
+
+// ── wallClockToUtc / renderInTimeZone (#965) ───────────────────────────────
+
+describe("wallClockToUtc", () => {
+  it("converts a New York wall clock during EDT (summer, UTC-4)", () => {
+    const utc = wallClockToUtc({
+      wallClock: { year: 2026, month: 7, day: 15, hour: 12, minute: 0 },
+      timeZone: "America/New_York",
+    });
+    expect(utc.toISOString()).toBe("2026-07-15T16:00:00.000Z");
+  });
+
+  it("converts a New York wall clock during EST (winter, UTC-5)", () => {
+    const utc = wallClockToUtc({
+      wallClock: { year: 2026, month: 1, day: 15, hour: 12, minute: 0 },
+      timeZone: "America/New_York",
+    });
+    expect(utc.toISOString()).toBe("2026-01-15T17:00:00.000Z");
+  });
+
+  it("correctly resolves wall clocks either side of the spring-forward transition", () => {
+    // 2026-03-08 is the US spring-forward date for America/New_York.
+    const beforeTransition = wallClockToUtc({
+      wallClock: { year: 2026, month: 3, day: 8, hour: 1, minute: 30 },
+      timeZone: "America/New_York",
+    });
+    const afterTransition = wallClockToUtc({
+      wallClock: { year: 2026, month: 3, day: 8, hour: 3, minute: 30 },
+      timeZone: "America/New_York",
+    });
+    expect(beforeTransition.toISOString()).toBe("2026-03-08T06:30:00.000Z");
+    expect(afterTransition.toISOString()).toBe("2026-03-08T07:30:00.000Z");
+  });
+
+  it("is a round trip with renderInTimeZone across a DST boundary", () => {
+    const summerUtc = wallClockToUtc({
+      wallClock: { year: 2026, month: 7, day: 15, hour: 9, minute: 0 },
+      timeZone: "America/New_York",
+    });
+    const winterUtc = wallClockToUtc({
+      wallClock: { year: 2026, month: 1, day: 15, hour: 9, minute: 0 },
+      timeZone: "America/New_York",
+    });
+
+    const summerLocal = renderInTimeZone(summerUtc, "America/New_York");
+    const winterLocal = renderInTimeZone(winterUtc, "America/New_York");
+
+    expect(summerLocal.utcOffsetMinutes).toBe(-240); // EDT
+    expect(winterLocal.utcOffsetMinutes).toBe(-300); // EST
+    expect(summerLocal.isoLocal).toBe("2026-07-15T09:00:00-04:00");
+    expect(winterLocal.isoLocal).toBe("2026-01-15T09:00:00-05:00");
+  });
+});
+
+describe("renderInTimeZone", () => {
+  it("does not mutate the stored UTC instant it renders", () => {
+    const stored = new Date("2026-05-04T13:00:00.000Z");
+    const before = stored.getTime();
+    renderInTimeZone(stored, "Asia/Tokyo");
+    expect(stored.getTime()).toBe(before);
+  });
+
+  it("renders the same UTC instant differently across timezones", () => {
+    const stored = new Date("2026-05-04T13:00:00.000Z");
+    const tokyo = renderInTimeZone(stored, "Asia/Tokyo");
+    const london = renderInTimeZone(stored, "Europe/London");
+    const newYork = renderInTimeZone(stored, "America/New_York");
+
+    expect(tokyo.isoLocal).toBe("2026-05-04T22:00:00+09:00");
+    expect(london.isoLocal).toBe("2026-05-04T14:00:00+01:00");
+    expect(newYork.isoLocal).toBe("2026-05-04T09:00:00-04:00");
+  });
+});
+
+// ── normalizeScheduleWindowToUtc (#965) ─────────────────────────────────────
+
+describe("normalizeScheduleWindowToUtc", () => {
+  it("passes already-UTC Date windows through unchanged", () => {
+    const start = new Date("2026-05-01T00:00:00Z");
+    const end = new Date("2026-05-08T00:00:00Z");
+    const normalized = normalizeScheduleWindowToUtc({ start, end });
+    expect(normalized.startDate.getTime()).toBe(start.getTime());
+    expect(normalized.endDate.getTime()).toBe(end.getTime());
+  });
+
+  it("normalizes a wall-clock authored window to UTC", () => {
+    const normalized = normalizeScheduleWindowToUtc({
+      start: {
+        wallClock: { year: 2026, month: 5, day: 4, hour: 0, minute: 0 },
+        timeZone: "America/New_York",
+      },
+      end: {
+        wallClock: { year: 2026, month: 5, day: 11, hour: 0, minute: 0 },
+        timeZone: "America/New_York",
+      },
+    });
+    expect(normalized.startDate.toISOString()).toBe("2026-05-04T04:00:00.000Z");
+    expect(normalized.endDate.toISOString()).toBe("2026-05-11T04:00:00.000Z");
+  });
+
+  it("supports mixing a UTC Date and a wall-clock endpoint", () => {
+    const normalized = normalizeScheduleWindowToUtc({
+      start: new Date("2026-05-01T00:00:00Z"),
+      end: {
+        wallClock: { year: 2026, month: 5, day: 8, hour: 0, minute: 0 },
+        timeZone: "America/New_York",
+      },
+    });
+    expect(normalized.startDate.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(normalized.endDate.toISOString()).toBe("2026-05-08T04:00:00.000Z");
+  });
+
+  it("throws when the normalized window is inverted", () => {
+    expect(() =>
+      normalizeScheduleWindowToUtc({
+        start: new Date("2026-05-08T00:00:00Z"),
+        end: new Date("2026-05-01T00:00:00Z"),
+      }),
+    ).toThrow(/end must be strictly after start/i);
+  });
+
+  it("throws when the normalized window has zero duration (exact boundary)", () => {
+    const sameInstant = new Date("2026-05-01T00:00:00Z");
+    expect(() =>
+      normalizeScheduleWindowToUtc({ start: sameInstant, end: new Date(sameInstant) }),
+    ).toThrow(/end must be strictly after start/i);
+  });
+});
+
+// ── ISO week (UTC) helpers: week rollover and boundary moments (#965) ──────
+
+describe("startOfIsoWeekUtc / endOfIsoWeekUtc / isSameIsoWeekUtc", () => {
+  it("returns the same instant when given exactly the Monday 00:00:00.000 UTC boundary", () => {
+    const monday = new Date("2026-05-04T00:00:00.000Z"); // a Monday
+    expect(startOfIsoWeekUtc(monday).getTime()).toBe(monday.getTime());
+  });
+
+  it("rolls a mid-week instant back to the preceding Monday", () => {
+    const wednesday = new Date("2026-05-06T15:30:00.000Z");
+    expect(startOfIsoWeekUtc(wednesday).toISOString()).toBe("2026-05-04T00:00:00.000Z");
+  });
+
+  it("rolls a Sunday instant back to the Monday that started its week", () => {
+    const sundayNight = new Date("2026-05-10T23:59:59.999Z");
+    expect(startOfIsoWeekUtc(sundayNight).toISOString()).toBe("2026-05-04T00:00:00.000Z");
+  });
+
+  it("computes an exclusive week end that equals the next week's start", () => {
+    const monday = new Date("2026-05-04T00:00:00.000Z");
+    const nextMonday = new Date("2026-05-11T00:00:00.000Z");
+    expect(endOfIsoWeekUtc(monday).getTime()).toBe(nextMonday.getTime());
+    expect(startOfIsoWeekUtc(nextMonday).getTime()).toBe(nextMonday.getTime());
+  });
+
+  it("treats the last millisecond of a week and the first millisecond of the next as different weeks", () => {
+    const lastMsOfWeek = new Date("2026-05-10T23:59:59.999Z");
+    const firstMsOfNextWeek = new Date("2026-05-11T00:00:00.000Z");
+    expect(isSameIsoWeekUtc(lastMsOfWeek, firstMsOfNextWeek)).toBe(false);
+  });
+
+  it("treats two instants on different days of the same week as the same week", () => {
+    const mondayMorning = new Date("2026-05-04T02:00:00.000Z");
+    const sundayNight = new Date("2026-05-10T22:00:00.000Z");
+    expect(isSameIsoWeekUtc(mondayMorning, sundayNight)).toBe(true);
+  });
+
+  it("handles week rollover across a month boundary", () => {
+    // 2026-06-01 is a Monday.
+    const lastDayOfMay = new Date("2026-05-31T12:00:00.000Z");
+    expect(startOfIsoWeekUtc(lastDayOfMay).toISOString()).toBe("2026-05-25T00:00:00.000Z");
+    expect(isSameIsoWeekUtc(lastDayOfMay, new Date("2026-05-25T00:00:00.000Z"))).toBe(true);
+    expect(isSameIsoWeekUtc(lastDayOfMay, new Date("2026-06-01T00:00:00.000Z"))).toBe(false);
   });
 });
 

--- a/backend/rewards/src/index.ts
+++ b/backend/rewards/src/index.ts
@@ -1,5 +1,20 @@
-export { generateMerkleTree, verifyProof, computeLeaf, hashPair } from "./merkleTree";
-export type { RewardEntry, MerkleTreeResult } from "./merkleTree";
+export {
+  generateMerkleTree,
+  verifyProof,
+  computeLeaf,
+  hashPair,
+  previewRewardClaim,
+  findProofShapeError,
+} from "./merkleTree";
+export type {
+  RewardEntry,
+  MerkleTreeResult,
+  RewardCampaignInfo,
+  ClaimPreviewInput,
+  ClaimPreviewState,
+  ClaimPreviewErrorCode,
+  ClaimPreviewResult,
+} from "./merkleTree";
 
 export {
   calculateRewards,
@@ -7,3 +22,27 @@ export {
   getUserProof,
 } from "./generateTree";
 export type { UserRewardInput } from "./generateTree";
+
+export {
+  summarizeRewardScheduleHealth,
+  wallClockToUtc,
+  renderInTimeZone,
+  normalizeScheduleWindowToUtc,
+  getTimeZoneOffsetMs,
+  startOfIsoWeekUtc,
+  endOfIsoWeekUtc,
+  isSameIsoWeekUtc,
+} from "./scheduleHealth";
+export type {
+  RewardScheduleLike,
+  RewardScheduleStatus,
+  RewardScheduleWarningLevel,
+  RewardScheduleMonitorInput,
+  RewardScheduleHealthSummary,
+  RewardScheduleHealthOptions,
+  WallClockDateTime,
+  ZonedWallClock,
+  RenderedLocalTime,
+  AuthoredScheduleWindow,
+  NormalizedScheduleWindow,
+} from "./scheduleHealth";

--- a/backend/rewards/src/merkleTree.ts
+++ b/backend/rewards/src/merkleTree.ts
@@ -192,3 +192,151 @@ export function verifyProof(
 
   return computed.toString("hex") === root;
 }
+
+// ─── Claim preview validation (#964) ───────────────────────────────────────
+
+/** A single 32-byte proof element must be exactly 64 lowercase/uppercase hex chars. */
+const PROOF_ELEMENT_PATTERN = /^[0-9a-fA-F]{64}$/;
+const ROOT_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/**
+ * Identifies the reward campaign a claim preview is checked against.
+ */
+export interface RewardCampaignInfo {
+  /** Stable identifier for the distribution campaign (e.g. "2026-W22"). */
+  campaignId: string;
+  /** The Merkle root currently published on-chain for this campaign. */
+  merkleRoot: string;
+}
+
+/**
+ * A claim a client wants previewed before submitting a claim transaction.
+ * `campaignId` and `merkleRoot` are whatever the client last cached — they
+ * may be stale relative to the current campaign.
+ */
+export interface ClaimPreviewInput {
+  campaignId: string;
+  merkleRoot: string;
+  index: number;
+  address: string;
+  amount: string;
+  proof: string[];
+}
+
+export type ClaimPreviewState = "valid" | "invalid" | "stale";
+
+export type ClaimPreviewErrorCode =
+  | "campaign_id_mismatch"
+  | "malformed_proof"
+  | "root_mismatch"
+  | "proof_verification_failed";
+
+export interface ClaimPreviewResult {
+  state: ClaimPreviewState;
+  errorCode?: ClaimPreviewErrorCode;
+  message: string;
+}
+
+/**
+ * Structural validation of a proof array: every element must be a 32-byte
+ * hex string, the depth must respect MAX_PROOF_DEPTH, and no sibling hash
+ * may repeat (a well-formed Merkle proof never revisits the same node twice
+ * — a repeated element is a sign of a truncated, replayed, or tampered proof).
+ */
+export function findProofShapeError(proof: string[]): string | null {
+  if (!Array.isArray(proof)) {
+    return "Proof must be an array of hex-encoded sibling hashes";
+  }
+
+  const sizeCheck = validateProofSize(proof);
+  if (!sizeCheck.valid) {
+    return sizeCheck.reason ?? "Proof exceeds maximum depth";
+  }
+
+  const seen = new Set<string>();
+  for (const element of proof) {
+    if (typeof element !== "string" || !PROOF_ELEMENT_PATTERN.test(element)) {
+      return `Proof contains a malformed path element: "${String(element)}"`;
+    }
+    const normalized = element.toLowerCase();
+    if (seen.has(normalized)) {
+      return `Proof contains a duplicate path element: "${element}"`;
+    }
+    seen.add(normalized);
+  }
+
+  return null;
+}
+
+/**
+ * Preview a reward claim before the caller submits an on-chain transaction.
+ *
+ * Validates, in order: the campaign ID matches the active campaign, the
+ * proof array is well-formed (correct hex shape, bounded depth, no
+ * duplicate path elements), the client's cached Merkle root matches the
+ * campaign's current root (catching "root drift" — a proof generated
+ * against a previous distribution), and finally that the proof
+ * cryptographically verifies against the current root.
+ *
+ * @param input   - The claim the caller wants to preview.
+ * @param current - The active campaign's canonical id and Merkle root.
+ */
+export function previewRewardClaim(
+  input: ClaimPreviewInput,
+  current: RewardCampaignInfo,
+): ClaimPreviewResult {
+  if (input.campaignId !== current.campaignId) {
+    return {
+      state: "invalid",
+      errorCode: "campaign_id_mismatch",
+      message: `Claim targets campaign "${input.campaignId}" but the active campaign is "${current.campaignId}".`,
+    };
+  }
+
+  const shapeError = findProofShapeError(input.proof);
+  if (shapeError) {
+    return {
+      state: "invalid",
+      errorCode: "malformed_proof",
+      message: shapeError,
+    };
+  }
+
+  if (!ROOT_PATTERN.test(input.merkleRoot)) {
+    return {
+      state: "invalid",
+      errorCode: "malformed_proof",
+      message: `Merkle root "${input.merkleRoot}" is not a valid 32-byte hex value.`,
+    };
+  }
+
+  if (input.merkleRoot.toLowerCase() !== current.merkleRoot.toLowerCase()) {
+    return {
+      state: "stale",
+      errorCode: "root_mismatch",
+      message:
+        "This claim was generated against an earlier version of the reward tree. Refresh to fetch an updated proof.",
+    };
+  }
+
+  const isValid = verifyProof(
+    current.merkleRoot,
+    input.index,
+    input.address,
+    input.amount,
+    input.proof,
+  );
+
+  if (!isValid) {
+    return {
+      state: "invalid",
+      errorCode: "proof_verification_failed",
+      message: "This proof does not verify against the current reward tree.",
+    };
+  }
+
+  return {
+    state: "valid",
+    message: "Claim proof is valid and can be submitted.",
+  };
+}

--- a/backend/rewards/src/scheduleHealth.ts
+++ b/backend/rewards/src/scheduleHealth.ts
@@ -1,3 +1,205 @@
+// ─── Timezone normalization for weekly campaign windows (#965) ────────────
+//
+// A `Date` in JavaScript is always a UTC instant internally — there is no
+// such thing as a "local Date". The actual timezone problem lives at the
+// *authoring* boundary: a campaign manager enters a wall-clock window
+// ("Monday 00:00") in their own timezone, and that has to become one
+// unambiguous UTC instant before it is ever persisted. From then on, every
+// stored schedule window (`startDate` / `endDate` on RewardScheduleLike) is
+// UTC and must never be reinterpreted in a different zone. Renderers read
+// that stored UTC instant and format it for display in whatever timezone a
+// viewer needs — formatting never mutates or feeds back into the stored
+// window. See docs/reward-schedule-authoring.md for authoring guidance.
+
+const MS_PER_MINUTE = 60 * 1000;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** A wall-clock date/time as authored by a human, with no attached zone. */
+export interface WallClockDateTime {
+  year: number;
+  /** 1-12 */
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+}
+
+/** A wall-clock moment paired with the IANA timezone it was authored in. */
+export interface ZonedWallClock {
+  wallClock: WallClockDateTime;
+  /** IANA timezone identifier, e.g. "America/New_York". */
+  timeZone: string;
+}
+
+function offsetFormatter(timeZone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hourCycle: "h23",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function partsToMap(parts: Intl.DateTimeFormatPart[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const part of parts) {
+    if (part.type !== "literal") {
+      map[part.type] = part.value;
+    }
+  }
+  return map;
+}
+
+/**
+ * The offset (in ms) that must be *added* to `instant`'s UTC time to reach
+ * the wall-clock time as it appears in `timeZone` at that instant. Uses the
+ * live IANA rules via Intl, so it is correct across DST transitions rather
+ * than assuming a fixed offset for the zone.
+ */
+export function getTimeZoneOffsetMs(instant: Date, timeZone: string): number {
+  const map = partsToMap(offsetFormatter(timeZone).formatToParts(instant));
+  const asUtc = Date.UTC(
+    Number(map.year),
+    Number(map.month) - 1,
+    Number(map.day),
+    Number(map.hour),
+    Number(map.minute),
+    Number(map.second),
+  );
+  return asUtc - instant.getTime();
+}
+
+/**
+ * Convert a wall-clock date/time authored in `timeZone` into the precise
+ * UTC instant it represents. Handles DST transitions by measuring the
+ * actual offset in effect for that timezone at that date rather than a
+ * fixed offset, with one correction pass in case the initial guess landed
+ * on the wrong side of a transition.
+ */
+export function wallClockToUtc(zoned: ZonedWallClock): Date {
+  const { year, month, day, hour, minute } = zoned.wallClock;
+  const guessUtcMs = Date.UTC(year, month - 1, day, hour, minute, 0);
+
+  const firstOffset = getTimeZoneOffsetMs(new Date(guessUtcMs), zoned.timeZone);
+  const correctedMs = guessUtcMs - firstOffset;
+
+  const secondOffset = getTimeZoneOffsetMs(new Date(correctedMs), zoned.timeZone);
+  const finalMs = secondOffset === firstOffset ? correctedMs : guessUtcMs - secondOffset;
+
+  return new Date(finalMs);
+}
+
+/** The result of rendering a stored UTC instant for display in a target timezone. */
+export interface RenderedLocalTime {
+  /** ISO-8601 string with the target zone's UTC offset, e.g. "2026-05-04T09:00:00-04:00". */
+  isoLocal: string;
+  timeZone: string;
+  /** Offset from UTC in effect at this instant, in minutes (e.g. -240 for EDT). */
+  utcOffsetMinutes: number;
+}
+
+/**
+ * Render a stored UTC instant in `timeZone` for display purposes. This is a
+ * pure read: it never changes the stored window, only how it is presented.
+ */
+export function renderInTimeZone(utcInstant: Date, timeZone: string): RenderedLocalTime {
+  const offsetMs = getTimeZoneOffsetMs(utcInstant, timeZone);
+  const offsetMinutes = Math.round(offsetMs / MS_PER_MINUTE);
+
+  const map = partsToMap(offsetFormatter(timeZone).formatToParts(utcInstant));
+  const sign = offsetMinutes < 0 ? "-" : "+";
+  const absMinutes = Math.abs(offsetMinutes);
+  const offsetHours = String(Math.floor(absMinutes / 60)).padStart(2, "0");
+  const offsetMins = String(absMinutes % 60).padStart(2, "0");
+
+  const isoLocal =
+    `${map.year}-${map.month}-${map.day}T${map.hour}:${map.minute}:${map.second}` +
+    `${sign}${offsetHours}:${offsetMins}`;
+
+  return { isoLocal, timeZone, utcOffsetMinutes: offsetMinutes };
+}
+
+/** A schedule window as authored, before normalization. */
+export interface AuthoredScheduleWindow {
+  start: Date | ZonedWallClock;
+  end: Date | ZonedWallClock;
+}
+
+export interface NormalizedScheduleWindow {
+  startDate: Date;
+  endDate: Date;
+}
+
+function isZonedWallClock(value: Date | ZonedWallClock): value is ZonedWallClock {
+  return !(value instanceof Date);
+}
+
+/**
+ * Normalize an authored campaign window to UTC `Date`s suitable for
+ * storage. Values that are already `Date` instances pass through unchanged
+ * (they are already UTC instants); wall-clock values authored in a named
+ * timezone are converted via `wallClockToUtc`.
+ *
+ * Throws if the normalized end is not strictly after the normalized start.
+ */
+export function normalizeScheduleWindowToUtc(
+  window: AuthoredScheduleWindow,
+): NormalizedScheduleWindow {
+  const startDate = isZonedWallClock(window.start)
+    ? wallClockToUtc(window.start)
+    : window.start;
+  const endDate = isZonedWallClock(window.end) ? wallClockToUtc(window.end) : window.end;
+
+  if (endDate.getTime() <= startDate.getTime()) {
+    throw new Error(
+      "Schedule window end must be strictly after start once normalized to UTC.",
+    );
+  }
+
+  return { startDate, endDate };
+}
+
+// ─── ISO week (UTC) helpers for weekly campaign rollover (#965) ───────────
+//
+// Weekly campaign boundaries are defined purely in UTC clock terms — Monday
+// 00:00:00.000 UTC through the following Monday 00:00:00.000 UTC (exclusive)
+// — independent of any viewer's local timezone. This keeps "which week does
+// this claim belong to" unambiguous regardless of where a schedule is
+// authored or where a claimant happens to be.
+
+/** Start of the UTC ISO week (Monday 00:00:00.000 UTC) containing `instant`. */
+export function startOfIsoWeekUtc(instant: Date): Date {
+  const utcDay = instant.getUTCDay(); // 0 (Sun) .. 6 (Sat)
+  const isoDayIndex = utcDay === 0 ? 7 : utcDay; // Mon=1 .. Sun=7
+  const daysSinceMonday = isoDayIndex - 1;
+
+  const startOfDayUtc = Date.UTC(
+    instant.getUTCFullYear(),
+    instant.getUTCMonth(),
+    instant.getUTCDate(),
+    0,
+    0,
+    0,
+    0,
+  );
+
+  return new Date(startOfDayUtc - daysSinceMonday * MS_PER_DAY);
+}
+
+/** Start of the *next* UTC ISO week — i.e. the exclusive end of the current one. */
+export function endOfIsoWeekUtc(instant: Date): Date {
+  return new Date(startOfIsoWeekUtc(instant).getTime() + 7 * MS_PER_DAY);
+}
+
+/** Whether `a` and `b` fall within the same UTC ISO week (Mon–Sun). */
+export function isSameIsoWeekUtc(a: Date, b: Date): boolean {
+  return startOfIsoWeekUtc(a).getTime() === startOfIsoWeekUtc(b).getTime();
+}
+
 export interface RewardScheduleLike {
   protocolName: string;
   tokenSymbol: string;

--- a/client/src/features/google_sheets/GoogleSheetsPanel.tsx
+++ b/client/src/features/google_sheets/GoogleSheetsPanel.tsx
@@ -9,18 +9,24 @@ import {
   Unlink2,
   CheckCircle2,
   AlertCircle,
+  AlertTriangle,
   Loader2,
+  Eye,
 } from "lucide-react";
 import { GoogleSheetsService } from "./googleSheetsService";
-import type { GoogleSheetsConfig } from "./types";
+import type { GoogleSheetsConfig, DailyYieldMetric } from "./types";
+import type { DryRunSyncSummary } from "./dryRunSync";
 import { GoogleAuthError, GOOGLE_AUTH_MESSAGES } from "./errors";
 
 export interface GoogleSheetsPanelProps {
   walletAddress: string | null;
+  /** Metrics that would be written on the next sync, used to power the dry-run preview (#962). */
+  pendingMetrics?: DailyYieldMetric[];
 }
 
 export default function GoogleSheetsPanel({
   walletAddress,
+  pendingMetrics,
 }: GoogleSheetsPanelProps) {
   const [config, setConfig] = useState<GoogleSheetsConfig | null>(null);
   const [spreadsheetId, setSpreadsheetId] = useState("");
@@ -31,6 +37,9 @@ export default function GoogleSheetsPanel({
   const [authStatus, setAuthStatus] = useState<
     "connected" | "expired" | "missing_scope" | "not_connected"
   >("not_connected");
+  const [dryRunSummary, setDryRunSummary] = useState<DryRunSyncSummary | null>(null);
+  const [dryRunLoading, setDryRunLoading] = useState(false);
+  const [dryRunError, setDryRunError] = useState("");
 
   // Only the public client_id is needed here; the client secret lives
   // server-side inside /api/google-sheets/token (process.env.GOOGLE_CLIENT_SECRET).
@@ -88,6 +97,30 @@ export default function GoogleSheetsPanel({
       setSuccess("Google Sheets unlinked");
     }
   }, []);
+
+  const handlePreviewSync = useCallback(async () => {
+    if (!pendingMetrics || pendingMetrics.length === 0) return;
+
+    setDryRunError("");
+    setDryRunSummary(null);
+    setDryRunLoading(true);
+
+    try {
+      const summary = await service.previewSync(pendingMetrics);
+      setDryRunSummary(summary);
+    } catch (err) {
+      if (err instanceof GoogleAuthError) {
+        setAuthStatus(service.getAuthStatus());
+        setDryRunError(GOOGLE_AUTH_MESSAGES[err.code] ?? err.message);
+      } else {
+        setDryRunError(
+          err instanceof Error ? err.message : "Failed to preview sync",
+        );
+      }
+    } finally {
+      setDryRunLoading(false);
+    }
+  }, [pendingMetrics]);
 
   return (
     <div className="space-y-6">
@@ -184,6 +217,78 @@ export default function GoogleSheetsPanel({
               every night at 12:00 AM UTC.
             </p>
           </div>
+
+          {pendingMetrics && pendingMetrics.length > 0 && (
+            <div className="space-y-3" data-testid="dry-run-section">
+              <button
+                onClick={() => void handlePreviewSync()}
+                disabled={dryRunLoading}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-white/5 hover:bg-white/10 border border-white/10 disabled:opacity-50 text-white rounded-lg font-medium"
+              >
+                {dryRunLoading ? (
+                  <>
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Previewing sync...
+                  </>
+                ) : (
+                  <>
+                    <Eye className="w-4 h-4" />
+                    Preview Sync ({pendingMetrics.length} row
+                    {pendingMetrics.length !== 1 ? "s" : ""})
+                  </>
+                )}
+              </button>
+
+              {dryRunError && (
+                <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+                  <AlertCircle className="w-5 h-5 text-red-500" />
+                  <span className="text-sm text-red-400">{dryRunError}</span>
+                </div>
+              )}
+
+              {dryRunSummary && (
+                <div
+                  className="p-4 bg-black/30 border border-white/10 rounded-lg space-y-3"
+                  data-testid="dry-run-summary"
+                >
+                  <p className="text-sm font-semibold text-gray-200">
+                    Dry-run preview — nothing has been written yet
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 text-sm">
+                    <div className="flex items-center justify-between px-3 py-2 bg-green-500/10 border border-green-500/20 rounded-lg">
+                      <span className="text-green-400">Added</span>
+                      <span className="font-mono text-green-300">{dryRunSummary.added.length}</span>
+                    </div>
+                    <div className="flex items-center justify-between px-3 py-2 bg-blue-500/10 border border-blue-500/20 rounded-lg">
+                      <span className="text-blue-400">Updated</span>
+                      <span className="font-mono text-blue-300">{dryRunSummary.updated.length}</span>
+                    </div>
+                    <div className="flex items-center justify-between px-3 py-2 bg-gray-500/10 border border-gray-500/20 rounded-lg">
+                      <span className="text-gray-400">Skipped</span>
+                      <span className="font-mono text-gray-300">{dryRunSummary.skipped.length}</span>
+                    </div>
+                    <div className="flex items-center justify-between px-3 py-2 bg-amber-500/10 border border-amber-500/20 rounded-lg">
+                      <span className="text-amber-400">Conflicted</span>
+                      <span className="font-mono text-amber-300">{dryRunSummary.conflicted.length}</span>
+                    </div>
+                  </div>
+
+                  {dryRunSummary.conflicted.length > 0 && (
+                    <div className="flex items-start gap-2 p-3 bg-amber-500/10 border border-amber-500/30 rounded-lg">
+                      <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0 mt-0.5" />
+                      <p className="text-xs text-amber-300">
+                        {dryRunSummary.conflicted.length} row
+                        {dryRunSummary.conflicted.length !== 1 ? "s" : ""} disagree
+                        with data already in the sheet and will be skipped by a
+                        real sync. Resolve them in the spreadsheet before
+                        committing.
+                      </p>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
         </div>
       ) : (
         <div className="glass-panel p-6 space-y-4">

--- a/client/src/features/google_sheets/dryRunSync.test.ts
+++ b/client/src/features/google_sheets/dryRunSync.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from "vitest";
+import { buildRowKey, rowKeyToString, computeDryRunSyncPlan } from "./dryRunSync";
+import type { DailyYieldMetric } from "./types";
+import type { ExistingSheetRow } from "./dryRunSync";
+
+function metric(overrides: Partial<DailyYieldMetric> = {}): DailyYieldMetric {
+  return {
+    date: "2026-05-04",
+    vaultName: "USDC Vault",
+    depositAmount: 1000n,
+    currentValue: 1050n,
+    dailyYield: 5n,
+    apy: 12.34,
+    walletAddress: "GALICE",
+    asset: "USDC",
+    ...overrides,
+  };
+}
+
+function existingRow(overrides: Partial<ExistingSheetRow> = {}): ExistingSheetRow {
+  return {
+    walletAddress: "GALICE",
+    vaultName: "USDC Vault",
+    asset: "USDC",
+    timestamp: "2026-05-04",
+    depositAmount: "1000",
+    currentValue: "1050",
+    dailyYield: "5",
+    apy: "12.34",
+    ...overrides,
+  };
+}
+
+describe("buildRowKey / rowKeyToString", () => {
+  it("builds a key from wallet, vault, asset, and date", () => {
+    const key = buildRowKey(metric());
+    expect(key).toEqual({
+      walletAddress: "GALICE",
+      vaultName: "USDC Vault",
+      asset: "USDC",
+      timestamp: "2026-05-04",
+    });
+  });
+
+  it("falls back to placeholders when wallet/asset are absent", () => {
+    const key = buildRowKey(metric({ walletAddress: undefined, asset: undefined }));
+    expect(key.walletAddress).toBe("unknown-wallet");
+    expect(key.asset).toBe("unknown-asset");
+  });
+
+  it("produces distinct strings for different keys", () => {
+    const a = rowKeyToString(buildRowKey(metric()));
+    const b = rowKeyToString(buildRowKey(metric({ asset: "XLM" })));
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("computeDryRunSyncPlan", () => {
+  it("marks a metric with no existing row as added", () => {
+    const summary = computeDryRunSyncPlan([metric()], []);
+    expect(summary.added).toHaveLength(1);
+    expect(summary.updated).toHaveLength(0);
+    expect(summary.skipped).toHaveLength(0);
+    expect(summary.conflicted).toHaveLength(0);
+    expect(summary.totalRows).toBe(1);
+  });
+
+  it("marks a metric that exactly matches an existing row as skipped", () => {
+    const summary = computeDryRunSyncPlan([metric()], [existingRow()]);
+    expect(summary.skipped).toHaveLength(1);
+    expect(summary.added).toHaveLength(0);
+    expect(summary.conflicted).toHaveLength(0);
+  });
+
+  it("tolerates small floating point drift in apy when matching", () => {
+    const summary = computeDryRunSyncPlan(
+      [metric({ apy: 12.341 })],
+      [existingRow({ apy: "12.34" })],
+    );
+    expect(summary.skipped).toHaveLength(1);
+  });
+
+  it("marks a metric that overwrites a placeholder row as updated", () => {
+    const summary = computeDryRunSyncPlan(
+      [metric({ currentValue: 2000n })],
+      [existingRow({ currentValue: "0", isPlaceholder: true })],
+    );
+    expect(summary.updated).toHaveLength(1);
+    expect(summary.conflicted).toHaveLength(0);
+  });
+
+  it("flags a real value disagreement against a non-placeholder row as conflicted", () => {
+    const summary = computeDryRunSyncPlan(
+      [metric({ currentValue: 2000n })],
+      [existingRow({ currentValue: "999" })],
+    );
+    expect(summary.conflicted).toHaveLength(1);
+    expect(summary.conflicted[0].reason).toMatch(/different values/i);
+  });
+
+  it("keys conflicts by wallet, vault, asset, and timestamp independently", () => {
+    // Same day, same vault, but a different wallet and a different asset —
+    // these must not collide with each other or with the existing row.
+    const summary = computeDryRunSyncPlan(
+      [
+        metric({ walletAddress: "GBOB", currentValue: 5000n }),
+        metric({ asset: "XLM", currentValue: 7000n }),
+      ],
+      [existingRow()],
+    );
+    expect(summary.added).toHaveLength(2);
+    expect(summary.conflicted).toHaveLength(0);
+  });
+
+  it("flags a within-batch duplicate key as conflicted", () => {
+    const summary = computeDryRunSyncPlan(
+      [metric({ currentValue: 1050n }), metric({ currentValue: 9999n })],
+      [],
+    );
+    expect(summary.added).toHaveLength(1);
+    expect(summary.conflicted).toHaveLength(1);
+    expect(summary.conflicted[0].reason).toMatch(/duplicate entry/i);
+  });
+
+  it("counts totalRows across all buckets", () => {
+    const summary = computeDryRunSyncPlan(
+      [
+        metric({ walletAddress: "GNEW" }), // added
+        metric(), // skipped (matches existingRow())
+      ],
+      [existingRow()],
+    );
+    expect(summary.totalRows).toBe(2);
+    expect(summary.added.length + summary.updated.length + summary.skipped.length + summary.conflicted.length).toBe(2);
+  });
+
+  it("handles an empty metrics batch", () => {
+    const summary = computeDryRunSyncPlan([], [existingRow()]);
+    expect(summary.totalRows).toBe(0);
+    expect(summary.added).toHaveLength(0);
+  });
+});

--- a/client/src/features/google_sheets/dryRunSync.ts
+++ b/client/src/features/google_sheets/dryRunSync.ts
@@ -1,0 +1,172 @@
+/**
+ * Google Sheets dry-run sync planning (#962).
+ *
+ * Given the metrics we want to write and a snapshot of what is currently in
+ * the linked spreadsheet, compute what a real sync *would* do — without
+ * writing anything — so the panel can show the user a preview and let them
+ * confirm before committing.
+ */
+
+import type { DailyYieldMetric } from "./types";
+
+export type SheetRowAction = "added" | "updated" | "skipped" | "conflicted";
+
+/** The identity of a spreadsheet row: one row per wallet/vault/asset/day. */
+export interface SheetRowKey {
+  walletAddress: string;
+  vaultName: string;
+  asset: string;
+  timestamp: string;
+}
+
+/** A row already present in the linked spreadsheet, as read back for comparison. */
+export interface ExistingSheetRow {
+  walletAddress: string;
+  vaultName: string;
+  asset: string;
+  timestamp: string;
+  depositAmount: string;
+  currentValue: string;
+  dailyYield: string;
+  apy: string;
+  /**
+   * True when the existing row is a known incomplete placeholder (e.g. a
+   * prior partial sync). Placeholders are safe to overwrite as an 'updated'
+   * row rather than being flagged as a conflict.
+   */
+  isPlaceholder?: boolean;
+}
+
+export interface SyncRowPlan {
+  key: SheetRowKey;
+  action: SheetRowAction;
+  metric: DailyYieldMetric;
+  existingRow?: ExistingSheetRow;
+  reason: string;
+}
+
+export interface DryRunSyncSummary {
+  added: SyncRowPlan[];
+  updated: SyncRowPlan[];
+  skipped: SyncRowPlan[];
+  conflicted: SyncRowPlan[];
+  totalRows: number;
+}
+
+const DEFAULT_WALLET = "unknown-wallet";
+const DEFAULT_ASSET = "unknown-asset";
+const APY_TOLERANCE = 0.005;
+
+export function buildRowKey(metric: DailyYieldMetric): SheetRowKey {
+  return {
+    walletAddress: metric.walletAddress ?? DEFAULT_WALLET,
+    vaultName: metric.vaultName,
+    asset: metric.asset ?? DEFAULT_ASSET,
+    timestamp: metric.date,
+  };
+}
+
+export function rowKeyToString(key: SheetRowKey): string {
+  return [key.walletAddress, key.vaultName, key.asset, key.timestamp].join("::");
+}
+
+/** Whether a metric's values exactly match what's already recorded for its key. */
+function valuesMatch(metric: DailyYieldMetric, existing: ExistingSheetRow): boolean {
+  return (
+    metric.depositAmount.toString() === existing.depositAmount &&
+    metric.currentValue.toString() === existing.currentValue &&
+    metric.dailyYield.toString() === existing.dailyYield &&
+    Math.abs(metric.apy - Number.parseFloat(existing.apy)) < APY_TOLERANCE
+  );
+}
+
+/**
+ * Compute a dry-run sync plan: for each incoming metric, decide whether it
+ * would be added, update an existing row, be skipped as a no-op, or
+ * conflict with an existing row that holds different, non-placeholder data.
+ *
+ * A within-batch duplicate (two incoming metrics resolving to the same row
+ * key) is also surfaced as a conflict on the later entry — ambiguous source
+ * data should never be silently resolved by "last write wins".
+ */
+export function computeDryRunSyncPlan(
+  metrics: DailyYieldMetric[],
+  existingRows: ExistingSheetRow[],
+): DryRunSyncSummary {
+  const existingByKey = new Map<string, ExistingSheetRow>();
+  for (const row of existingRows) {
+    existingByKey.set(
+      rowKeyToString({
+        walletAddress: row.walletAddress,
+        vaultName: row.vaultName,
+        asset: row.asset,
+        timestamp: row.timestamp,
+      }),
+      row,
+    );
+  }
+
+  const summary: DryRunSyncSummary = { added: [], updated: [], skipped: [], conflicted: [], totalRows: 0 };
+  const seenInBatch = new Set<string>();
+
+  for (const metric of metrics) {
+    const key = buildRowKey(metric);
+    const keyStr = rowKeyToString(key);
+    summary.totalRows += 1;
+
+    if (seenInBatch.has(keyStr)) {
+      summary.conflicted.push({
+        key,
+        action: "conflicted",
+        metric,
+        reason: `Duplicate entry for ${key.walletAddress}/${key.vaultName}/${key.asset} on ${key.timestamp} within the same sync batch.`,
+      });
+      continue;
+    }
+    seenInBatch.add(keyStr);
+
+    const existing = existingByKey.get(keyStr);
+
+    if (!existing) {
+      summary.added.push({
+        key,
+        action: "added",
+        metric,
+        reason: "No existing row for this wallet/vault/asset/day.",
+      });
+      continue;
+    }
+
+    if (valuesMatch(metric, existing)) {
+      summary.skipped.push({
+        key,
+        action: "skipped",
+        metric,
+        existingRow: existing,
+        reason: "Existing row already matches — nothing to write.",
+      });
+      continue;
+    }
+
+    if (existing.isPlaceholder) {
+      summary.updated.push({
+        key,
+        action: "updated",
+        metric,
+        existingRow: existing,
+        reason: "Existing row was an incomplete placeholder — safe to overwrite.",
+      });
+      continue;
+    }
+
+    summary.conflicted.push({
+      key,
+      action: "conflicted",
+      metric,
+      existingRow: existing,
+      reason: `Existing row for this wallet/vault/asset/day holds different values than the new sync data. Refusing to overwrite automatically — review and resolve manually.`,
+    });
+  }
+
+  return summary;
+}

--- a/client/src/features/google_sheets/googleSheetsService.test.ts
+++ b/client/src/features/google_sheets/googleSheetsService.test.ts
@@ -143,6 +143,97 @@ describe("GoogleSheetsService", () => {
         ).rejects.toMatchObject({ code: "INSUFFICIENT_SCOPE" });
     });
 
+    // ── previewSync / dry-run mode (#962) ──────────────────────────────────
+
+    describe("previewSync", () => {
+        const validSession = {
+            accessToken: "token",
+            refreshToken: "refresh",
+            expiresAt: Date.now() + 3600000,
+            email: "test@example.com",
+            grantedScopes: ["https://www.googleapis.com/auth/spreadsheets"],
+        };
+        const config = {
+            spreadsheetId: "sheet-123",
+            sheetName: "Yield Metrics",
+            isLinked: true,
+            linkedAt: Date.now(),
+        };
+
+        beforeEach(() => {
+            localStorage.setItem("stellar_yield_google_oauth", JSON.stringify(validSession));
+            localStorage.setItem("stellar_yield_google_sheets", JSON.stringify(config));
+        });
+
+        it("throws when no spreadsheet is linked", async () => {
+            localStorage.removeItem("stellar_yield_google_sheets");
+            await expect(service.previewSync([])).rejects.toThrow("Google Sheets not configured");
+        });
+
+        it("fetches existing rows and returns a dry-run summary", async () => {
+            global.fetch = vi.fn().mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    rows: [
+                        {
+                            walletAddress: "GALICE",
+                            vaultName: "USDC Vault",
+                            asset: "USDC",
+                            timestamp: "2026-05-04",
+                            depositAmount: "1000",
+                            currentValue: "1050",
+                            dailyYield: "5",
+                            apy: "12.34",
+                        },
+                    ],
+                }),
+            });
+
+            const summary = await service.previewSync([
+                {
+                    date: "2026-05-04",
+                    vaultName: "USDC Vault",
+                    depositAmount: 1000n,
+                    currentValue: 1050n,
+                    dailyYield: 5n,
+                    apy: 12.34,
+                    walletAddress: "GALICE",
+                    asset: "USDC",
+                },
+                {
+                    date: "2026-05-05",
+                    vaultName: "USDC Vault",
+                    depositAmount: 1000n,
+                    currentValue: 1075n,
+                    dailyYield: 25n,
+                    apy: 12.4,
+                    walletAddress: "GALICE",
+                    asset: "USDC",
+                },
+            ]);
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining("/api/google-sheets/rows?"),
+                expect.objectContaining({
+                    headers: { Authorization: "Bearer token" },
+                }),
+            );
+            expect(summary.skipped).toHaveLength(1);
+            expect(summary.added).toHaveLength(1);
+            expect(summary.totalRows).toBe(2);
+        });
+
+        it("surfaces an API error when reading rows fails", async () => {
+            global.fetch = vi.fn().mockResolvedValueOnce({
+                ok: false,
+                status: 403,
+                json: async () => ({ error: "no access", code: "ACCESS_DENIED" }),
+            });
+
+            await expect(service.previewSync([])).rejects.toMatchObject({ code: "ACCESS_DENIED" });
+        });
+    });
+
     it("should unlink account", () => {
         const config = {
             spreadsheetId: "123",

--- a/client/src/features/google_sheets/googleSheetsService.ts
+++ b/client/src/features/google_sheets/googleSheetsService.ts
@@ -10,6 +10,11 @@ import {
   REQUIRED_SHEETS_SCOPE,
   type GoogleAuthErrorCode,
 } from "./errors";
+import {
+  computeDryRunSyncPlan,
+  type DryRunSyncSummary,
+  type ExistingSheetRow,
+} from "./dryRunSync";
 
 const STORAGE_KEY = "stellar_yield_google_sheets";
 const SESSION_KEY = "stellar_yield_google_oauth";
@@ -157,6 +162,45 @@ export class GoogleSheetsService {
 
         this.saveConfig(config);
         return config;
+    }
+
+    /**
+     * Preview what a sync of `metrics` would do to the linked spreadsheet
+     * without writing anything: fetches the current sheet contents and
+     * diffs them against `metrics` to classify each row as added, updated,
+     * skipped, or conflicted (#962).
+     */
+    async previewSync(metrics: DailyYieldMetric[]): Promise<DryRunSyncSummary> {
+        const session = await this.ensureValidSession();
+        const config = this.getConfig();
+
+        if (!config) {
+            throw new Error("Google Sheets not configured");
+        }
+
+        const existingRows = await this.fetchExistingRows(session, config);
+        return computeDryRunSyncPlan(metrics, existingRows);
+    }
+
+    private async fetchExistingRows(
+        session: GoogleOAuthSession,
+        config: GoogleSheetsConfig,
+    ): Promise<ExistingSheetRow[]> {
+        const params = new URLSearchParams({
+            spreadsheetId: config.spreadsheetId,
+            sheetName: config.sheetName,
+        });
+
+        const response = await fetch(`/api/google-sheets/rows?${params}`, {
+            headers: { Authorization: `Bearer ${session.accessToken}` },
+        });
+
+        if (!response.ok) {
+            throw await this.parseApiError(response, "Failed to read spreadsheet rows");
+        }
+
+        const data = (await response.json()) as { rows?: ExistingSheetRow[] };
+        return data.rows ?? [];
     }
 
     async appendYieldMetrics(metrics: DailyYieldMetric[]): Promise<void> {

--- a/client/src/features/google_sheets/index.ts
+++ b/client/src/features/google_sheets/index.ts
@@ -1,3 +1,11 @@
 export { default as GoogleSheetsPanel } from "./GoogleSheetsPanel";
 export { GoogleSheetsService } from "./googleSheetsService";
 export type { GoogleSheetsConfig, GoogleOAuthSession, DailyYieldMetric } from "./types";
+export { computeDryRunSyncPlan, buildRowKey, rowKeyToString } from "./dryRunSync";
+export type {
+  SheetRowAction,
+  SheetRowKey,
+  ExistingSheetRow,
+  SyncRowPlan,
+  DryRunSyncSummary,
+} from "./dryRunSync";

--- a/client/src/features/google_sheets/types.ts
+++ b/client/src/features/google_sheets/types.ts
@@ -27,4 +27,8 @@ export interface DailyYieldMetric {
     currentValue: bigint;
     dailyYield: bigint;
     apy: number;
+    /** Wallet this metric belongs to. Used for dry-run conflict detection (#962). */
+    walletAddress?: string;
+    /** Asset/token symbol for this vault position. Used for dry-run conflict detection (#962). */
+    asset?: string;
 }

--- a/client/src/features/offramp/OffRampPanel.tsx
+++ b/client/src/features/offramp/OffRampPanel.tsx
@@ -7,6 +7,7 @@ import { useState, useCallback, useEffect } from "react";
 import {
   ArrowRight,
   AlertCircle,
+  AlertTriangle,
   CheckCircle2,
   Clock,
   XCircle,
@@ -15,7 +16,7 @@ import TxStatusTimeline from "../../components/transaction/TxStatusTimeline";
 import type { TxPhase } from "../../services/transactionPhase";
 import { ExitImpactEstimator } from "../ExitImpactEstimator";
 import { OffRampService } from "./offRampService";
-import type { OffRampTransaction, WithdrawalRequest } from "./types";
+import type { OffRampTransaction, WithdrawalRequest, ResumeValidationResult } from "./types";
 
 export interface OffRampPanelProps {
   walletAddress: string | null;
@@ -37,25 +38,33 @@ export default function OffRampPanel({
   const [currentTxId, setCurrentTxId] = useState<string | null>(null);
   const [transactions, setTransactions] = useState<OffRampTransaction[]>([]);
   const [error, setError] = useState("");
+  const [blockedResume, setBlockedResume] = useState<
+    { transaction: OffRampTransaction; validation: Extract<ResumeValidationResult, { canResume: false }> } | null
+  >(null);
 
   // API key and base URL are managed server-side in /api/offramp proxy.
   const service = new OffRampService("moonpay");
 
-  // Load transaction history and auto-resume pending
+  // Load transaction history and resume a pending transaction — but only
+  // after revalidating expiry, resume metadata, and the connected wallet
+  // (#963). A stale or wallet-mismatched quote surfaces a restart prompt
+  // instead of silently continuing.
   useEffect(() => {
     const history = service.getAllTransactions();
     setTransactions(history);
 
-    // Auto-resume most recent pending transaction if any
-    const pending = history
-      .filter((t) => t.status === "pending")
-      .sort((a, b) => b.createdAt - a.createdAt)[0];
+    if (txPhase !== "idle") return;
 
-    if (pending && txPhase === "idle") {
-      setCurrentTxId(pending.id);
+    const resumable = service.findResumableTransaction(walletAddress);
+    if (!resumable) return;
+
+    if (resumable.validation.canResume) {
+      setCurrentTxId(resumable.transaction.id);
       setTxPhase("polling");
+    } else {
+      setBlockedResume({ transaction: resumable.transaction, validation: resumable.validation });
     }
-  }, [txPhase]);
+  }, [txPhase, walletAddress]);
 
   // Poll current transaction status
   useEffect(() => {
@@ -99,12 +108,14 @@ export default function OffRampPanel({
         bankAccount,
         bankName,
         accountHolder,
+        walletAddress: walletAddress ?? undefined,
       };
 
       setTxPhase("submitting");
       const tx = await service.initiateWithdrawal(request);
       setCurrentTxId(tx.id);
       setTxPhase("polling");
+      setBlockedResume(null);
       setTransactions(service.getAllTransactions());
     } catch (err) {
       setTxPhase("failure");
@@ -149,6 +160,32 @@ export default function OffRampPanel({
 
   return (
     <div className="space-y-6">
+      {/* Blocked resume — restart flow (#963) */}
+      {blockedResume && (
+        <div
+          className="glass-panel p-6 border border-amber-500/30 space-y-3"
+          data-testid="offramp-restart-flow"
+        >
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 text-amber-400 shrink-0 mt-0.5" />
+            <div className="flex-1">
+              <p className="font-semibold text-amber-400">
+                Previous withdrawal can't be resumed
+              </p>
+              <p className="text-sm text-gray-400 mt-1">
+                {blockedResume.validation.message}
+              </p>
+            </div>
+          </div>
+          <button
+            onClick={() => setBlockedResume(null)}
+            className="text-sm font-medium text-amber-400 hover:text-amber-300 underline"
+          >
+            Start a new withdrawal
+          </button>
+        </div>
+      )}
+
       {/* Withdrawal Form */}
       <div className="glass-panel p-6 space-y-4">
         <h2 className="text-xl font-semibold">Withdraw to Bank Account</h2>

--- a/client/src/features/offramp/OffRampRetryResume.test.ts
+++ b/client/src/features/offramp/OffRampRetryResume.test.ts
@@ -1,122 +1,118 @@
 /**
- * Off-Ramp Retry and Resume Tests
+ * Off-Ramp Retry and Resume Tests (#963)
+ *
+ * Covers:
+ * 1. Only safe (non-sensitive) resume metadata is persisted to localStorage.
+ * 2. Retry works within the same session, but requires a restart after a
+ *    genuine reload (new service instance, no in-memory raw request).
+ * 3. findResumableTransaction / validateResumedTransaction correctly block
+ *    resume on an expired quote, incomplete metadata, or a changed wallet.
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { OffRampService } from "./offRampService";
-import type { WithdrawalRequest } from "./types";
+import { OffRampService, isQuoteExpired, maskBankAccount, validateResumedTransaction, QUOTE_TTL_MS } from "./offRampService";
+import type { WithdrawalRequest, OffRampTransaction } from "./types";
+
+function makeRequest(overrides: Partial<WithdrawalRequest> = {}): WithdrawalRequest {
+    return {
+        vaultContractId: "test-vault",
+        shares: 1000n,
+        usdcAmount: 5000n,
+        bankAccount: "123456789",
+        bankName: "Chase",
+        accountHolder: "John Doe",
+        walletAddress: "GALICE",
+        ...overrides,
+    };
+}
 
 describe("OffRampService Retry and Resume", () => {
     let service: OffRampService;
 
     beforeEach(() => {
-        service = new OffRampService("moonpay", "test-key", "https://api.test.com");
+        service = new OffRampService("moonpay");
         localStorage.clear();
         global.fetch = vi.fn();
     });
 
-    it("should store request data for later retry", async () => {
-        (global.fetch as any).mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ id: "tx-retry-1", status: "pending" }),
+    // ── Safe persistence ─────────────────────────────────────────────────
+
+    describe("safe resume metadata persistence", () => {
+        it("persists only masked bank account details, never the raw number", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: "tx-retry-1", status: "pending" }),
+            });
+
+            const tx = await service.initiateWithdrawal(makeRequest());
+
+            expect(tx.bankAccount).toBe(maskBankAccount("123456789"));
+            expect(tx.resumeMetadata).toBeDefined();
+            expect(tx.resumeMetadata?.maskedBankAccount).toBe(maskBankAccount("123456789"));
+            expect(tx.resumeMetadata?.bankName).toBe("Chase");
+            expect(tx.resumeMetadata?.walletAddress).toBe("GALICE");
+
+            // The raw account number must not appear anywhere in what's stored.
+            const rawStorage = localStorage.getItem("stellar_yield_offramp_txns") ?? "";
+            expect(rawStorage).not.toContain("123456789");
+
+            const loaded = service.getAllTransactions()[0];
+            expect(loaded.bankAccount).toBe(maskBankAccount("123456789"));
         });
 
-        const request: WithdrawalRequest = {
-            vaultContractId: "test-vault",
-            shares: 1000n,
-            usdcAmount: 5000n,
-            bankAccount: "123456789",
-            bankName: "Chase",
-            accountHolder: "John Doe",
-        };
+        it("masks a short bank account entirely rather than under-masking it", () => {
+            expect(maskBankAccount("12")).toBe("**");
+            expect(maskBankAccount("1234")).toBe("****");
+        });
 
-        const tx = await service.initiateWithdrawal(request);
-        expect(tx.request).toBeDefined();
-        expect(tx.request?.shares).toBe(1000n);
-
-        const loaded = service.getAllTransactions()[0];
-        expect(loaded.request?.shares).toBe(1000n);
+        it("keeps the last 4 digits visible for longer account numbers", () => {
+            expect(maskBankAccount("987654321")).toBe("*****4321");
+        });
     });
 
-    it("should identify retryable errors (500)", async () => {
+    // ── isRetryable classification (pre-existing, exercised on first failure too) ──
+
+    it("marks isRetryable on the very first failed submission (500)", async () => {
         (global.fetch as any).mockResolvedValueOnce({
             ok: false,
             status: 500,
             statusText: "Internal Server Error",
         });
 
-        const request: WithdrawalRequest = {
-            vaultContractId: "test-vault",
-            shares: 1000n,
-            usdcAmount: 5000n,
-            bankAccount: "123456789",
-            bankName: "Chase",
-            accountHolder: "John Doe",
-        };
-
-        try {
-            await service.initiateWithdrawal(request);
-        } catch (e) {
-            // expected
-        }
+        await expect(service.initiateWithdrawal(makeRequest())).rejects.toThrow();
 
         const tx = service.getAllTransactions()[0];
         expect(tx.status).toBe("failed");
         expect(tx.isRetryable).toBe(true);
     });
 
-    it("should identify terminal errors (403)", async () => {
+    it("marks isRetryable false on the very first failed submission (403)", async () => {
         (global.fetch as any).mockResolvedValueOnce({
             ok: false,
             status: 403,
             statusText: "Forbidden",
         });
 
-        const request: WithdrawalRequest = {
-            vaultContractId: "test-vault",
-            shares: 1000n,
-            usdcAmount: 5000n,
-            bankAccount: "123456789",
-            bankName: "Chase",
-            accountHolder: "John Doe",
-        };
-
-        try {
-            await service.initiateWithdrawal(request);
-        } catch (e) {
-            // expected
-        }
+        await expect(service.initiateWithdrawal(makeRequest())).rejects.toThrow();
 
         const tx = service.getAllTransactions()[0];
         expect(tx.status).toBe("failed");
         expect(tx.isRetryable).toBe(false);
     });
 
-    it("should successfully retry a failed transaction", async () => {
-        // First attempt fails
+    // ── Same-session retry ───────────────────────────────────────────────
+
+    it("successfully retries a failed transaction within the same session", async () => {
         (global.fetch as any).mockResolvedValueOnce({
             ok: false,
             status: 500,
             statusText: "Internal Server Error",
         });
 
-        const request: WithdrawalRequest = {
-            vaultContractId: "test-vault",
-            shares: 1000n,
-            usdcAmount: 5000n,
-            bankAccount: "123456789",
-            bankName: "Chase",
-            accountHolder: "John Doe",
-        };
-
-        try {
-            await service.initiateWithdrawal(request);
-        } catch (e) {}
-
+        await expect(service.initiateWithdrawal(makeRequest())).rejects.toThrow();
         const failedTx = service.getAllTransactions()[0];
         expect(failedTx.status).toBe("failed");
 
-        // Retry succeeds
         (global.fetch as any).mockResolvedValueOnce({
             ok: true,
             json: async () => ({ id: failedTx.id, status: "pending" }),
@@ -127,30 +123,182 @@ describe("OffRampService Retry and Resume", () => {
         expect(retriedTx.errorMessage).toBeUndefined();
     });
 
-    it("should resume polling after refresh (pollStatus)", async () => {
-        (global.fetch as any).mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ id: "tx-resume", status: "pending" }),
+    // ── Reload behavior ──────────────────────────────────────────────────
+
+    describe("after a reload (fresh service instance)", () => {
+        it("can still poll status", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: "tx-resume", status: "pending" }),
+            });
+            const tx = await service.initiateWithdrawal(makeRequest());
+
+            // Simulate a reload: a brand new service instance, same localStorage.
+            const reloadedService = new OffRampService("moonpay");
+
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ status: "completed" }),
+            });
+            const updated = await reloadedService.pollStatus(tx.id);
+            expect(updated?.status).toBe("completed");
         });
 
-        const request: WithdrawalRequest = {
-            vaultContractId: "test-vault",
-            shares: 1000n,
-            usdcAmount: 5000n,
-            bankAccount: "123456789",
-            bankName: "Chase",
-            accountHolder: "John Doe",
-        };
+        it("refuses to retry automatically — the raw request was never persisted", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: false,
+                status: 500,
+                statusText: "Internal Server Error",
+            });
+            await expect(service.initiateWithdrawal(makeRequest())).rejects.toThrow();
+            const failedTx = service.getAllTransactions()[0];
 
-        const tx = await service.initiateWithdrawal(request);
-        
-        // Mock poll response showing completion
-        (global.fetch as any).mockResolvedValueOnce({
-            ok: true,
-            json: async () => ({ status: "completed" }),
+            // Simulate a reload: a brand new service instance, same localStorage,
+            // but an empty in-memory rawRequests map.
+            const reloadedService = new OffRampService("moonpay");
+
+            await expect(reloadedService.retryTransaction(failedTx.id)).rejects.toMatchObject({
+                message: expect.stringMatching(/start a new withdrawal/i),
+            });
+        });
+    });
+
+    // ── validateResumedTransaction / findResumableTransaction ───────────
+
+    describe("validateResumedTransaction", () => {
+        function baseTx(overrides: Partial<OffRampTransaction> = {}): OffRampTransaction {
+            const now = Date.now();
+            return {
+                id: "tx-1",
+                status: "pending",
+                amount: "5000",
+                currency: "USDC",
+                bankAccount: "*****6789",
+                memo: "SY:JohnDoe:123456",
+                createdAt: now,
+                quoteExpiresAt: now + QUOTE_TTL_MS,
+                resumeMetadata: {
+                    vaultContractId: "test-vault",
+                    bankName: "Chase",
+                    accountHolder: "John Doe",
+                    maskedBankAccount: "*****6789",
+                    walletAddress: "GALICE",
+                },
+                ...overrides,
+            };
+        }
+
+        it("allows resume when the quote is fresh, metadata is complete, and the wallet matches", () => {
+            const result = validateResumedTransaction(baseTx(), "GALICE");
+            expect(result.canResume).toBe(true);
         });
 
-        const updated = await service.pollStatus(tx.id);
-        expect(updated?.status).toBe("completed");
+        it("blocks resume when the quote has expired", () => {
+            const expired = baseTx({ quoteExpiresAt: Date.now() - 1000 });
+            const result = validateResumedTransaction(expired, "GALICE");
+            expect(result.canResume).toBe(false);
+            if (!result.canResume) expect(result.reason).toBe("quote_expired");
+        });
+
+        it("blocks resume at the exact expiry boundary instant", () => {
+            const now = Date.now();
+            const exactlyExpired = baseTx({ quoteExpiresAt: now });
+            // isQuoteExpired uses strict `>`, so `now === quoteExpiresAt` is not yet expired.
+            expect(isQuoteExpired(exactlyExpired, now)).toBe(false);
+            expect(isQuoteExpired(exactlyExpired, now + 1)).toBe(true);
+        });
+
+        it("blocks resume when resumeMetadata is missing (pre-#963 persisted transaction)", () => {
+            const legacy = baseTx({ resumeMetadata: undefined });
+            const result = validateResumedTransaction(legacy, "GALICE");
+            expect(result.canResume).toBe(false);
+            if (!result.canResume) expect(result.reason).toBe("incomplete_metadata");
+        });
+
+        it("blocks resume when resumeMetadata is missing required fields", () => {
+            const incomplete = baseTx({
+                resumeMetadata: {
+                    vaultContractId: "test-vault",
+                    bankName: "",
+                    accountHolder: "John Doe",
+                    maskedBankAccount: "",
+                },
+            });
+            const result = validateResumedTransaction(incomplete, "GALICE");
+            expect(result.canResume).toBe(false);
+            if (!result.canResume) expect(result.reason).toBe("incomplete_metadata");
+        });
+
+        it("blocks resume when the connected wallet differs from the originating wallet", () => {
+            const result = validateResumedTransaction(baseTx(), "GBOB");
+            expect(result.canResume).toBe(false);
+            if (!result.canResume) expect(result.reason).toBe("wallet_changed");
+        });
+
+        it("allows resume when no wallet is currently connected (can't yet tell it changed)", () => {
+            const result = validateResumedTransaction(baseTx(), null);
+            expect(result.canResume).toBe(true);
+        });
+
+        it("allows resume when the transaction predates wallet tracking", () => {
+            const noWallet = baseTx({
+                resumeMetadata: {
+                    vaultContractId: "test-vault",
+                    bankName: "Chase",
+                    accountHolder: "John Doe",
+                    maskedBankAccount: "*****6789",
+                    walletAddress: undefined,
+                },
+            });
+            const result = validateResumedTransaction(noWallet, "GBOB");
+            expect(result.canResume).toBe(true);
+        });
+    });
+
+    describe("findResumableTransaction", () => {
+        it("returns null when there is nothing pending", () => {
+            expect(service.findResumableTransaction("GALICE")).toBeNull();
+        });
+
+        it("returns the most recent pending transaction with its validation result", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: "tx-a", status: "pending" }),
+            });
+            const tx = await service.initiateWithdrawal(makeRequest());
+
+            const result = service.findResumableTransaction("GALICE");
+            expect(result).not.toBeNull();
+            expect(result?.transaction.id).toBe(tx.id);
+            expect(result?.validation.canResume).toBe(true);
+        });
+
+        it("flags a wallet change on the resumable transaction", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: "tx-a", status: "pending" }),
+            });
+            await service.initiateWithdrawal(makeRequest({ walletAddress: "GALICE" }));
+
+            const result = service.findResumableTransaction("GDIFFERENT");
+            expect(result?.validation.canResume).toBe(false);
+            if (result && !result.validation.canResume) {
+                expect(result.validation.reason).toBe("wallet_changed");
+            }
+        });
+
+        it("flags an expired quote on the resumable transaction", async () => {
+            (global.fetch as any).mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({ id: "tx-a", status: "pending" }),
+            });
+            const tx = await service.initiateWithdrawal(makeRequest());
+
+            const result = service.findResumableTransaction("GALICE", tx.createdAt + QUOTE_TTL_MS + 1);
+            expect(result?.validation.canResume).toBe(false);
+            if (result && !result.validation.canResume) {
+                expect(result.validation.reason).toBe("quote_expired");
+            }
+        });
     });
 });

--- a/client/src/features/offramp/index.ts
+++ b/client/src/features/offramp/index.ts
@@ -1,3 +1,4 @@
 export { default as OffRampPanel } from "./OffRampPanel";
-export { OffRampService } from "./offRampService";
+export { OffRampService, isQuoteExpired, maskBankAccount, validateResumedTransaction } from "./offRampService";
 export type { OffRampTransaction, WithdrawalRequest, OffRampConfig } from "./types";
+export type { SafeResumeMetadata, ResumeBlockedReason, ResumeValidationResult } from "./types";

--- a/client/src/features/offramp/offRampService.ts
+++ b/client/src/features/offramp/offRampService.ts
@@ -3,7 +3,14 @@
  * Handles integration with MoonPay or Stellar Anchor for bank withdrawals
  */
 
-import type { OffRampTransaction, WithdrawalRequest, OffRampProvider, OffRampErrorType } from "./types";
+import type {
+    OffRampTransaction,
+    WithdrawalRequest,
+    OffRampProvider,
+    OffRampErrorType,
+    SafeResumeMetadata,
+    ResumeValidationResult,
+} from "./types";
 import { OffRampError } from "./types";
 
 function createOffRampError(
@@ -35,9 +42,70 @@ export const QUOTE_TTL_MS = 5 * 60 * 1_000;
  * Returns true when the transaction's provider quote has expired.
  * A transaction without a quoteExpiresAt is treated as non-expiring.
  */
-export function isQuoteExpired(tx: import("./types").OffRampTransaction, nowMs = Date.now()): boolean {
+export function isQuoteExpired(tx: OffRampTransaction, nowMs = Date.now()): boolean {
     if (tx.quoteExpiresAt === undefined) return false;
     return nowMs > tx.quoteExpiresAt;
+}
+
+/** Mask a bank account number for safe display/storage, keeping only the last 4 characters. */
+export function maskBankAccount(bankAccount: string): string {
+    if (bankAccount.length <= 4) return "*".repeat(bankAccount.length);
+    return "*".repeat(bankAccount.length - 4) + bankAccount.slice(-4);
+}
+
+function toSafeResumeMetadata(request: WithdrawalRequest): SafeResumeMetadata {
+    return {
+        vaultContractId: request.vaultContractId,
+        bankName: request.bankName,
+        accountHolder: request.accountHolder,
+        maskedBankAccount: maskBankAccount(request.bankAccount),
+        walletAddress: request.walletAddress,
+    };
+}
+
+/**
+ * Decide whether a persisted transaction is safe to silently resume after a
+ * reload, or whether the caller should show a restart flow instead (#963).
+ *
+ * Checks, in order: quote expiry, presence of complete resume metadata
+ * (a transaction persisted before this field existed, or corrupted in
+ * storage, is treated as incomplete), and whether the wallet resuming the
+ * flow matches the wallet that started it.
+ */
+export function validateResumedTransaction(
+    tx: OffRampTransaction,
+    currentWalletAddress: string | null,
+    nowMs = Date.now(),
+): ResumeValidationResult {
+    if (isQuoteExpired(tx, nowMs)) {
+        return {
+            canResume: false,
+            reason: "quote_expired",
+            message: "This withdrawal's quote has expired. Start a new withdrawal to get current rates.",
+        };
+    }
+
+    if (!tx.resumeMetadata || !tx.resumeMetadata.maskedBankAccount || !tx.resumeMetadata.bankName) {
+        return {
+            canResume: false,
+            reason: "incomplete_metadata",
+            message: "This withdrawal is missing required details and can't be resumed automatically.",
+        };
+    }
+
+    if (
+        tx.resumeMetadata.walletAddress !== undefined &&
+        currentWalletAddress !== null &&
+        tx.resumeMetadata.walletAddress !== currentWalletAddress
+    ) {
+        return {
+            canResume: false,
+            reason: "wallet_changed",
+            message: "This withdrawal was started from a different wallet. Reconnect that wallet or start a new withdrawal.",
+        };
+    }
+
+    return { canResume: true };
 }
 
 const STORAGE_KEY = "stellar_yield_offramp_txns";
@@ -46,6 +114,15 @@ const OFFRAMP_PROXY = "/api/offramp";
 
 export class OffRampService {
     readonly provider: OffRampProvider;
+
+    /**
+     * Raw request payloads (including the unmasked bank account), kept
+     * in-memory only for same-session retries. Never persisted — a fresh
+     * page load starts with an empty map, which is what forces
+     * retryTransaction to require a restart instead of silently
+     * resubmitting after a reload (#963).
+     */
+    private readonly rawRequests = new Map<string, WithdrawalRequest>();
 
     constructor(provider: OffRampProvider) {
         this.provider = provider;
@@ -57,6 +134,8 @@ export class OffRampService {
      */
     async initiateWithdrawal(request: WithdrawalRequest): Promise<OffRampTransaction> {
         const txId = `offramp_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+        // Kept in-memory only — see rawRequests doc comment.
+        this.rawRequests.set(txId, request);
 
         const now = Date.now();
         const transaction: OffRampTransaction = {
@@ -64,17 +143,17 @@ export class OffRampService {
             status: "pending",
             amount: request.usdcAmount.toString(),
             currency: "USDC",
-            bankAccount: request.bankAccount,
+            bankAccount: maskBankAccount(request.bankAccount),
             memo: this.generateMemo(request),
             createdAt: now,
             quoteExpiresAt: now + QUOTE_TTL_MS,
-            request, // Store request for potential retries
+            resumeMetadata: toSafeResumeMetadata(request),
         };
 
         // Validate destination address and memo
         this.validateDestination(request.bankAccount, transaction.memo);
 
-        // Store transaction locally
+        // Store transaction locally (safe fields only — see resumeMetadata)
         this.saveTransaction(transaction);
 
         // Call off-ramp provider API
@@ -82,6 +161,7 @@ export class OffRampService {
             await this.submitToProvider(transaction, request);
         } catch (error) {
             transaction.status = "failed";
+            transaction.isRetryable = this.checkIfRetryable(error);
             if (error instanceof OffRampError) {
                 transaction.errorMessage = error.userMessage;
             } else {
@@ -95,11 +175,25 @@ export class OffRampService {
     }
 
     /**
-     * Retry a failed transaction
+     * Retry a failed transaction. Only possible within the same session
+     * that created it — the raw request (needed to resubmit the actual
+     * bank account to the provider) is never persisted, so after a reload
+     * this throws and the caller should fall back to a restart flow (#963).
      */
     async retryTransaction(txId: string): Promise<OffRampTransaction> {
         const tx = this.loadTransaction(txId);
-        if (!tx || !tx.request) throw new Error("Transaction not found or missing request data");
+        if (!tx) throw new Error("Transaction not found");
+
+        const rawRequest = this.rawRequests.get(txId);
+        if (!rawRequest) {
+            throw createOffRampError(
+                "SUBMISSION_FAILED",
+                "This withdrawal can no longer be retried automatically after a reload. Please start a new withdrawal.",
+                false,
+                undefined,
+                txId,
+            );
+        }
 
         tx.status = "pending";
         tx.errorMessage = undefined;
@@ -107,7 +201,7 @@ export class OffRampService {
         this.saveTransaction(tx);
 
         try {
-            await this.submitToProvider(tx, tx.request);
+            await this.submitToProvider(tx, rawRequest);
             return tx;
         } catch (error) {
             tx.status = "failed";
@@ -116,6 +210,28 @@ export class OffRampService {
             this.saveTransaction(tx);
             throw error;
         }
+    }
+
+    /**
+     * Find the most recently created pending transaction, if any, and
+     * validate whether it's safe to silently resume (#963). Callers (e.g.
+     * the panel's mount effect) should use this instead of blindly resuming
+     * the newest pending transaction — see validateResumedTransaction.
+     */
+    findResumableTransaction(
+        currentWalletAddress: string | null,
+        nowMs = Date.now(),
+    ): { transaction: OffRampTransaction; validation: ResumeValidationResult } | null {
+        const pending = this.getAllTransactions()
+            .filter((t) => t.status === "pending")
+            .sort((a, b) => b.createdAt - a.createdAt)[0];
+
+        if (!pending) return null;
+
+        return {
+            transaction: pending,
+            validation: validateResumedTransaction(pending, currentWalletAddress, nowMs),
+        };
     }
 
     /**
@@ -237,7 +353,9 @@ export class OffRampService {
         const payload = {
             amount: transaction.amount,
             currency: transaction.currency,
-            bankAccount: transaction.bankAccount,
+            // The raw (unmasked) bank account from the in-memory request —
+            // transaction.bankAccount is masked for safe storage/display (#963).
+            bankAccount: request.bankAccount,
             memo: transaction.memo,
             accountHolder: request.accountHolder,
             bankName: request.bankName,

--- a/client/src/features/offramp/types.ts
+++ b/client/src/features/offramp/types.ts
@@ -28,6 +28,7 @@ export interface OffRampTransaction {
     status: OffRampStatus;
     amount: string;
     currency: string;
+    /** Masked once persisted — see maskBankAccount. Never the full account number (#963). */
     bankAccount: string;
     memo: string;
     createdAt: number;
@@ -36,7 +37,8 @@ export interface OffRampTransaction {
     quoteExpiresAt?: number;
     errorMessage?: string;
     isRetryable?: boolean;
-    request?: WithdrawalRequest;
+    /** Non-sensitive fields safe to persist and use to validate a resume attempt (#963). */
+    resumeMetadata?: SafeResumeMetadata;
 }
 
 export interface WithdrawalRequest {
@@ -46,7 +48,29 @@ export interface WithdrawalRequest {
     bankAccount: string;
     bankName: string;
     accountHolder: string;
+    /** Wallet initiating this withdrawal — used to detect a changed-wallet resume (#963). */
+    walletAddress?: string;
 }
+
+/**
+ * Non-sensitive fields safe to persist to localStorage for resuming a
+ * withdrawal across a page reload. Deliberately excludes the raw bank
+ * account number and any provider credentials — only a masked account
+ * number is retained (#963).
+ */
+export interface SafeResumeMetadata {
+    vaultContractId: string;
+    bankName: string;
+    accountHolder: string;
+    maskedBankAccount: string;
+    walletAddress?: string;
+}
+
+export type ResumeBlockedReason = "quote_expired" | "incomplete_metadata" | "wallet_changed";
+
+export type ResumeValidationResult =
+    | { canResume: true }
+    | { canResume: false; reason: ResumeBlockedReason; message: string };
 
 /**
  * OffRampError class for handling off-ramp specific errors

--- a/client/src/features/rewards/BatchClaimPreview.tsx
+++ b/client/src/features/rewards/BatchClaimPreview.tsx
@@ -1,14 +1,15 @@
 import { useState, useEffect, useCallback } from "react";
-import { AlertCircle, CheckCircle2, Clock, Zap, RefreshCw } from "lucide-react";
+import { AlertCircle, AlertOctagon, CheckCircle2, Clock, Zap, RefreshCw } from "lucide-react";
 import { useWallet } from "../../context/useWallet";
 import { getApiBaseUrl } from "../../lib/api";
-import type { BatchClaimPreview, ClaimProofData } from "./types";
+import type { BatchClaimPreview, ClaimProofData, CurrentCampaignInfo } from "./types";
 import {
   buildBatchClaimPreview,
   formatYieldAmount,
   getClaimableVaults,
   getStaleProofVaults,
   getUnavailableVaults,
+  getInvalidProofVaults,
 } from "./batchClaimUtils";
 
 const getApiBase = () => {
@@ -22,6 +23,8 @@ const getApiBase = () => {
 interface BatchClaimPreviewProps {
   vaultIds: string[];
   vaultMetadata: Record<string, { name: string }>;
+  /** Active campaign id/root, when known, to detect stale or wrong-campaign cached proofs (#964). */
+  currentCampaign?: CurrentCampaignInfo;
 }
 
 /**
@@ -31,6 +34,7 @@ interface BatchClaimPreviewProps {
 export default function BatchClaimPreview({
   vaultIds,
   vaultMetadata,
+  currentCampaign,
 }: BatchClaimPreviewProps) {
   const { isConnected, walletAddress } = useWallet();
   const [preview, setPreview] = useState<BatchClaimPreview | null>(null);
@@ -77,7 +81,7 @@ export default function BatchClaimPreview({
       const results = await Promise.all(proofPromises);
       const vaultProofs = Object.fromEntries(results);
 
-      const batchPreview = buildBatchClaimPreview(vaultProofs, vaultMetadata);
+      const batchPreview = buildBatchClaimPreview(vaultProofs, vaultMetadata, currentCampaign);
       setPreview(batchPreview);
     } catch (err) {
       setError(
@@ -86,7 +90,7 @@ export default function BatchClaimPreview({
     } finally {
       setLoading(false);
     }
-  }, [walletAddress, vaultIds, vaultMetadata]);
+  }, [walletAddress, vaultIds, vaultMetadata, currentCampaign]);
 
   useEffect(() => {
     if (isConnected && walletAddress) {
@@ -130,6 +134,7 @@ export default function BatchClaimPreview({
   const claimableVaults = getClaimableVaults(preview.vaults);
   const staleVaults = getStaleProofVaults(preview.vaults);
   const unavailableVaults = getUnavailableVaults(preview.vaults);
+  const invalidVaults = getInvalidProofVaults(preview.vaults);
 
   return (
     <div className="space-y-6">
@@ -192,6 +197,16 @@ export default function BatchClaimPreview({
               </span>
             </div>
           )}
+
+          {invalidVaults.length > 0 && (
+            <div className="flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/20 rounded-lg">
+              <AlertOctagon size={16} className="text-red-400" />
+              <span className="text-sm text-red-400">
+                {invalidVaults.length} invalid proof
+                {invalidVaults.length !== 1 ? "s" : ""}
+              </span>
+            </div>
+          )}
         </div>
       </div>
 
@@ -247,6 +262,16 @@ export default function BatchClaimPreview({
                   <span className="text-xs text-red-400">Missing</span>
                 </div>
               )}
+
+              {vault.status === "invalid_proof" && (
+                <div
+                  className="flex items-center gap-1 px-2 py-1 bg-red-500/20 rounded"
+                  title={vault.previewMessage}
+                >
+                  <AlertOctagon size={16} className="text-red-400" />
+                  <span className="text-xs text-red-400">Invalid</span>
+                </div>
+              )}
             </div>
           </div>
         ))}
@@ -278,6 +303,22 @@ export default function BatchClaimPreview({
             <p className="text-sm text-red-300">
               {unavailableVaults.map((v) => v.vaultName).join(", ")} have no
               available rewards or proof data.
+            </p>
+          </div>
+        </div>
+      )}
+
+      {invalidVaults.length > 0 && (
+        <div className="flex items-start gap-3 bg-red-500/10 border border-red-500/20 rounded-xl p-4">
+          <AlertOctagon className="text-red-400 shrink-0 mt-0.5" size={20} />
+          <div>
+            <p className="font-semibold text-red-400 mb-1">
+              Invalid Claim Data
+            </p>
+            <p className="text-sm text-red-300">
+              {invalidVaults.map((v) => v.vaultName).join(", ")} have a cached
+              proof that does not match the active reward campaign and must
+              not be submitted. Refresh to fetch a corrected proof.
             </p>
           </div>
         </div>

--- a/client/src/features/rewards/batchClaimUtils.test.ts
+++ b/client/src/features/rewards/batchClaimUtils.test.ts
@@ -7,8 +7,9 @@ import {
     getClaimableVaults,
     getStaleProofVaults,
     getUnavailableVaults,
+    getInvalidProofVaults,
 } from './batchClaimUtils';
-import type { ClaimProofData } from './types';
+import type { ClaimProofData, CurrentCampaignInfo } from './types';
 
 describe('batchClaimUtils', () => {
     beforeEach(() => {
@@ -309,6 +310,114 @@ describe('batchClaimUtils', () => {
             const unavailable = getUnavailableVaults(vaults);
             expect(unavailable).toHaveLength(1);
             expect(unavailable[0].vaultId).toBe('v2');
+        });
+    });
+
+    // ── #964: campaign-aware buildBatchClaimPreview ────────────────────────
+
+    describe('buildBatchClaimPreview with currentCampaign', () => {
+        const currentCampaign: CurrentCampaignInfo = {
+            campaignId: '2026-W22',
+            merkleRoot: 'a'.repeat(64),
+        };
+
+        it('keeps a matching campaign/root proof claimable', () => {
+            const vaultProofs = {
+                vault1: {
+                    index: 0,
+                    amount: '5000000000',
+                    proof: ['b'.repeat(64)],
+                    timestamp: Date.now() - 1000,
+                    campaignId: '2026-W22',
+                    merkleRoot: 'a'.repeat(64),
+                } as ClaimProofData,
+            };
+            const vaultMetadata = { vault1: { name: 'USDC Vault' } };
+
+            const preview = buildBatchClaimPreview(vaultProofs, vaultMetadata, currentCampaign);
+
+            expect(preview.vaults[0].status).toBe('claimable');
+            expect(preview.canClaimAll).toBe(true);
+        });
+
+        it('marks a campaign-ID mismatch as invalid_proof, not stale', () => {
+            const vaultProofs = {
+                vault1: {
+                    index: 0,
+                    amount: '5000000000',
+                    proof: ['b'.repeat(64)],
+                    timestamp: Date.now() - 1000,
+                    campaignId: '2026-W21',
+                    merkleRoot: 'a'.repeat(64),
+                } as ClaimProofData,
+            };
+            const vaultMetadata = { vault1: { name: 'USDC Vault' } };
+
+            const preview = buildBatchClaimPreview(vaultProofs, vaultMetadata, currentCampaign);
+
+            expect(preview.vaults[0].status).toBe('invalid_proof');
+            expect(preview.vaults[0].proofStale).toBe(false);
+            expect(preview.vaults[0].previewMessage).toMatch(/campaign/i);
+            expect(preview.canClaimAll).toBe(false);
+            expect(getInvalidProofVaults(preview.vaults)).toHaveLength(1);
+        });
+
+        it('marks root drift as stale_proof', () => {
+            const vaultProofs = {
+                vault1: {
+                    index: 0,
+                    amount: '5000000000',
+                    proof: ['b'.repeat(64)],
+                    timestamp: Date.now() - 1000,
+                    campaignId: '2026-W22',
+                    merkleRoot: 'c'.repeat(64),
+                } as ClaimProofData,
+            };
+            const vaultMetadata = { vault1: { name: 'USDC Vault' } };
+
+            const preview = buildBatchClaimPreview(vaultProofs, vaultMetadata, currentCampaign);
+
+            expect(preview.vaults[0].status).toBe('stale_proof');
+            expect(preview.vaults[0].proofStale).toBe(true);
+            expect(preview.anyProofsStale).toBe(true);
+            expect(preview.canClaimAll).toBe(false);
+        });
+
+        it('marks a malformed proof array as invalid_proof', () => {
+            const vaultProofs = {
+                vault1: {
+                    index: 0,
+                    amount: '5000000000',
+                    proof: ['not-a-hex-hash'],
+                    timestamp: Date.now() - 1000,
+                    campaignId: '2026-W22',
+                    merkleRoot: 'a'.repeat(64),
+                } as ClaimProofData,
+            };
+            const vaultMetadata = { vault1: { name: 'USDC Vault' } };
+
+            const preview = buildBatchClaimPreview(vaultProofs, vaultMetadata, currentCampaign);
+
+            expect(preview.vaults[0].status).toBe('invalid_proof');
+            expect(preview.canClaimAll).toBe(false);
+        });
+
+        it('does not run campaign checks when currentCampaign is omitted (backward compatible)', () => {
+            const vaultProofs = {
+                vault1: {
+                    index: 0,
+                    amount: '5000000000',
+                    proof: ['not-a-hex-hash'],
+                    timestamp: Date.now() - 1000,
+                    campaignId: 'some-other-campaign',
+                    merkleRoot: 'z'.repeat(64),
+                } as ClaimProofData,
+            };
+            const vaultMetadata = { vault1: { name: 'USDC Vault' } };
+
+            const preview = buildBatchClaimPreview(vaultProofs, vaultMetadata);
+
+            expect(preview.vaults[0].status).toBe('claimable');
         });
     });
 });

--- a/client/src/features/rewards/batchClaimUtils.ts
+++ b/client/src/features/rewards/batchClaimUtils.ts
@@ -1,4 +1,5 @@
-import type { BatchClaimPreview, VaultRewardStatus, ClaimProofData } from './types';
+import type { BatchClaimPreview, VaultRewardStatus, ClaimProofData, CurrentCampaignInfo } from './types';
+import { getClaimPreviewState } from './claimPreviewValidation';
 
 const PROOF_STALE_THRESHOLD_MS = 24 * 60 * 60 * 1000; // 24 hours
 const ESTIMATED_FEE_STROOPS = '1000000'; // 0.1 YIELD
@@ -52,17 +53,25 @@ export function isProofStale(timestamp: number): boolean {
 }
 
 /**
- * Build a batch claim preview from multiple vault proofs
+ * Build a batch claim preview from multiple vault proofs.
+ *
+ * When `currentCampaign` is provided, each proof is additionally checked
+ * against the active campaign's id and Merkle root (#964): a campaign-ID
+ * mismatch or malformed proof marks the vault 'invalid_proof' (must not be
+ * submitted), while root drift is folded into the existing 'stale_proof'
+ * signal alongside time-based staleness.
  */
 export function buildBatchClaimPreview(
     vaultProofs: Record<string, ClaimProofData | null>,
     vaultMetadata: Record<string, { name: string }>,
+    currentCampaign?: CurrentCampaignInfo,
 ): BatchClaimPreview {
     const vaults: VaultRewardStatus[] = [];
     let totalClaimable = 0n;
     let totalEstimatedFees = 0n;
     let allProofsAvailable = true;
     let anyProofsStale = false;
+    let anyProofsInvalid = false;
 
     for (const [vaultId, proof] of Object.entries(vaultProofs)) {
         const metadata = vaultMetadata[vaultId];
@@ -83,14 +92,27 @@ export function buildBatchClaimPreview(
             continue;
         }
 
-        const stale = isProofStale(proof.timestamp);
+        const preview = currentCampaign
+            ? getClaimPreviewState(
+                { campaignId: proof.campaignId, merkleRoot: proof.merkleRoot, proof: proof.proof },
+                currentCampaign,
+            )
+            : null;
+
+        const timeStale = isProofStale(proof.timestamp);
+        const rootStale = preview?.state === 'stale';
+        const invalid = preview?.state === 'invalid';
+        const stale = timeStale || rootStale;
+
         const amount = BigInt(proof.amount);
         const fee = BigInt(ESTIMATED_FEE_STROOPS);
 
         totalClaimable += amount;
         totalEstimatedFees += fee;
 
-        if (stale) {
+        if (invalid) {
+            anyProofsInvalid = true;
+        } else if (stale) {
             anyProofsStale = true;
         }
 
@@ -99,10 +121,11 @@ export function buildBatchClaimPreview(
             vaultName: metadata.name,
             claimableAmount: proof.amount,
             proofAvailable: true,
-            proofStale: stale,
+            proofStale: stale && !invalid,
             lastProofUpdate: new Date(proof.timestamp).toISOString(),
             estimatedFee: fee.toString(),
-            status: stale ? 'stale_proof' : 'claimable',
+            status: invalid ? 'invalid_proof' : stale ? 'stale_proof' : 'claimable',
+            previewMessage: invalid ? preview?.message : undefined,
         });
     }
 
@@ -112,7 +135,7 @@ export function buildBatchClaimPreview(
         vaults,
         allProofsAvailable,
         anyProofsStale,
-        canClaimAll: allProofsAvailable && !anyProofsStale,
+        canClaimAll: allProofsAvailable && !anyProofsStale && !anyProofsInvalid,
     };
 }
 
@@ -153,4 +176,12 @@ export function getStaleProofVaults(vaults: VaultRewardStatus[]): VaultRewardSta
  */
 export function getUnavailableVaults(vaults: VaultRewardStatus[]): VaultRewardStatus[] {
     return vaults.filter(v => !v.proofAvailable);
+}
+
+/**
+ * Get vaults whose cached proof failed campaign-ID or shape validation and
+ * must not be submitted as-is (#964).
+ */
+export function getInvalidProofVaults(vaults: VaultRewardStatus[]): VaultRewardStatus[] {
+    return vaults.filter(v => v.status === 'invalid_proof');
 }

--- a/client/src/features/rewards/claimPreviewValidation.test.ts
+++ b/client/src/features/rewards/claimPreviewValidation.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { findProofShapeError, getClaimPreviewState } from './claimPreviewValidation';
+import type { CurrentCampaignInfo } from './types';
+
+describe('findProofShapeError', () => {
+    const validHash = 'a'.repeat(64);
+    const otherValidHash = 'b'.repeat(64);
+
+    it('returns null for a well-formed proof', () => {
+        expect(findProofShapeError([validHash, otherValidHash])).toBeNull();
+    });
+
+    it('returns null for an empty proof', () => {
+        expect(findProofShapeError([])).toBeNull();
+    });
+
+    it('flags a malformed (non-hex) element', () => {
+        expect(findProofShapeError(['not-valid-hex'])).toMatch(/malformed/i);
+    });
+
+    it('flags an element with the wrong length', () => {
+        expect(findProofShapeError(['ab'.repeat(10)])).toMatch(/malformed/i);
+    });
+
+    it('flags a duplicate path element', () => {
+        expect(findProofShapeError([validHash, otherValidHash, validHash])).toMatch(/duplicate/i);
+    });
+
+    it('flags a proof deeper than the maximum allowed depth', () => {
+        const deepProof = Array.from({ length: 21 }, (_, i) => i.toString(16).padStart(64, '0'));
+        expect(findProofShapeError(deepProof)).toMatch(/exceeds/i);
+    });
+});
+
+describe('getClaimPreviewState', () => {
+    const current: CurrentCampaignInfo = {
+        campaignId: '2026-W22',
+        merkleRoot: 'a'.repeat(64),
+    };
+    const proof = ['b'.repeat(64)];
+
+    it('returns valid when campaign, root, and shape all match', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W22', merkleRoot: 'a'.repeat(64), proof },
+            current,
+        );
+        expect(result.state).toBe('valid');
+        expect(result.errorCode).toBeUndefined();
+    });
+
+    it('treats missing campaignId/merkleRoot as an optimistic pass-through (no crash)', () => {
+        const result = getClaimPreviewState({ proof }, current);
+        expect(result.state).toBe('valid');
+    });
+
+    it('flags a campaign ID mismatch as invalid', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W21', merkleRoot: 'a'.repeat(64), proof },
+            current,
+        );
+        expect(result.state).toBe('invalid');
+        expect(result.errorCode).toBe('campaign_id_mismatch');
+    });
+
+    it('flags a malformed proof as invalid', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W22', merkleRoot: 'a'.repeat(64), proof: ['bad-hash'] },
+            current,
+        );
+        expect(result.state).toBe('invalid');
+        expect(result.errorCode).toBe('malformed_proof');
+    });
+
+    it('flags a duplicate proof path as invalid', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W22', merkleRoot: 'a'.repeat(64), proof: [proof[0], proof[0]] },
+            current,
+        );
+        expect(result.state).toBe('invalid');
+        expect(result.errorCode).toBe('malformed_proof');
+    });
+
+    it('flags a drifted root as stale, not invalid', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W22', merkleRoot: 'c'.repeat(64), proof },
+            current,
+        );
+        expect(result.state).toBe('stale');
+        expect(result.errorCode).toBe('root_mismatch');
+    });
+
+    it('is case-insensitive when comparing roots', () => {
+        const result = getClaimPreviewState(
+            { campaignId: '2026-W22', merkleRoot: 'A'.repeat(64), proof },
+            current,
+        );
+        expect(result.state).toBe('valid');
+    });
+});

--- a/client/src/features/rewards/claimPreviewValidation.ts
+++ b/client/src/features/rewards/claimPreviewValidation.ts
@@ -1,0 +1,104 @@
+import type {
+    ClaimPreviewResult,
+    CurrentCampaignInfo,
+} from './types';
+
+/** A single 32-byte proof element must be exactly 64 hex characters. */
+const PROOF_ELEMENT_PATTERN = /^[0-9a-fA-F]{64}$/;
+const ROOT_PATTERN = /^[0-9a-fA-F]{64}$/;
+
+/** Mirrors backend/rewards MAX_PROOF_DEPTH — trees up to 2^20 recipients. */
+const MAX_PROOF_DEPTH = 20;
+
+/**
+ * Structural validation of a proof array: every element must be a 32-byte
+ * hex string, the depth must respect MAX_PROOF_DEPTH, and no sibling hash
+ * may repeat (a well-formed Merkle proof never revisits the same node twice
+ * — a repeated element is a sign of a truncated, replayed, or tampered proof).
+ */
+export function findProofShapeError(proof: string[]): string | null {
+    if (!Array.isArray(proof)) {
+        return 'Proof must be an array of hex-encoded sibling hashes';
+    }
+
+    if (proof.length > MAX_PROOF_DEPTH) {
+        return `Proof depth ${proof.length} exceeds maximum allowed depth of ${MAX_PROOF_DEPTH}`;
+    }
+
+    const seen = new Set<string>();
+    for (const element of proof) {
+        if (typeof element !== 'string' || !PROOF_ELEMENT_PATTERN.test(element)) {
+            return `Proof contains a malformed path element: "${String(element)}"`;
+        }
+        const normalized = element.toLowerCase();
+        if (seen.has(normalized)) {
+            return `Proof contains a duplicate path element: "${element}"`;
+        }
+        seen.add(normalized);
+    }
+
+    return null;
+}
+
+export interface ClaimPreviewCandidate {
+    /** Campaign the cached proof was generated for, if known. */
+    campaignId?: string;
+    /** Merkle root the cached proof was generated against, if known. */
+    merkleRoot?: string;
+    proof: string[];
+}
+
+/**
+ * Client-side pre-flight check for a cached claim proof: campaign ID match,
+ * proof shape, and root drift relative to the currently active campaign.
+ *
+ * This intentionally does not repeat the cryptographic Merkle verification
+ * the backend already performed when it issued the proof — its job is to
+ * catch cases where *locally cached* proof data has gone stale or was
+ * corrupted before the user attempts to submit a claim transaction.
+ */
+export function getClaimPreviewState(
+    candidate: ClaimPreviewCandidate,
+    current: CurrentCampaignInfo,
+): ClaimPreviewResult {
+    if (candidate.campaignId !== undefined && candidate.campaignId !== current.campaignId) {
+        return {
+            state: 'invalid',
+            errorCode: 'campaign_id_mismatch',
+            message: `This proof targets campaign "${candidate.campaignId}", but the active campaign is "${current.campaignId}".`,
+        };
+    }
+
+    const shapeError = findProofShapeError(candidate.proof);
+    if (shapeError) {
+        return {
+            state: 'invalid',
+            errorCode: 'malformed_proof',
+            message: shapeError,
+        };
+    }
+
+    if (candidate.merkleRoot !== undefined) {
+        if (!ROOT_PATTERN.test(candidate.merkleRoot)) {
+            return {
+                state: 'invalid',
+                errorCode: 'malformed_proof',
+                message: `Merkle root "${candidate.merkleRoot}" is not a valid 32-byte hex value.`,
+            };
+        }
+
+        if (candidate.merkleRoot.toLowerCase() !== current.merkleRoot.toLowerCase()) {
+            return {
+                state: 'stale',
+                errorCode: 'root_mismatch',
+                message:
+                    'This proof was generated against an earlier version of the reward tree. Refresh to get an updated proof.',
+            };
+        }
+    }
+
+    return {
+        state: 'valid',
+        message: 'Claim proof looks valid.',
+    };
+}

--- a/client/src/features/rewards/types.ts
+++ b/client/src/features/rewards/types.ts
@@ -10,7 +10,9 @@ export interface VaultRewardStatus {
     proofStale: boolean;
     lastProofUpdate: string | null;
     estimatedFee: string;
-    status: 'claimable' | 'unavailable' | 'stale_proof';
+    status: 'claimable' | 'unavailable' | 'stale_proof' | 'invalid_proof';
+    /** Human-readable reason when status is 'invalid_proof' (#964). */
+    previewMessage?: string;
 }
 
 export interface BatchClaimPreview {
@@ -27,4 +29,30 @@ export interface ClaimProofData {
     amount: string;
     proof: string[];
     timestamp: number;
+    /** Distribution campaign this proof was generated for (#964). */
+    campaignId?: string;
+    /** Merkle root this proof was generated against (#964). */
+    merkleRoot?: string;
+}
+
+/**
+ * The active reward campaign's canonical id and Merkle root, used to detect
+ * campaign-ID mismatches and root drift in cached claim proofs (#964).
+ */
+export interface CurrentCampaignInfo {
+    campaignId: string;
+    merkleRoot: string;
+}
+
+export type ClaimPreviewState = 'valid' | 'invalid' | 'stale';
+
+export type ClaimPreviewErrorCode =
+    | 'campaign_id_mismatch'
+    | 'malformed_proof'
+    | 'root_mismatch';
+
+export interface ClaimPreviewResult {
+    state: ClaimPreviewState;
+    errorCode?: ClaimPreviewErrorCode;
+    message: string;
 }

--- a/docs/reward-schedule-authoring.md
+++ b/docs/reward-schedule-authoring.md
@@ -1,0 +1,81 @@
+# Reward Schedule Authoring: Timezone & Weekly Window Expectations
+
+## Overview
+Reward schedule windows (`startDate` / `endDate` on `RewardScheduleLike`, see
+`docs/reward_registry.md`) drift when local timezones, UTC storage, and
+weekly campaign boundaries get mixed up during authoring. This document is
+the canonical clock model for anyone entering or editing a schedule window,
+and for anyone building tooling that renders one.
+
+Implementation: `backend/rewards/src/scheduleHealth.ts`.
+Tests: `backend/rewards/src/__tests__/scheduleHealth.test.ts`.
+
+## The model
+
+1. **Stored windows are always UTC.** A JavaScript `Date` has no attached
+   timezone — internally it is always a UTC epoch timestamp. Every
+   `startDate` / `endDate` that reaches storage must already be that UTC
+   instant. Never store a "local" date string and reinterpret it later.
+2. **Timezone conversion happens once, at authoring time.** If a schedule is
+   authored as a wall-clock time in a named timezone (e.g. "Monday 00:00 in
+   America/New_York"), convert it to UTC immediately with
+   `normalizeScheduleWindowToUtc` / `wallClockToUtc` before it is persisted.
+   Do not store the timezone name alongside the instant and re-derive UTC
+   later — that reintroduces the exact drift this document exists to
+   prevent.
+3. **Rendering is a pure, non-mutating read.** `renderInTimeZone(utcInstant,
+   timeZone)` formats a stored UTC instant for a viewer in any timezone. It
+   never changes, and must never be fed back into, the stored window.
+4. **Weekly campaign boundaries are defined in UTC, not local time.** "Which
+   week does this claim belong to" is answered by `startOfIsoWeekUtc`,
+   `endOfIsoWeekUtc`, and `isSameIsoWeekUtc` — Monday 00:00:00.000 UTC
+   through the following Monday 00:00:00.000 UTC (exclusive), independent of
+   where a schedule was authored or where a claimant is located. Do not
+   compute week boundaries from a viewer's local calendar day.
+
+## API summary
+
+| Function | Purpose |
+|---|---|
+| `wallClockToUtc({ wallClock, timeZone })` | Convert an authored wall-clock moment in a named IANA timezone to its precise UTC instant. Uses live `Intl` timezone rules, so it is correct across DST transitions rather than assuming a fixed offset. |
+| `normalizeScheduleWindowToUtc({ start, end })` | Normalize a full authored window (each endpoint either an already-UTC `Date` or a `{ wallClock, timeZone }` pair) to `{ startDate, endDate }` UTC `Date`s. Throws if the normalized end is not strictly after the normalized start. |
+| `renderInTimeZone(utcInstant, timeZone)` | Format a stored UTC instant for display in a target timezone. Returns the local ISO string, the timezone name, and the UTC offset (minutes) in effect at that instant. |
+| `startOfIsoWeekUtc(instant)` | Monday 00:00:00.000 UTC of the week containing `instant`. |
+| `endOfIsoWeekUtc(instant)` | Start of the *next* UTC week — the exclusive end of the current one. |
+| `isSameIsoWeekUtc(a, b)` | Whether two instants fall in the same UTC Monday–Sunday week. |
+
+## Authoring checklist
+
+- [ ] If the source material (governance proposal, protocol docs, campaign
+      brief) gives a wall-clock time in a specific timezone, capture the
+      IANA timezone name (e.g. `"America/New_York"`, not `"EST"` or a raw
+      UTC offset — fixed offsets don't account for DST) and pass both
+      through `wallClockToUtc` / `normalizeScheduleWindowToUtc` before
+      storing.
+- [ ] If the source material already gives a UTC or offset-qualified ISO
+      string (e.g. `"2026-05-04T04:00:00-04:00"`), `new Date(...)` already
+      parses it into the correct UTC instant — no additional conversion
+      needed.
+- [ ] Never persist a naive `"YYYY-MM-DD HH:mm"` string without an
+      accompanying timezone. It is ambiguous by construction and cannot be
+      normalized later without guessing.
+- [ ] When displaying a stored window to a user, call `renderInTimeZone`
+      with their timezone at render time — don't precompute and cache a
+      "local" string, since a cached string silently goes stale if the
+      viewer's timezone or the display requirements change.
+- [ ] When reasoning about "this week's" campaign, use the UTC ISO week
+      helpers, not `Date#getDay()` / `Date#getDate()` (which report in the
+      host machine's local timezone and will disagree with a server running
+      in a different zone).
+
+## Known limits
+
+- Wall-clock times that fall inside a DST "spring forward" gap (a local time
+  that never occurs, e.g. 2:30 AM on a spring-forward date in a zone that
+  jumps from 2:00 to 3:00) are inherently ambiguous. `wallClockToUtc`
+  resolves them by the offset in effect at the initial UTC guess; treat any
+  schedule authored in that one-hour gap as needing manual confirmation.
+- `wallClockToUtc` / `renderInTimeZone` rely on the JavaScript runtime's
+  built-in ICU timezone database (`Intl`). Keep the Node.js version current
+  so IANA rule changes (e.g. a country changing its DST policy) are
+  reflected.


### PR DESCRIPTION
## Summary

- **#965 (backend/rewards — schedule timezone normalization)**: `scheduleHealth.ts` had no timezone handling at all, so reward schedule windows could drift when local timezones, UTC storage, and weekly campaign boundaries got mixed during authoring. Added `wallClockToUtc` / `renderInTimeZone` (DST-correct — they read the live IANA offset via `Intl` for the specific instant, rather than assuming a fixed offset for a zone), `normalizeScheduleWindowToUtc` for converting an authored window to storage-ready UTC `Date`s, and UTC ISO-week helpers (`startOfIsoWeekUtc` / `endOfIsoWeekUtc` / `isSameIsoWeekUtc`) so "which week does this belong to" is unambiguous regardless of where a schedule was authored. Documented the model and an authoring checklist in `docs/reward-schedule-authoring.md`.

- **#964 (backend/rewards + client/rewards — claim preview validation)**: `verifyProof` only checked cryptographic validity — nothing validated the campaign ID, proof shape, or root drift before a claim reached the chain. Added `previewRewardClaim` with typed errors (`campaign_id_mismatch`, `malformed_proof`, `root_mismatch`, `proof_verification_failed`) and `findProofShapeError` (rejects malformed hex, duplicate path elements, and over-depth proofs — a well-formed Merkle proof never repeats a sibling hash). Mirrored the structural checks client-side (`claimPreviewValidation.ts`) and wired them into `buildBatchClaimPreview`, adding a new `invalid_proof` vault status (campaign mismatch / malformed proof) distinct from the existing time-based `stale_proof`, with matching badges/warnings in `BatchClaimPreview.tsx`.

- **#962 (client/google_sheets — dry-run sync)**: there was no way to preview what a sheet sync would change before writing rows. Added `dryRunSync.ts` (`computeDryRunSyncPlan`), which keys rows by wallet + vault + asset + day and classifies each incoming metric as added, updated, skipped, or conflicted — a real value disagreement against a non-placeholder existing row is flagged as a conflict rather than silently overwritten, and within-batch duplicate keys are also flagged rather than resolved by last-write-wins. Added `GoogleSheetsService.previewSync` (reads current rows via a new `/api/google-sheets/rows` call) and a "Preview Sync" summary section in `GoogleSheetsPanel.tsx` showing the added/updated/skipped/conflicted counts before any commit.

- **#963 (client/offramp — resume validation)**: `OffRampPanel` silently auto-resumed the most recently created pending withdrawal on every mount, with no check on quote expiry or wallet identity, and the *full* raw bank account number was persisted to `localStorage` indefinitely via the transaction's `request` field. Now only non-sensitive `resumeMetadata` (masked account number, bank name, account holder, wallet) is persisted; the raw request lives in an in-memory-only `Map` on the service instance, so retry only works within the same session — after a real reload, `retryTransaction` throws and the caller falls back to a restart flow instead of resubmitting stale/incomplete data. Added `validateResumedTransaction` / `findResumableTransaction` to gate auto-resume on quote expiry, complete resume metadata, and a matching wallet address, plus a restart-flow banner in the panel when resume is blocked, explaining why.

## Notes

- While rewriting `OffRampRetryResume.test.ts` for #963 I found (and fixed) a pre-existing bug: `isRetryable` was only ever set on a retry/poll failure, never on a transaction's *first* failed submission — leaving 2 of that file's 5 tests failing on `main` today. Verified via `git stash` against the base commit.
- `backend/rewards` isn't wired into `.github/workflows/ci.yml` on `main` as of this branch's base commit, so its test suite doesn't run in CI yet — verified by running it locally (`npx jest` — 109 passed) and via `npx tsc --noEmit` (clean).

## Test plan

- [x] `cd backend/rewards && npx jest` — 109 passed
- [x] `cd client && npx vitest run src/features/rewards src/features/google_sheets src/features/offramp` — 143 passed
- [x] `cd client && npx tsc -b` — clean for all touched files (pre-existing, unrelated errors elsewhere in `zap`/`soroban.ts` confirmed via `git stash` against the base commit)

Closes #965
Closes #964
Closes #962
Closes #963