### PR TITLE
added zap routes

### DIFF
--- a/client/src/features/zap/ZapDepositPanel.tsx
+++ b/client/src/features/zap/ZapDepositPanel.tsx
@@ -6,7 +6,7 @@ import { decodeTransactionError } from "../../utils/errorDecoder";
 import { zapDeposit } from "../../services/soroban";
 import type { TxPhase } from "../../services/transactionPhase";
 import { TX_PHASE_PIPELINE } from "../../services/transactionPhase";
-import { fetchSwapQuote } from "./fetchSwapQuote";
+import { fetchSwapQuote, verifySwapQuote } from "./fetchSwapQuote";
 import { minAmountAfterSlippage } from "./slippage";
 import { parseDecimalToStroops, formatStroopsToDecimal } from "./amount";
 import {
@@ -236,6 +236,14 @@ export default function ZapDepositPanel({ walletAddress }: ZapDepositPanelProps)
     setError("");
     setShowFailedModal(false);
     try {
+      if (quoteData) {
+        const isValid = await verifySwapQuote(quoteData);
+        if (!isValid) {
+          setError('Quote validation failed. Please refresh and try again.');
+          setShowFailedModal(true);
+          return;
+        }
+      }
       const result = await zapDeposit(
         walletAddress,
         {

--- a/client/src/features/zap/fetchSwapQuote.ts
+++ b/client/src/features/zap/fetchSwapQuote.ts
@@ -22,3 +22,16 @@ export async function fetchSwapQuote(
 
   return res.json() as Promise<ZapQuoteResponse>;
 }
+export async function verifySwapQuote(quote: ZapQuoteResponse): Promise<boolean> {
+  const res = await fetch(apiUrl("/api/zap/verify"), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(quote),
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error(txt || `Quote verification failed (${res.status})`);
+  }
+  const data = await res.json();
+  return data.success === true;
+}

--- a/client/src/features/zap/types.ts
+++ b/client/src/features/zap/types.ts
@@ -26,6 +26,10 @@ export interface ZapQuoteResponse {
   minAmountOutStroops: string;
   quoteAgeMs: number;
   isFallback: boolean;
+  issuedAt: string;
+  expiresAt: string;
+  routeHash: string;
+  assetConfigVersion: number;
 }
 
 /** Asset the user can select as zap input (Soroban SAC contract id). */

--- a/server/src/routes/zap.ts
+++ b/server/src/routes/zap.ts
@@ -1,6 +1,6 @@
 import { Router, Request, Response } from "express";
 import { getZapSupportedAssetsPayload } from "../config/zapAssetsConfig";
-import { getZapQuote, type ZapQuoteBody } from "../services/zapQuote";
+import { getZapQuote, verifyZapQuote, type ZapQuoteBody } from "../services/zapQuote";
 import { sendError } from "../utils/errorResponse";
 import { validateZapQuote } from "../middleware/validation";
 
@@ -44,6 +44,10 @@ router.post("/quote", validateZapQuote, async (req: Request, res: Response) => {
       minAmountOutStroops: quote.minAmountOutStroops,
       quoteAgeMs: quote.quoteAgeMs,
       isFallback: quote.isFallback,
+      issuedAt: quote.issuedAt,
+      expiresAt: quote.expiresAt,
+      routeHash: quote.routeHash,
+      assetConfigVersion: quote.assetConfigVersion,
     });
   } catch (e) {
     sendError(
@@ -51,6 +55,29 @@ router.post("/quote", validateZapQuote, async (req: Request, res: Response) => {
       500,
       "QUOTE_FAILED",
       "Quote failed",
+      e instanceof Error ? e.message : undefined
+    );
+  }
+});
+
+router.post("/verify", (req: Request, res: Response) => {
+  try {
+    const result = verifyZapQuote(req.body);
+    if (!result.valid) {
+      return sendError(
+        res,
+        400,
+        result.errorCode || "INVALID_QUOTE",
+        result.reason || "Invalid quote",
+      );
+    }
+    res.json({ success: true });
+  } catch (e) {
+    sendError(
+      res,
+      500,
+      "VERIFY_FAILED",
+      "Failed to verify quote",
       e instanceof Error ? e.message : undefined
     );
   }

--- a/server/src/services/zapQuote.ts
+++ b/server/src/services/zapQuote.ts
@@ -1,7 +1,9 @@
 import * as StellarSdk from "@stellar/stellar-sdk";
+import crypto from "crypto";
 import { slippageRegistry } from "./slippageRegistry";
 import { getYieldData } from "./yieldService";
 import { freezeService } from "./freezeService";
+import { getZapSupportedAssetsPayload } from "../config/zapAssetsConfig";
 
 export interface ZapQuoteBody {
   inputTokenContract: string;
@@ -23,6 +25,10 @@ export interface ZapQuoteResult {
   minAmountOutStroops: string;
   quoteAgeMs: number;
   isFallback: boolean;
+  issuedAt: string;
+  expiresAt: string;
+  routeHash: string;
+  assetConfigVersion: string;
 }
 
 const rpcUrl = process.env.SOROBAN_RPC_URL ?? "https://soroban-testnet.stellar.org";
@@ -37,9 +43,20 @@ function mulDivStroops(amountIn: string, numerator: string, denominator: string)
   return ((a * n) / d).toString();
 }
 
+export function getAssetConfigVersion(): string {
+  const payload = getZapSupportedAssetsPayload();
+  const data = JSON.stringify(payload);
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+export function computeRouteHash(path: { contractId: string }[]): string {
+  const ids = path.map(p => p.contractId).join("->");
+  return crypto.createHash("sha256").update(ids).digest("hex");
+}
+
 export async function quoteViaRouterSimulation(
   body: ZapQuoteBody,
-): Promise<ZapQuoteResult | null> {
+): Promise<Omit<ZapQuoteResult, "issuedAt" | "expiresAt" | "routeHash" | "assetConfigVersion"> | null> {
   const routerId = process.env.DEX_ROUTER_CONTRACT_ID;
   const simSource = process.env.ZAP_QUOTE_SIM_SOURCE_ACCOUNT;
   if (!routerId || !simSource) {
@@ -113,7 +130,7 @@ export async function quoteViaRouterSimulation(
   }
 }
 
-export function quoteFallback(body: ZapQuoteBody): ZapQuoteResult {
+export function quoteFallback(body: ZapQuoteBody): Omit<ZapQuoteResult, "issuedAt" | "expiresAt" | "routeHash" | "assetConfigVersion"> {
   const amountIn = body.amountInStroops;
   const now = Date.now();
 
@@ -183,6 +200,11 @@ export async function getZapQuote(body: ZapQuoteBody): Promise<ZapQuoteResult> {
   const now = Date.now();
   const quotedAtMs = new Date(quotedAt).getTime();
 
+  const routeHash = computeRouteHash(sim.path);
+  const assetConfigVersion = getAssetConfigVersion();
+  const issuedAt = quotedAt;
+  const expiresAt = new Date(quotedAtMs + 60 * 1000).toISOString();
+
   return {
     ...sim,
     slippageApplied: effectiveSlippage,
@@ -191,5 +213,42 @@ export async function getZapQuote(body: ZapQuoteBody): Promise<ZapQuoteResult> {
     quotedAt,
     quoteAgeMs: now - quotedAtMs,
     isFallback: sim.source === "fallback_rate",
+    issuedAt,
+    expiresAt,
+    routeHash,
+    assetConfigVersion,
   };
+}
+
+export function verifyZapQuote(quote: any): { valid: boolean; reason?: string; errorCode?: string } {
+  const now = Date.now();
+  if (!quote || typeof quote !== "object") {
+    return { valid: false, reason: "Invalid quote format", errorCode: "INVALID_QUOTE" };
+  }
+  if (!quote.expiresAt || new Date(quote.expiresAt).getTime() < now) {
+    return { valid: false, reason: "Quote has expired", errorCode: "STALE_QUOTE" };
+  }
+  const currentVersion = getAssetConfigVersion();
+  if (quote.assetConfigVersion !== currentVersion) {
+    return { valid: false, reason: "Asset configuration has drifted", errorCode: "CONFIG_DRIFT" };
+  }
+  if (!quote.path || !Array.isArray(quote.path)) {
+    return { valid: false, reason: "Invalid path in quote", errorCode: "ROUTE_MISMATCH" };
+  }
+  const currentRouteHash = computeRouteHash(quote.path);
+  if (quote.routeHash !== currentRouteHash) {
+    return { valid: false, reason: "Route path mismatch", errorCode: "ROUTE_MISMATCH" };
+  }
+  // Check unsupported asset transitions
+  const payload = getZapSupportedAssetsPayload();
+  const supportedIds = new Set([
+    ...payload.assets.map(a => a.contractId),
+    payload.vaultToken.contractId
+  ]);
+  for (const hop of quote.path) {
+    if (!supportedIds.has(hop.contractId)) {
+      return { valid: false, reason: `Asset ${hop.contractId} is no longer supported`, errorCode: "ROUTE_MISMATCH" };
+    }
+  }
+  return { valid: true };
 }


### PR DESCRIPTION


Implemented the **Zap route safety** enhancements:

### Server
* Added `POST /api/zap/verify` endpoint with full quote validation logic.
* Extended quote JSON response in `/api/zap/quote` to include `issuedAt`, `expiresAt`, `routeHash`, and `assetConfigVersion`.

### Client
* Added `verifySwapQuote` helper in `fetchSwapQuote.ts` to call the new verification endpoint.
* Updated imports in `ZapDepositPanel.tsx` to include `verifySwapQuote`.
* Integrated quote verification into the `handleZap` flow – the transaction now aborts if the quote is invalid or stale.

### Types
* Extended `ZapQuoteResponse` in `types.ts` with the new metadata fields.

Closes #946
Closes #947
Closes #948
Closes #949