### PR TITLE
feat(#991): add route-level lazy-load error boundaries for heavy anal…

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -238,7 +238,7 @@ const router = createBrowserRouter([
       {
         path: "/apy",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="analytics">
             <ApyDashboard />
           </RouteBoundary>
         ),
@@ -310,7 +310,7 @@ const router = createBrowserRouter([
       {
         path: "/governance",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="governance">
             <GovernanceDashboard />
           </RouteBoundary>
         ),
@@ -374,7 +374,7 @@ const router = createBrowserRouter([
       {
         path: "/transparency",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="transparency">
             <TransparencyDashboard />
           </RouteBoundary>
         ),
@@ -382,7 +382,7 @@ const router = createBrowserRouter([
       {
         path: "/transparency/incidents",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="transparency">
             <RiskChronology />
           </RouteBoundary>
         ),
@@ -390,7 +390,7 @@ const router = createBrowserRouter([
       {
         path: "/transparency/relayer",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="transparency">
             <RelayerStatusPage />
           </RouteBoundary>
         ),
@@ -422,7 +422,7 @@ const router = createBrowserRouter([
       {
         path: "/treasury",
         element: (
-          <RouteBoundary>
+          <RouteBoundary routeName="treasury">
             <TreasurySimulation />
           </RouteBoundary>
         ),

--- a/client/src/components/common/RouteBoundary.test.tsx
+++ b/client/src/components/common/RouteBoundary.test.tsx
@@ -1,12 +1,83 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { RouteBoundary, RouteLoadingPanel } from "./RouteBoundary";
+import {
+  classifyRouteFailure,
+  logRouteFailure,
+} from "../../utils/diagnostics";
 
-function Boom() {
-  throw new Error("kaboom from child");
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function Boom({ message = "kaboom from child" }: { message?: string }) {
+  throw new Error(message);
 }
 
+function makeChunkLoadError(): Error {
+  const err = new Error("Loading chunk 42 failed.");
+  err.name = "ChunkLoadError";
+  return err;
+}
+
+// ─── diagnostics unit tests ──────────────────────────────────────────────────
+
+describe("classifyRouteFailure", () => {
+  it("returns 'chunk_load_error' for ChunkLoadError name", () => {
+    const err = makeChunkLoadError();
+    expect(classifyRouteFailure(err)).toBe("chunk_load_error");
+  });
+
+  it("returns 'chunk_load_error' for 'Loading chunk N failed' messages", () => {
+    const err = new Error("Loading chunk 99 failed.");
+    expect(classifyRouteFailure(err)).toBe("chunk_load_error");
+  });
+
+  it("returns 'chunk_load_error' for Vite dynamic import messages", () => {
+    const err = new Error("Failed to fetch dynamically imported module: /assets/foo.js");
+    expect(classifyRouteFailure(err)).toBe("chunk_load_error");
+  });
+
+  it("returns 'render_error' for a plain render error", () => {
+    expect(classifyRouteFailure(new Error("oops"))).toBe("render_error");
+  });
+
+  it("returns 'unknown' for non-Error values", () => {
+    expect(classifyRouteFailure("string error")).toBe("unknown");
+    expect(classifyRouteFailure(null)).toBe("unknown");
+    expect(classifyRouteFailure(42)).toBe("unknown");
+  });
+});
+
+describe("logRouteFailure", () => {
+  it("emits a structured console.error with routeName, failureType, and message", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const error = new Error("test");
+    logRouteFailure({ routeName: "analytics", failureType: "chunk_load_error", error });
+    expect(spy).toHaveBeenCalledWith(
+      "[diagnostics] route failure",
+      expect.objectContaining({
+        routeName: "analytics",
+        failureType: "chunk_load_error",
+        message: "test",
+      }),
+    );
+    spy.mockRestore();
+  });
+});
+
+// ─── RouteBoundary component tests ──────────────────────────────────────────
+
 describe("RouteBoundary", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Suppress expected console.error noise from error boundaries in tests.
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
   it("renders children when there is no error", () => {
     render(
       <RouteBoundary>
@@ -17,7 +88,6 @@ describe("RouteBoundary", () => {
   });
 
   it("shows the error panel with the real message and does not swallow it", () => {
-    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(
       <RouteBoundary>
         <Boom />
@@ -26,8 +96,79 @@ describe("RouteBoundary", () => {
     expect(screen.queryByRole("alert")).not.toBeNull();
     expect(screen.queryByText(/kaboom from child/)).not.toBeNull();
     // The real error was logged, not silently discarded.
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
+    expect(consoleSpy).toHaveBeenCalled();
+  });
+
+  it("logs the routeName and failureType through diagnostics on render error", () => {
+    render(
+      <RouteBoundary routeName="analytics">
+        <Boom message="render failed" />
+      </RouteBoundary>,
+    );
+    // diagnostics call includes routeName
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[diagnostics] route failure",
+      expect.objectContaining({ routeName: "analytics", failureType: "render_error" }),
+    );
+  });
+
+  it("shows 'render_error' failure type badge in the error panel", () => {
+    render(
+      <RouteBoundary routeName="governance">
+        <Boom />
+      </RouteBoundary>,
+    );
+    expect(screen.queryByText("render_error")).not.toBeNull();
+    expect(screen.queryByText(/governance/)).not.toBeNull();
+  });
+
+  it("offers 'Try again' button for render errors that clears the error on click", () => {
+    const { rerender } = render(
+      <RouteBoundary>
+        <Boom />
+      </RouteBoundary>,
+    );
+    const btn = screen.getByRole("button", { name: /try again/i });
+    expect(btn).not.toBeNull();
+    fireEvent.click(btn);
+    // After retry the error is cleared; re-render with safe content to confirm.
+    rerender(
+      <RouteBoundary>
+        <div>recovered</div>
+      </RouteBoundary>,
+    );
+    expect(screen.queryByText("recovered")).not.toBeNull();
+  });
+
+  it("shows 'Reload page' button for chunk-load errors", () => {
+    // Patch getDerivedStateFromError path by throwing an error whose name is ChunkLoadError.
+    function ChunkBoom() {
+      throw makeChunkLoadError();
+    }
+    render(
+      <RouteBoundary routeName="treasury">
+        <ChunkBoom />
+      </RouteBoundary>,
+    );
+    expect(screen.queryByRole("alert")).not.toBeNull();
+    expect(screen.queryByText(/Reload page/i)).not.toBeNull();
+    // failure type label should be chunk_load_error
+    expect(screen.queryByText("chunk_load_error")).not.toBeNull();
+  });
+
+  it("logs the routeName and failureType for chunk-load errors", () => {
+    function ChunkBoom() {
+      throw makeChunkLoadError();
+    }
+    render(
+      <RouteBoundary routeName="treasury">
+        <ChunkBoom />
+      </RouteBoundary>,
+    );
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[diagnostics] route failure",
+      expect.objectContaining({ routeName: "treasury", failureType: "chunk_load_error" }),
+    );
   });
 
   it("renders an accessible loading panel for the suspense fallback", () => {

--- a/client/src/components/common/RouteBoundary.tsx
+++ b/client/src/components/common/RouteBoundary.tsx
@@ -1,56 +1,122 @@
 import { Component, Suspense } from "react";
 import type { ErrorInfo, ReactNode } from "react";
+import {
+  classifyRouteFailure,
+  logRouteFailure,
+} from "../../utils/diagnostics";
+import type { RouteFailureType } from "../../utils/diagnostics";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
+  /** Human-readable route identifier used in diagnostic logs (e.g. "analytics", "treasury"). */
+  routeName?: string;
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
+  failureType: RouteFailureType | null;
+  /** Whether a chunk-load retry has already been attempted (avoids infinite loops). */
+  chunkRetryAttempted: boolean;
 }
 
 /**
  * Catches render/load errors from a route subtree and shows a fallback panel
  * that surfaces the real error — it never swallows errors silently.
+ *
+ * For chunk-load failures (dynamic-import / code-splitting) it offers a
+ * targeted retry that reloads the page so the browser can re-fetch the
+ * missing chunk.  Render errors get a standard in-place retry instead.
  */
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null };
+  state: ErrorBoundaryState = {
+    error: null,
+    failureType: null,
+    chunkRetryAttempted: false,
+  };
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
-    return { error };
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
+    return {
+      error,
+      failureType: classifyRouteFailure(error),
+    };
   }
 
   componentDidCatch(error: Error, info: ErrorInfo): void {
-    // Log the real error so monitoring/console still sees it.
+    const routeName = this.props.routeName ?? "unknown";
+    const failureType = classifyRouteFailure(error);
+
+    // Emit structured diagnostics so monitoring tools can index by route + type.
+    logRouteFailure({ routeName, failureType, error });
+
+    // Legacy console output so the component stack is still visible in DevTools.
     console.error("[RouteBoundary] render error:", error, info.componentStack);
   }
 
-  private handleRetry = () => this.setState({ error: null });
+  /** Re-try a render error without reloading the page. */
+  private handleRenderRetry = () => {
+    this.setState({ error: null, failureType: null, chunkRetryAttempted: false });
+  };
+
+  /**
+   * Re-try a chunk-load error by reloading the page.
+   *
+   * A hard reload forces the browser to re-fetch all chunk scripts so a
+   * transient CDN hiccup or stale cache entry doesn't block the user
+   * permanently.  We only do this once per mount to avoid reload loops.
+   */
+  private handleChunkRetry = () => {
+    if (this.state.chunkRetryAttempted) {
+      // Already tried a reload — fall back to clearing state so the user at
+      // least sees a fresh error panel rather than nothing.
+      this.setState({ error: null, failureType: null });
+      return;
+    }
+    this.setState({ chunkRetryAttempted: true }, () => {
+      window.location.reload();
+    });
+  };
 
   render(): ReactNode {
-    const { error } = this.state;
+    const { error, failureType } = this.state;
+
     if (error) {
+      const isChunkError = failureType === "chunk_load_error";
+
       return (
         <div
           role="alert"
+          aria-live="assertive"
           className="m-6 rounded-xl border border-red-500/30 bg-red-500/10 p-6 text-sm text-red-300"
         >
           <p className="font-semibold text-red-200">
-            Something went wrong loading this page.
+            {isChunkError
+              ? "Failed to load this page — the resource could not be fetched."
+              : "Something went wrong loading this page."}
           </p>
-          <p className="mt-1 break-words font-mono text-xs text-red-300/90">
+
+          {/* Failure type badge */}
+          <p className="mt-1 text-xs text-red-400/70">
+            <span className="font-mono">{failureType}</span>
+            {this.props.routeName && (
+              <> &middot; route: <span className="font-mono">{this.props.routeName}</span></>
+            )}
+          </p>
+
+          <p className="mt-2 break-words font-mono text-xs text-red-300/90">
             {error.message}
           </p>
+
           <button
             type="button"
-            onClick={this.handleRetry}
+            onClick={isChunkError ? this.handleChunkRetry : this.handleRenderRetry}
             className="mt-4 rounded-lg bg-red-500/20 px-3 py-1.5 text-red-100 transition-colors hover:bg-red-500/30"
           >
-            Try again
+            {isChunkError ? "Reload page" : "Try again"}
           </button>
         </div>
       );
     }
+
     return this.props.children;
   }
 }
@@ -69,14 +135,26 @@ export function RouteLoadingPanel() {
   );
 }
 
+export interface RouteBoundaryProps {
+  children: ReactNode;
+  /**
+   * Human-readable name for this route, forwarded to diagnostics on failure.
+   * Defaults to "unknown" when omitted.
+   * @example "analytics" | "treasury" | "governance" | "transparency"
+   */
+  routeName?: string;
+}
+
 /**
  * Route-level boundary: renders a loading panel while a lazy page loads, and an
  * error panel (surfacing the real error) if the page throws while loading or
  * rendering. Wrap analytics-heavy route elements with this.
+ *
+ * Pass `routeName` so diagnostics can identify which route failed.
  */
-export function RouteBoundary({ children }: { children: ReactNode }) {
+export function RouteBoundary({ children, routeName }: RouteBoundaryProps) {
   return (
-    <ErrorBoundary>
+    <ErrorBoundary routeName={routeName}>
       <Suspense fallback={<RouteLoadingPanel />}>{children}</Suspense>
     </ErrorBoundary>
   );

--- a/client/src/test-setup.ts
+++ b/client/src/test-setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+import { expect } from 'vitest';
+import * as matchers from '@testing-library/jest-dom/matchers';
+
+// Extend vitest's expect with jest-dom matchers so tests can use
+// expect(el).toBeInTheDocument(), .toHaveTextContent(), etc.
+expect.extend(matchers);

--- a/client/src/utils/diagnostics.ts
+++ b/client/src/utils/diagnostics.ts
@@ -1,0 +1,59 @@
+/**
+ * Diagnostics utility for route-level error reporting.
+ *
+ * Classifies failures into typed categories so monitoring systems and console
+ * output carry actionable context (route name + failure type).
+ */
+
+/** High-level failure categories that a route boundary can emit. */
+export type RouteFailureType =
+  | "chunk_load_error" // dynamic import / code-splitting chunk failed to fetch
+  | "render_error"     // component threw during React render
+  | "unknown";         // anything that doesn't match the above
+
+/**
+ * Infer the failure type from the raw error thrown by a lazy-loaded route.
+ *
+ * Vite and webpack both surface failed chunks as errors whose name or message
+ * contains "ChunkLoadError" or "Loading chunk" / "Loading CSS chunk".
+ */
+export function classifyRouteFailure(error: unknown): RouteFailureType {
+  if (!(error instanceof Error)) return "unknown";
+
+  const name = error.name ?? "";
+  const msg = error.message ?? "";
+
+  if (
+    name === "ChunkLoadError" ||
+    /loading chunk/i.test(msg) ||
+    /loading css chunk/i.test(msg) ||
+    /failed to fetch dynamically imported module/i.test(msg) ||
+    /dynamically imported module/i.test(msg)
+  ) {
+    return "chunk_load_error";
+  }
+
+  return "render_error";
+}
+
+export interface RouteErrorContext {
+  routeName: string;
+  failureType: RouteFailureType;
+  error: Error;
+}
+
+/**
+ * Log a route-level failure through the diagnostics channel.
+ *
+ * Emits a structured console.error so log-aggregation tools (Sentry,
+ * Datadog, etc.) can index `routeName` and `failureType` as structured
+ * fields, while the raw stack is still present.
+ */
+export function logRouteFailure({ routeName, failureType, error }: RouteErrorContext): void {
+  console.error("[diagnostics] route failure", {
+    routeName,
+    failureType,
+    message: error.message,
+    stack: error.stack,
+  });
+}


### PR DESCRIPTION
## Description

Lazy-loaded analytics pages can fail independently due to chunk loading issues, API shape changes, or render errors. Without route-level isolation, a single failure blanks the full app. This PR adds targeted error boundaries for the heavy analytics routes so failures are contained, surfaced clearly, and recoverable without a full-page loss.

Closes #991

---

### What changed

**`client/src/utils/diagnostics.ts`** *(new)*
- `classifyRouteFailure(error)` — detects `ChunkLoadError` / Vite dynamic-import failures vs plain render errors, returning a typed `RouteFailureType` (`"chunk_load_error" | "render_error" | "unknown"`).
- `logRouteFailure({ routeName, failureType, error })` — emits a structured `console.error` with `routeName` and `failureType` as indexable fields so monitoring tools (Sentry, Datadog, etc.) can filter by route and failure category.

**`client/src/components/common/RouteBoundary.tsx`**
- Accepts an optional `routeName` prop forwarded to diagnostics on failure.
- Calls `logRouteFailure()` in `componentDidCatch` with the classified failure type.
- **Chunk-load errors** → "Reload page" button performs a hard reload to re-fetch the missing chunk; a retry-attempted guard prevents reload loops.
- **Render errors** → "Try again" in-place retry clears error state and re-renders children.
- Error panel displays a `failureType` badge and `routeName` for fast diagnosis.

**`client/src/App.tsx`**
- Passes `routeName` to `RouteBoundary` for the four targeted route groups:

| Route(s) | `routeName` |
|---|---|
| `/apy` | `analytics` |
| `/treasury` | `treasury` |
| `/governance` | `governance` |
| `/transparency`, `/transparency/incidents`, `/transparency/relayer` | `transparency` |

**`client/src/components/common/RouteBoundary.test.tsx`**
- Tests for `classifyRouteFailure` across all failure categories (ChunkLoadError name, "Loading chunk N" message, Vite dynamic-import message, plain error, non-Error values).
- Tests for `logRouteFailure` structured output (`routeName`, `failureType`, `message` present in log call).
- Tests for routeName badge and failure type label appearing in the error panel.
- Tests for "Try again" vs "Reload page" button rendering based on failure type.
- Tests that diagnostics are called with the correct `routeName` for both error classes.

**`client/src/test-setup.ts`**
- Extended vitest `expect` with `@testing-library/jest-dom` matchers via `expect.extend(matchers)` for richer DOM assertions across all tests.

---

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

---

## Verification Commands

- [ ] `npm run lint` / `npm run test` (Frontend/Backend)
- [ ] `cargo fmt` / `cargo clippy` / `cargo test` (Smart Contracts)

### Contract Security (if `contracts/` changed)

N/A — no contract changes in this PR.

---

## UI Snapshot Checklist

- [x] No visual changes (checked only if UI is unchanged; explain briefly)

> This PR adds error boundary fallback UI that is only visible when a route fails to load. The fallback panel uses existing design tokens (red-500 palette, rounded-xl, glass styling) consistent with the rest of the app. No changes are made to any page that renders under normal conditions.

---

## Additional Notes

- The chunk-load retry uses `window.location.reload()` intentionally — re-fetching a failed dynamic import chunk requires the browser to re-request the script, which cannot be done purely in React state. The `chunkRetryAttempted` flag ensures the reload only fires once per boundary mount.
- `routeName` is optional and defaults to `"unknown"` in diagnostics output so existing `RouteBoundary` usages without the prop continue to work without changes.
- All other routes already wrapped in `RouteBoundary` (portfolio, calculator, rewards, etc.) benefit from the enhanced retry/logging behaviour automatically; only the `routeName` label was missing and has been added for the four specified route groups in the acceptance criteria.

---

