### PR TITLE
 Add deterministic token vesting schedule normalization tests

### DIFF
--- a/client/src/components/charts/CorrelationHeatmap.tsx
+++ b/client/src/components/charts/CorrelationHeatmap.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 
 interface CorrelationMatrix {
@@ -36,40 +37,81 @@ export default function CorrelationHeatmap() {
   const [data, setData] = useState<CorrelationMatrix | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
 
-  useEffect(() => {
-    async function loadData() {
-      try {
-        setLoading(true);
-        const response = await fetch(apiUrl("/api/correlation?window=30"));
-        if (!response.ok) {
-          throw new Error("Unable to fetch correlation data");
-        }
-        const json = await response.json() as CorrelationMatrix;
-        setData(json);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Error fetching correlation data");
-      } finally {
-        setLoading(false);
-      }
+  const loadData = async (showLoader = true) => {
+    if (showLoader) {
+      setLoading(true);
     }
 
-    loadData();
+    try {
+      setError(null);
+      const response = await fetch(apiUrl("/api/correlation?window=30"));
+      if (!response.ok) {
+        throw new Error("Unable to fetch correlation data");
+      }
+      const json = (await response.json()) as CorrelationMatrix;
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error fetching correlation data");
+    } finally {
+      setLoading(false);
+      setRetrying(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadData();
   }, []);
+
+  const isEmpty = !!data && (data.items.length === 0 || data.matrix.length === 0);
 
   if (loading) {
     return (
-      <div className="glass-card mt-8 p-6 animate-pulse">
-        <div className="h-6 w-1/3 bg-gray-700/50 rounded mb-6"></div>
-        <div className="h-[300px] bg-slate-800/30 rounded-xl"></div>
+      <div className="glass-card mt-8 p-6">
+        <div className="mb-6 h-6 w-1/3 animate-pulse rounded bg-gray-700/50"></div>
+        <div className="h-[260px] w-full rounded-lg border border-white/10 bg-white/[0.02] p-5 sm:h-[300px]">
+          <p className="mb-3 text-sm text-gray-400" role="status">
+            Loading correlation data...
+          </p>
+          <div className="h-full w-full animate-pulse rounded-lg bg-gradient-to-r from-gray-700/30 via-gray-600/30 to-gray-700/30" />
+        </div>
       </div>
     );
   }
 
-  if (error || !data) {
+  if (error) {
     return (
-      <div className="glass-card mt-8 p-6 text-center text-red-400">
-        <p>{error || "Failed to load"}</p>
+      <div className="glass-card mt-8 p-6">
+        <div className="flex h-[260px] w-full flex-col items-center justify-center rounded-lg border border-red-500/30 bg-red-500/10 px-6 py-8 text-center sm:h-[300px]">
+          <AlertTriangle size={24} className="mb-3 text-red-300" />
+          <p className="font-semibold text-red-100">Unable to load correlation data</p>
+          <p className="mt-1 max-w-sm text-sm text-red-200/90">{error}</p>
+          <button
+            type="button"
+            onClick={() => {
+              setRetrying(true);
+              void loadData(false);
+            }}
+            className="btn-secondary mt-4 inline-flex items-center gap-2"
+          >
+            <RefreshCw size={14} className={retrying ? "animate-spin" : ""} />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || isEmpty) {
+    return (
+      <div className="glass-card mt-8 p-6">
+        <div className="flex h-[260px] w-full flex-col items-center justify-center rounded-lg border border-white/10 bg-white/[0.02] px-6 py-8 text-center sm:h-[300px]">
+          <p className="font-semibold text-gray-300">No correlation data available</p>
+          <p className="mt-1 text-sm text-gray-500">
+            There isn&apos;t enough position history yet to compute asset correlations.
+          </p>
+        </div>
       </div>
     );
   }

--- a/client/src/components/charts_v2/CorrelationHeatmap.tsx
+++ b/client/src/components/charts_v2/CorrelationHeatmap.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { AlertTriangle, RefreshCw } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 
 interface CorrelationMatrix {
@@ -36,40 +37,81 @@ export default function CorrelationHeatmap() {
   const [data, setData] = useState<CorrelationMatrix | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [retrying, setRetrying] = useState(false);
 
-  useEffect(() => {
-    async function loadData() {
-      try {
-        setLoading(true);
-        const response = await fetch(apiUrl("/api/correlation?window=30"));
-        if (!response.ok) {
-          throw new Error("Unable to fetch correlation data");
-        }
-        const json = await response.json() as CorrelationMatrix;
-        setData(json);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Error fetching correlation data");
-      } finally {
-        setLoading(false);
-      }
+  const loadData = async (showLoader = true) => {
+    if (showLoader) {
+      setLoading(true);
     }
 
-    loadData();
+    try {
+      setError(null);
+      const response = await fetch(apiUrl("/api/correlation?window=30"));
+      if (!response.ok) {
+        throw new Error("Unable to fetch correlation data");
+      }
+      const json = (await response.json()) as CorrelationMatrix;
+      setData(json);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Error fetching correlation data");
+    } finally {
+      setLoading(false);
+      setRetrying(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadData();
   }, []);
+
+  const isEmpty = !!data && (data.items.length === 0 || data.matrix.length === 0);
 
   if (loading) {
     return (
-      <div className="glass-card mt-8 p-6 animate-pulse">
-        <div className="h-6 w-1/3 bg-gray-700/50 rounded mb-6"></div>
-        <div className="h-[300px] bg-slate-800/30 rounded-xl"></div>
+      <div className="glass-card mt-8 p-6">
+        <div className="mb-6 h-6 w-1/3 animate-pulse rounded bg-gray-700/50"></div>
+        <div className="h-[260px] w-full rounded-lg border border-white/10 bg-white/[0.02] p-5 sm:h-[300px]">
+          <p className="mb-3 text-sm text-gray-400" role="status">
+            Loading correlation data...
+          </p>
+          <div className="h-full w-full animate-pulse rounded-lg bg-gradient-to-r from-gray-700/30 via-gray-600/30 to-gray-700/30" />
+        </div>
       </div>
     );
   }
 
-  if (error || !data) {
+  if (error) {
     return (
-      <div className="glass-card mt-8 p-6 text-center text-red-400">
-        <p>{error || "Failed to load"}</p>
+      <div className="glass-card mt-8 p-6">
+        <div className="flex h-[260px] w-full flex-col items-center justify-center rounded-lg border border-red-500/30 bg-red-500/10 px-6 py-8 text-center sm:h-[300px]">
+          <AlertTriangle size={24} className="mb-3 text-red-300" />
+          <p className="font-semibold text-red-100">Unable to load correlation data</p>
+          <p className="mt-1 max-w-sm text-sm text-red-200/90">{error}</p>
+          <button
+            type="button"
+            onClick={() => {
+              setRetrying(true);
+              void loadData(false);
+            }}
+            className="btn-secondary mt-4 inline-flex items-center gap-2"
+          >
+            <RefreshCw size={14} className={retrying ? "animate-spin" : ""} />
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!data || isEmpty) {
+    return (
+      <div className="glass-card mt-8 p-6">
+        <div className="flex h-[260px] w-full flex-col items-center justify-center rounded-lg border border-white/10 bg-white/[0.02] px-6 py-8 text-center sm:h-[300px]">
+          <p className="font-semibold text-gray-300">No correlation data available</p>
+          <p className="mt-1 text-sm text-gray-500">
+            There isn&apos;t enough position history yet to compute asset correlations.
+          </p>
+        </div>
       </div>
     );
   }

--- a/client/src/pages/vesting/vestingService.test.ts
+++ b/client/src/pages/vesting/vestingService.test.ts
@@ -15,7 +15,9 @@ import {
     claimedPercent,
     fetchVestingSchedule,
     claimVested,
+    normalizeVestingSchedule,
     type VestingSchedule,
+    type RawVestingScheduleFields,
 } from "./vestingService";
 
 // ── formatTokens ─────────────────────────────────────────────────────────
@@ -140,5 +142,144 @@ describe("claimVested (no contract configured)", () => {
     it("error message mentions the contract is not configured", async () => {
         const result = await claimVested("GADDRTEST0000000000000000000000000000000");
         expect(result.error).toMatch(/not configured/i);
+    });
+});
+
+// ── normalizeVestingSchedule ───────────────────────────────────────────────
+//
+// Deterministic normalization: the same raw input must always produce the
+// same output, regardless of field encoding (bigint/number/string) or
+// malformed/out-of-order data returned by the contract.
+
+describe("normalizeVestingSchedule", () => {
+    const wellFormed: RawVestingScheduleFields = {
+        total_allocation: 1_000n,
+        vested_amount: 400n,
+        claimed_amount: 150n,
+        cliff_timestamp: 1_000_000n,
+        end_timestamp: 2_000_000n,
+        next_unlock_timestamp: 1_500_000n,
+        start_timestamp: 500_000n,
+    };
+
+    it("normalizes well-formed bigint fields", () => {
+        expect(normalizeVestingSchedule(wellFormed)).toEqual<VestingSchedule>({
+            totalAllocation: 1_000n,
+            vestedAmount: 400n,
+            claimedAmount: 150n,
+            claimableAmount: 250n,
+            cliffTimestamp: 1_000_000,
+            endTimestamp: 2_000_000,
+            nextUnlockTimestamp: 1_500_000,
+            startTimestamp: 500_000,
+        });
+    });
+
+    it("is deterministic across repeated calls with the same input", () => {
+        const first = normalizeVestingSchedule(wellFormed);
+        const second = normalizeVestingSchedule(wellFormed);
+        expect(second).toEqual(first);
+    });
+
+    it("accepts string-encoded amounts and timestamps", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: "1000",
+            vested_amount: "400",
+            claimed_amount: "150",
+            cliff_timestamp: "1000000",
+            end_timestamp: "2000000",
+            next_unlock_timestamp: "1500000",
+            start_timestamp: "500000",
+        };
+        expect(normalizeVestingSchedule(raw)).toEqual(normalizeVestingSchedule(wellFormed));
+    });
+
+    it("accepts number-encoded amounts and timestamps", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: 1000,
+            vested_amount: 400,
+            claimed_amount: 150,
+            cliff_timestamp: 1_000_000,
+            end_timestamp: 2_000_000,
+            next_unlock_timestamp: 1_500_000,
+            start_timestamp: 500_000,
+        };
+        expect(normalizeVestingSchedule(raw)).toEqual(normalizeVestingSchedule(wellFormed));
+    });
+
+    it("defaults missing fields to zero", () => {
+        expect(normalizeVestingSchedule({})).toEqual<VestingSchedule>({
+            totalAllocation: 0n,
+            vestedAmount: 0n,
+            claimedAmount: 0n,
+            claimableAmount: 0n,
+            cliffTimestamp: 0,
+            endTimestamp: 0,
+            nextUnlockTimestamp: 0,
+            startTimestamp: 0,
+        });
+    });
+
+    it("clamps negative amounts to zero", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: -1_000n,
+            vested_amount: -400n,
+            claimed_amount: -150n,
+        };
+        const result = normalizeVestingSchedule(raw);
+        expect(result.totalAllocation).toBe(0n);
+        expect(result.vestedAmount).toBe(0n);
+        expect(result.claimedAmount).toBe(0n);
+        expect(result.claimableAmount).toBe(0n);
+    });
+
+    it("clamps vestedAmount so it never exceeds totalAllocation", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: 100n,
+            vested_amount: 500n,
+            claimed_amount: 0n,
+        };
+        const result = normalizeVestingSchedule(raw);
+        expect(result.vestedAmount).toBe(100n);
+        expect(result.claimableAmount).toBe(100n);
+    });
+
+    it("clamps claimedAmount so it never exceeds vestedAmount", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: 1_000n,
+            vested_amount: 200n,
+            claimed_amount: 900n,
+        };
+        const result = normalizeVestingSchedule(raw);
+        expect(result.claimedAmount).toBe(200n);
+        expect(result.claimableAmount).toBe(0n);
+    });
+
+    it("floors claimableAmount at zero when claimed exceeds vested pre-clamp", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: 1_000n,
+            vested_amount: 300n,
+            claimed_amount: 300n,
+        };
+        expect(normalizeVestingSchedule(raw).claimableAmount).toBe(0n);
+    });
+
+    it("falls back to zero for non-numeric garbage strings", () => {
+        const raw: RawVestingScheduleFields = {
+            total_allocation: "not-a-number",
+            vested_amount: "NaN",
+            cliff_timestamp: "not-a-timestamp",
+        };
+        const result = normalizeVestingSchedule(raw);
+        expect(result.totalAllocation).toBe(0n);
+        expect(result.vestedAmount).toBe(0n);
+        expect(result.cliffTimestamp).toBe(0);
+    });
+
+    it("truncates fractional timestamp values", () => {
+        const raw: RawVestingScheduleFields = {
+            cliff_timestamp: 1_000_000.9,
+        };
+        expect(normalizeVestingSchedule(raw).cliffTimestamp).toBe(1_000_000);
     });
 });

--- a/client/src/pages/vesting/vestingService.ts
+++ b/client/src/pages/vesting/vestingService.ts
@@ -31,6 +31,94 @@ export interface VestingSchedule {
     startTimestamp: number;
 }
 
+/** Raw vesting schedule fields as returned by `scValToNative` for the contract's read call. */
+export interface RawVestingScheduleFields {
+    total_allocation?: unknown;
+    vested_amount?: unknown;
+    claimed_amount?: unknown;
+    cliff_timestamp?: unknown;
+    end_timestamp?: unknown;
+    next_unlock_timestamp?: unknown;
+    start_timestamp?: unknown;
+}
+
+/** Coerces a raw amount field to a non-negative bigint, defaulting to 0n. */
+function toNonNegativeBigInt(value: unknown): bigint {
+    try {
+        if (typeof value === "bigint") {
+            return value < 0n ? 0n : value;
+        }
+        if (typeof value === "number" && Number.isFinite(value)) {
+            const truncated = BigInt(Math.trunc(value));
+            return truncated < 0n ? 0n : truncated;
+        }
+        if (typeof value === "string" && value.trim() !== "") {
+            const parsed = BigInt(value.trim());
+            return parsed < 0n ? 0n : parsed;
+        }
+    } catch {
+        // Fall through to the default below on any parse failure.
+    }
+    return 0n;
+}
+
+/** Coerces a raw timestamp field to a whole-second Unix timestamp, defaulting to 0. */
+function toTimestamp(value: unknown): number {
+    if (typeof value === "bigint") {
+        return Number(value);
+    }
+    if (typeof value === "number" && Number.isFinite(value)) {
+        return Math.trunc(value);
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+        const parsed = Number(value.trim());
+        if (Number.isFinite(parsed)) {
+            return Math.trunc(parsed);
+        }
+    }
+    return 0;
+}
+
+/**
+ * Normalizes raw on-chain vesting schedule fields into a well-formed,
+ * internally-consistent `VestingSchedule`.
+ *
+ * Deterministic and pure: the same input always produces the same output,
+ * independent of wall-clock time or external state. Defensively clamps
+ * amounts so callers never see impossible states even if the contract
+ * returns malformed or out-of-order data:
+ *   - negative amounts clamp to 0
+ *   - `vestedAmount` never exceeds `totalAllocation`
+ *   - `claimedAmount` never exceeds `vestedAmount`
+ *   - `claimableAmount` is derived as `vestedAmount - claimedAmount`, floored at 0
+ */
+export function normalizeVestingSchedule(raw: RawVestingScheduleFields): VestingSchedule {
+    const totalAllocation = toNonNegativeBigInt(raw.total_allocation);
+
+    let vestedAmount = toNonNegativeBigInt(raw.vested_amount);
+    if (vestedAmount > totalAllocation) {
+        vestedAmount = totalAllocation;
+    }
+
+    let claimedAmount = toNonNegativeBigInt(raw.claimed_amount);
+    if (claimedAmount > vestedAmount) {
+        claimedAmount = vestedAmount;
+    }
+
+    const claimableAmount = vestedAmount - claimedAmount > 0n ? vestedAmount - claimedAmount : 0n;
+
+    return {
+        totalAllocation,
+        vestedAmount,
+        claimedAmount,
+        claimableAmount,
+        cliffTimestamp: toTimestamp(raw.cliff_timestamp),
+        endTimestamp: toTimestamp(raw.end_timestamp),
+        nextUnlockTimestamp: toTimestamp(raw.next_unlock_timestamp),
+        startTimestamp: toTimestamp(raw.start_timestamp),
+    };
+}
+
 /**
  * Fetches the vesting schedule for the given wallet address from the
  * on-chain contract via a read-only simulation.
@@ -76,31 +164,9 @@ export async function fetchVestingSchedule(
             return null;
         }
 
-        const val = StellarSdk.scValToNative(result.result.retval) as {
-            total_allocation: bigint;
-            vested_amount: bigint;
-            claimed_amount: bigint;
-            cliff_timestamp: bigint;
-            end_timestamp: bigint;
-            next_unlock_timestamp: bigint;
-            start_timestamp: bigint;
-        };
+        const val = StellarSdk.scValToNative(result.result.retval) as RawVestingScheduleFields;
 
-        const claimable =
-            val.vested_amount - val.claimed_amount > 0n
-                ? val.vested_amount - val.claimed_amount
-                : 0n;
-
-        return {
-            totalAllocation: val.total_allocation,
-            vestedAmount: val.vested_amount,
-            claimedAmount: val.claimed_amount,
-            claimableAmount: claimable,
-            cliffTimestamp: Number(val.cliff_timestamp),
-            endTimestamp: Number(val.end_timestamp),
-            nextUnlockTimestamp: Number(val.next_unlock_timestamp),
-            startTimestamp: Number(val.start_timestamp),
-        };
+        return normalizeVestingSchedule(val);
     } catch {
         // Gracefully return null — do not expose stack traces to users.
         return null;

--- a/packages/sdk/src/contractRegistry.ts
+++ b/packages/sdk/src/contractRegistry.ts
@@ -1,0 +1,149 @@
+/**
+ * SDK contract registry loader.
+ *
+ * Resolves Soroban contract IDs for a target network from a registry object
+ * (typically the parsed contents of `contracts/registry.json`), with
+ * explicit overrides taking priority over registry values.
+ *
+ * Unlike the client/server registries, this loader also applies a
+ * network-specific fallback chain: some networks (e.g. `local`) rarely have
+ * their own deployed contracts, so a missing entry there can fall back to a
+ * neighboring network's address for developer convenience. `testnet` and
+ * `mainnet` never fall back into each other — silently resolving a mainnet
+ * contract call against a testnet address (or vice versa) is a correctness
+ * and safety hazard, not a convenience.
+ */
+
+export type ContractName =
+  | "vault"
+  | "zap"
+  | "token"
+  | "governance"
+  | "strategy"
+  | "emissionController"
+  | "liquidStaking"
+  | "stableswap"
+  | "vesting";
+
+export type NetworkName = "testnet" | "mainnet" | "local";
+
+export type ContractRegistry = Record<NetworkName, Partial<Record<ContractName, string>>>;
+
+export const CONTRACT_NAMES: ContractName[] = [
+  "vault",
+  "zap",
+  "token",
+  "governance",
+  "strategy",
+  "emissionController",
+  "liquidStaking",
+  "stableswap",
+  "vesting",
+];
+
+/**
+ * Per-network fallback order, consulted in sequence when the requested
+ * network has no entry for a given contract. Deliberately does not include
+ * `testnet`/`mainnet` as fallbacks for one another.
+ */
+export const NETWORK_FALLBACK_ORDER: Record<NetworkName, NetworkName[]> = {
+  mainnet: [],
+  testnet: [],
+  local: ["testnet"],
+};
+
+export interface ResolvedContractId {
+  /** The resolved contract ID, or "" if none could be found. */
+  contractId: string;
+  /** The network that was originally requested. */
+  requestedNetwork: NetworkName;
+  /** Where the value actually came from: an override, a network, or nothing. */
+  resolvedFrom: NetworkName | "override" | "none";
+  /** True when the value came from a fallback network rather than the requested one. */
+  usedFallback: boolean;
+}
+
+export class ContractRegistryLoader {
+  constructor(
+    private readonly registry: ContractRegistry,
+    private readonly overrides: Partial<Record<ContractName, string | undefined>> = {},
+  ) {}
+
+  /**
+   * Resolves a single contract's ID for the given network, applying
+   * overrides first and the network fallback chain second.
+   */
+  resolve(name: ContractName, network: NetworkName): ResolvedContractId {
+    const override = this.overrides[name];
+    if (override && override.trim() !== "") {
+      return {
+        contractId: override,
+        requestedNetwork: network,
+        resolvedFrom: "override",
+        usedFallback: false,
+      };
+    }
+
+    const direct = this.registry[network]?.[name];
+    if (direct && direct.trim() !== "") {
+      return {
+        contractId: direct,
+        requestedNetwork: network,
+        resolvedFrom: network,
+        usedFallback: false,
+      };
+    }
+
+    for (const fallbackNetwork of NETWORK_FALLBACK_ORDER[network]) {
+      const fallbackId = this.registry[fallbackNetwork]?.[name];
+      if (fallbackId && fallbackId.trim() !== "") {
+        return {
+          contractId: fallbackId,
+          requestedNetwork: network,
+          resolvedFrom: fallbackNetwork,
+          usedFallback: true,
+        };
+      }
+    }
+
+    return {
+      contractId: "",
+      requestedNetwork: network,
+      resolvedFrom: "none",
+      usedFallback: false,
+    };
+  }
+
+  /** Resolves every known contract name for the given network. */
+  resolveAll(network: NetworkName): Record<ContractName, ResolvedContractId> {
+    return Object.fromEntries(
+      CONTRACT_NAMES.map((name) => [name, this.resolve(name, network)]),
+    ) as Record<ContractName, ResolvedContractId>;
+  }
+
+  /**
+   * Resolves a contract ID or throws a descriptive error, listing the
+   * fallback networks that were attempted, when nothing could be found.
+   */
+  requireContractId(name: ContractName, network: NetworkName): string {
+    const resolved = this.resolve(name, network);
+    if (!resolved.contractId) {
+      const fallbackChain = NETWORK_FALLBACK_ORDER[network];
+      const attempted = [network, ...fallbackChain].join(" -> ");
+      throw new Error(
+        `Missing contract ID for "${name}" on network "${network}". ` +
+          `Attempted lookup chain: ${attempted}. ` +
+          `Provide an override or populate contracts/registry.json.`,
+      );
+    }
+    return resolved.contractId;
+  }
+}
+
+/** Convenience factory mirroring the constructor, for call-site readability. */
+export function createContractRegistryLoader(
+  registry: ContractRegistry,
+  overrides: Partial<Record<ContractName, string | undefined>> = {},
+): ContractRegistryLoader {
+  return new ContractRegistryLoader(registry, overrides);
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -4,4 +4,5 @@ export * from "./types";
 export * from "./lifecycle";
 export * from "./signers";
 export * from "./errors";
+export * from "./contractRegistry";
 export * from "./generated/yield_vault";


### PR DESCRIPTION


1. Responsive empty/error states for portfolio analytics charts — CorrelationHeatmap.tsx (both charts/ and the duplicate charts_v2/) now has distinct, responsive loading/error/empty states matching the pattern already used by ApyHistoryChart and SharePriceChart (retry button, role="status", skeleton, sm: breakpoints), instead of the old single collapsed error || !data branch.
2. SDK contract registry loader with network-specific fallback — new packages/sdk/src/contractRegistry.ts, exported from index.ts. ContractRegistryLoader.resolve() applies overrides → direct network lookup → a NETWORK_FALLBACK_ORDER chain (only local → testnet; testnet/mainnet never fall back into each other, since that would be unsafe).
3. Deterministic vesting schedule normalization tests — extracted the inline raw→VestingSchedule conversion in vestingService.ts into a pure normalizeVestingSchedule() (handles bigint/number/string fields, clamps negatives, clamps vested ≤ total and claimed ≤ vested), wired it back into fetchVestingSchedule, and added a deterministic test suite covering encoding variants, missing fields, clamping, and garbage input.


closes #954
closes #956
closes #961
closes #957