### PR TITLE
Add risk preference drift history and reset audit trail

### DIFF
--- a/client/src/components/dashboard/RiskPreferenceDriftIndicator.tsx
+++ b/client/src/components/dashboard/RiskPreferenceDriftIndicator.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
-import { AlertTriangle, ShieldCheck, TrendingUp, Activity, Droplets, RefreshCw } from 'lucide-react';
+import { AlertTriangle, ShieldCheck, TrendingUp, Activity, Droplets, RefreshCw, RotateCcw, Clock } from 'lucide-react';
+import { detectDrift, resetDrift, getDriftHistory } from '../../services/riskPreferenceDriftService';
+import type { DriftResult, DriftSnapshot } from '../../services/riskPreferenceDriftService';
 
 interface DriftDimension {
   dimension: string;
@@ -7,15 +9,6 @@ interface DriftDimension {
   thresholdValue: number;
   deviationPct: number;
   isDrifting: boolean;
-}
-
-interface DriftResult {
-  userId: string;
-  statedPreference: string;
-  overallDriftPct: number;
-  isDrifting: boolean;
-  dimensions: DriftDimension[];
-  message: string;
 }
 
 const PREFERENCE_COLORS: Record<string, string> = {
@@ -30,39 +23,98 @@ const DIMENSION_ICONS: Record<string, typeof Activity> = {
   liquidity: Droplets,
 };
 
+interface HistoryEntryProps {
+  snapshot: DriftSnapshot;
+}
+
+function HistoryEntry({ snapshot }: HistoryEntryProps) {
+  const date = new Date(snapshot.createdAt);
+  const dimensions: DriftDimension[] = JSON.parse(snapshot.dimensionData || '[]');
+  const driftingCount = dimensions.filter((d: DriftDimension) => d.isDrifting).length;
+
+  return (
+    <div className="flex items-center justify-between p-2 rounded-lg bg-white/5 border border-white/10 text-xs">
+      <div className="flex items-center gap-2">
+        {snapshot.isDrifting ? (
+          <AlertTriangle size={12} className="text-amber-400" />
+        ) : (
+          <ShieldCheck size={12} className="text-green-400" />
+        )}
+        <div>
+          <div className="text-gray-300">
+            {date.toLocaleDateString()} {date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+          </div>
+          <div className="text-gray-500">Reason: {snapshot.reason}</div>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        {driftingCount > 0 && (
+          <span className="text-amber-400">{driftingCount} drifting</span>
+        )}
+        <span className={`font-medium ${snapshot.isDrifting ? 'text-amber-400' : 'text-green-400'}`}>
+          {snapshot.overallDriftPct}%
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export default function RiskPreferenceDriftIndicator({ walletAddress }: { walletAddress: string }) {
   const [driftResult, setDriftResult] = useState<DriftResult | null>(null);
+  const [history, setHistory] = useState<DriftSnapshot[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+  const [showResetModal, setShowResetModal] = useState(false);
+  const [resetReason, setResetReason] = useState('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchDrift = async () => {
-      setLoading(true);
-      try {
-        const res = await fetch('/api/risk/drift/detect', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            userId: walletAddress,
-            statedPreference: 'balanced',
-            positions: [
-              { protocol: 'Blend', weightPct: 40, volatilityPct: 6, liquidityUsd: 1_000_000 },
-              { protocol: 'Soroswap', weightPct: 35, volatilityPct: 15, liquidityUsd: 300_000 },
-              { protocol: 'DeFindex', weightPct: 25, volatilityPct: 8, liquidityUsd: 500_000 },
-            ],
-          }),
-        });
-        const data = await res.json();
-        setDriftResult(data.data);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch drift data');
-      } finally {
-        setLoading(false);
-      }
-    };
+  const fetchDrift = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await detectDrift(
+        walletAddress,
+        'balanced',
+        [
+          { protocol: 'Blend', weightPct: 40, volatilityPct: 6, liquidityUsd: 1_000_000 },
+          { protocol: 'Soroswap', weightPct: 35, volatilityPct: 15, liquidityUsd: 300_000 },
+          { protocol: 'DeFindex', weightPct: 25, volatilityPct: 8, liquidityUsd: 500_000 },
+        ],
+      );
+      setDriftResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch drift data');
+    } finally {
+      setLoading(false);
+    }
+  };
 
+  const fetchHistory = async () => {
+    try {
+      const h = await getDriftHistory(walletAddress, 5);
+      setHistory(h);
+    } catch {
+      // silently fail — history is non-critical
+    }
+  };
+
+  useEffect(() => {
     void fetchDrift();
+    void fetchHistory();
   }, [walletAddress]);
+
+  const handleReset = async () => {
+    if (!resetReason.trim()) return;
+    setShowResetModal(false);
+    try {
+      await resetDrift(walletAddress, driftResult?.statedPreference || 'balanced', resetReason.trim());
+      setResetReason('');
+      await fetchDrift();
+      await fetchHistory();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset drift');
+    }
+  };
 
   if (loading) {
     return (
@@ -86,8 +138,9 @@ export default function RiskPreferenceDriftIndicator({ walletAddress }: { wallet
   }
 
   return (
-    <div className="glass-card p-5">
-      <div className="flex items-center justify-between mb-4">
+    <div className="glass-card p-5 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {driftResult.isDrifting ? (
             <AlertTriangle size={18} className="text-amber-400" />
@@ -98,17 +151,28 @@ export default function RiskPreferenceDriftIndicator({ walletAddress }: { wallet
             Risk Preference Drift
           </h3>
         </div>
-        <span
-          className={`px-2.5 py-1 rounded-lg text-xs font-bold uppercase tracking-wider bg-gradient-to-r ${PREFERENCE_COLORS[driftResult.statedPreference] ?? 'from-gray-500 to-gray-600'} text-white`}
-        >
-          {driftResult.statedPreference}
-        </span>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowHistory(!showHistory)}
+            className="p-1.5 rounded-lg bg-white/5 border border-white/10 hover:bg-white/10 transition-colors"
+            title="Toggle drift history"
+          >
+            <Clock size={14} className="text-gray-400" />
+          </button>
+          <span
+            className={`px-2.5 py-1 rounded-lg text-xs font-bold uppercase tracking-wider bg-gradient-to-r ${PREFERENCE_COLORS[driftResult.statedPreference] ?? 'from-gray-500 to-gray-600'} text-white`}
+          >
+            {driftResult.statedPreference}
+          </span>
+        </div>
       </div>
 
-      <div className={`text-sm font-medium mb-3 ${driftResult.isDrifting ? 'text-amber-300' : 'text-green-300'}`}>
+      {/* Message */}
+      <div className={`text-sm font-medium ${driftResult.isDrifting ? 'text-amber-300' : 'text-green-300'}`}>
         {driftResult.message}
       </div>
 
+      {/* Dimensions */}
       <div className="space-y-2">
         {driftResult.dimensions.map((dim) => {
           const Icon = DIMENSION_ICONS[dim.dimension] ?? Activity;
@@ -144,21 +208,91 @@ export default function RiskPreferenceDriftIndicator({ walletAddress }: { wallet
         })}
       </div>
 
+      {/* Overall Drift Bar */}
       {driftResult.overallDriftPct > 0 && (
-        <div className="mt-3 pt-3 border-t border-white/10">
-          <div className="flex items-center justify-between text-xs">
+        <div className="pt-3 border-t border-white/10">
+          <div className="flex items-center justify-between text-xs mb-1.5">
             <span className="text-gray-400">Overall Drift</span>
             <span className={`font-bold ${driftResult.isDrifting ? 'text-amber-400' : 'text-green-400'}`}>
               {driftResult.overallDriftPct}%
             </span>
           </div>
-          <div className="mt-1.5 h-1.5 bg-white/10 rounded-full overflow-hidden">
+          <div className="h-1.5 bg-white/10 rounded-full overflow-hidden">
             <div
               className={`h-full rounded-full transition-all ${
                 driftResult.isDrifting ? 'bg-gradient-to-r from-amber-500 to-red-500' : 'bg-green-500'
               }`}
               style={{ width: `${Math.min(driftResult.overallDriftPct, 100)}%` }}
             />
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          onClick={() => setShowResetModal(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-amber-500/10 border border-amber-500/30 text-amber-400 text-xs font-medium hover:bg-amber-500/20 transition-colors"
+        >
+          <RotateCcw size={12} />
+          Reset Drift
+        </button>
+        <button
+          onClick={() => { void fetchDrift(); void fetchHistory(); }}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-gray-400 text-xs font-medium hover:bg-white/10 transition-colors"
+        >
+          <RefreshCw size={12} />
+          Refresh
+        </button>
+      </div>
+
+      {/* History Panel */}
+      {showHistory && (
+        <div className="space-y-2 pt-2 border-t border-white/10">
+          <div className="flex items-center justify-between">
+            <span className="text-xs font-semibold uppercase tracking-wider text-gray-500">Drift History</span>
+            {history.length > 0 && (
+              <span className="text-xs text-gray-500">{history.length} entries</span>
+            )}
+          </div>
+          {history.length === 0 ? (
+            <p className="text-xs text-gray-500 text-center py-4">No drift history recorded yet.</p>
+          ) : (
+            history.map((snapshot) => (
+              <HistoryEntry key={snapshot.id} snapshot={snapshot} />
+            ))
+          )}
+        </div>
+      )}
+
+      {/* Reset Modal */}
+      {showResetModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setShowResetModal(false)}>
+          <div className="glass-card p-6 max-w-md w-full mx-4 space-y-4" onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-400">Reset Risk Preference Drift</h3>
+            <p className="text-xs text-gray-500">Enter the reason for resetting the drift detection. This will be recorded in the audit trail.</p>
+            <textarea
+              value={resetReason}
+              onChange={(e) => setResetReason(e.target.value)}
+              placeholder="e.g., Portfolio rebalanced manually"
+              className="w-full p-2.5 rounded-lg bg-white/5 border border-white/10 text-sm text-gray-300 placeholder-gray-600 focus:outline-none focus:border-amber-500/50 resize-none"
+              rows={3}
+            />
+            <div className="flex items-center justify-end gap-2">
+              <button
+                onClick={() => { setShowResetModal(false); setResetReason(''); }}
+                className="px-3 py-1.5 rounded-lg bg-white/5 border border-white/10 text-gray-400 text-xs font-medium hover:bg-white/10 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleReset}
+                disabled={!resetReason.trim()}
+                className="px-3 py-1.5 rounded-lg bg-amber-500/20 border border-amber-500/40 text-amber-400 text-xs font-medium hover:bg-amber-500/30 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                Confirm Reset
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/client/src/services/riskPreferenceDriftService.ts
+++ b/client/src/services/riskPreferenceDriftService.ts
@@ -1,0 +1,91 @@
+export interface DriftDimension {
+  dimension: string;
+  actualValue: number;
+  thresholdValue: number;
+  deviationPct: number;
+  isDrifting: boolean;
+}
+
+export interface DriftResult {
+  id?: string;
+  userId: string;
+  statedPreference: string;
+  overallDriftPct: number;
+  isDrifting: boolean;
+  dimensions: DriftDimension[];
+  message: string;
+  detectedAt: string;
+}
+
+export interface DriftSnapshot {
+  id: string;
+  userId: string;
+  statedPreference: string;
+  overallDriftPct: number;
+  isDrifting: boolean;
+  dimensionData: string;
+  reason: string;
+  createdAt: string;
+}
+
+interface Position {
+  protocol: string;
+  weightPct: number;
+  volatilityPct: number;
+  liquidityUsd: number;
+}
+
+export async function detectDrift(
+  userId: string,
+  statedPreference: string,
+  positions: Position[],
+): Promise<DriftResult> {
+  const res = await fetch('/api/risk/drift/detect', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, statedPreference, positions }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Failed to detect drift' }));
+    throw new Error(err.error || 'Failed to detect drift');
+  }
+
+  const json = await res.json();
+  return json.data;
+}
+
+export async function resetDrift(
+  userId: string,
+  statedPreference: string,
+  reason: string,
+): Promise<DriftSnapshot> {
+  const res = await fetch('/api/risk/drift/reset', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, statedPreference, reason }),
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Failed to reset drift' }));
+    throw new Error(err.error || 'Failed to reset drift');
+  }
+
+  const json = await res.json();
+  return json.data;
+}
+
+export async function getDriftHistory(
+  userId: string,
+  limit: number = 10,
+): Promise<DriftSnapshot[]> {
+  const res = await fetch(`/api/risk/drift/history/${userId}?limit=${limit}`);
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ error: 'Failed to fetch drift history' }));
+    throw new Error(err.error || 'Failed to fetch drift history');
+  }
+
+  const json = await res.json();
+  return json.data;
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -210,6 +210,19 @@ model DriftEvent {
   @@index([vaultId, isRecovered])
 }
 
+model RiskPreferenceDriftSnapshot {
+  id               String   @id @default(uuid())
+  userId           String
+  statedPreference String   // conservative, balanced, aggressive
+  overallDriftPct  Float
+  isDrifting       Boolean
+  dimensionData    String   // JSON string of DriftDimension array
+  reason           String   // "auto_detected" or custom reset reason
+  createdAt        DateTime @default(now())
+
+  @@index([userId, createdAt])
+}
+
 // ── Rebalance Queue Models (Issue #281) ─────────────────────────────────────────
 
 model RebalanceQueueEntry {

--- a/server/src/routes/risk.ts
+++ b/server/src/routes/risk.ts
@@ -1,8 +1,11 @@
 import { Router, Request, Response } from "express";
 import rateLimit from "express-rate-limit";
-import { riskPreferenceDriftService, type RiskPreference, type UserRiskProfile, type PortfolioBehavior } from "../services/riskPreferenceDriftService";
+import { PrismaClient } from "@prisma/client";
+import { RiskPreferenceDriftService, riskPreferenceDriftService, type RiskPreference, type UserRiskProfile, type PortfolioBehavior } from "../services/riskPreferenceDriftService";
 import { stressMatrixService } from "../services/stressMatrixService";
 import { apyDispersionService, type ProviderApyInput } from "../services/apyDispersionService";
+
+const prisma = new PrismaClient();
 
 const router = Router();
 
@@ -36,7 +39,7 @@ const VALID_PREFERENCES: RiskPreference[] = ["conservative", "balanced", "aggres
  * POST /api/risk/drift/detect
  * Detect risk preference drift for a user's portfolio.
  */
-router.post("/drift/detect", riskAnalysisLimiter, (req: Request, res: Response) => {
+router.post("/drift/detect", riskAnalysisLimiter, async (req: Request, res: Response) => {
   try {
     const { userId, statedPreference, positions } = req.body as {
       userId?: string;
@@ -74,7 +77,8 @@ router.post("/drift/detect", riskAnalysisLimiter, (req: Request, res: Response) 
       positions,
     };
 
-    const result = riskPreferenceDriftService.detectDrift(profile, behavior);
+    const svc = new RiskPreferenceDriftService(prisma);
+    const result = await svc.detectDrift(profile, behavior);
     res.json({ success: true, data: result });
   } catch (error) {
     res.status(500).json({
@@ -220,6 +224,64 @@ router.delete("/stress-matrix/scenarios/:scenarioId", (req: Request, res: Respon
   }
 
   res.json({ success: true, message: `Scenario ${scenarioId} removed` });
+});
+
+/**
+ * POST /api/risk/drift/reset
+ * Reset risk preference drift with a recorded reason.
+ */
+router.post("/drift/reset", riskAnalysisLimiter, async (req: Request, res: Response) => {
+  try {
+    const { userId, statedPreference, reason } = req.body as {
+      userId?: string;
+      statedPreference?: string;
+      reason?: string;
+    };
+
+    if (!userId) {
+      res.status(400).json({ error: "userId is required" });
+      return;
+    }
+
+    if (!statedPreference || !VALID_PREFERENCES.includes(statedPreference as RiskPreference)) {
+      res.status(400).json({ error: `statedPreference must be one of: ${VALID_PREFERENCES.join(", ")}` });
+      return;
+    }
+
+    if (!reason || typeof reason !== "string" || reason.trim().length === 0) {
+      res.status(400).json({ error: "reason is required" });
+      return;
+    }
+
+    const svc = new RiskPreferenceDriftService(prisma);
+    const snapshot = await svc.resetDrift(userId, statedPreference as RiskPreference, reason.trim());
+    res.json({ success: true, data: snapshot });
+  } catch (error) {
+    res.status(500).json({
+      error: "Failed to reset risk preference drift",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+});
+
+/**
+ * GET /api/risk/drift/history/:userId
+ * Get recent drift history for a user.
+ */
+router.get("/drift/history/:userId", async (req: Request, res: Response) => {
+  try {
+    const { userId } = req.params;
+    const limit = Math.min(Math.max(parseInt(req.query.limit as string) || 10, 1), 100);
+
+    const svc = new RiskPreferenceDriftService(prisma);
+    const history = await svc.getDriftHistory(userId, limit);
+    res.json({ success: true, data: history });
+  } catch (error) {
+    res.status(500).json({
+      error: "Failed to fetch drift history",
+      message: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
 });
 
 export default router;

--- a/server/src/services/riskPreferenceDriftService.ts
+++ b/server/src/services/riskPreferenceDriftService.ts
@@ -1,3 +1,5 @@
+import { PrismaClient } from '@prisma/client';
+
 export type RiskPreference = 'conservative' | 'balanced' | 'aggressive';
 
 export interface UserRiskProfile {
@@ -29,6 +31,7 @@ export interface DriftDimension {
 }
 
 export interface DriftResult {
+  id?: string;
   userId: string;
   statedPreference: RiskPreference;
   overallDriftPct: number;
@@ -36,6 +39,17 @@ export interface DriftResult {
   dimensions: DriftDimension[];
   message: string;
   detectedAt: string;
+}
+
+export interface DriftSnapshot {
+  id: string;
+  userId: string;
+  statedPreference: string;
+  overallDriftPct: number;
+  isDrifting: boolean;
+  dimensionData: string;
+  reason: string;
+  createdAt: string;
 }
 
 const PREFERENCE_THRESHOLDS: Record<RiskPreference, {
@@ -47,7 +61,6 @@ const PREFERENCE_THRESHOLDS: Record<RiskPreference, {
   balanced: { maxConcentrationPct: 40, maxVolatilityPct: 18, minLiquidityUsd: 200_000 },
   aggressive: { maxConcentrationPct: 60, maxVolatilityPct: 35, minLiquidityUsd: 50_000 },
 };
-
 
 function computeConcentration(positionWeights: number[]): number {
   if (positionWeights.length === 0) return 0;
@@ -93,10 +106,13 @@ function evaluateDimension(
 }
 
 export class RiskPreferenceDriftService {
-  detectDrift(
+  constructor(private prisma?: PrismaClient) {}
+
+  async detectDrift(
     profile: UserRiskProfile,
     behavior: PortfolioBehavior,
-  ): DriftResult {
+    reason: string = 'auto_detected',
+  ): Promise<DriftResult> {
     const thresholds = PREFERENCE_THRESHOLDS[profile.statedPreference];
 
     const actualConcentration = behavior.positions.length > 0
@@ -105,8 +121,10 @@ export class RiskPreferenceDriftService {
     const actualVolatility = computeWeightedVolatility(behavior.positions);
     const actualLiquidity = computeWeightedLiquidity(behavior.positions);
 
+    let result: DriftResult;
+
     if (behavior.positions.length === 0) {
-      return {
+      result = {
         userId: profile.userId,
         statedPreference: profile.statedPreference,
         overallDriftPct: 0,
@@ -115,37 +133,104 @@ export class RiskPreferenceDriftService {
         message: `Portfolio aligns with ${profile.statedPreference} risk preference.`,
         detectedAt: new Date().toISOString(),
       };
-    }
-
-    const dimensions: DriftDimension[] = [
-      evaluateDimension('concentration', actualConcentration, thresholds.maxConcentrationPct, true),
-      evaluateDimension('volatility', actualVolatility, thresholds.maxVolatilityPct, true),
-      evaluateDimension('liquidity', actualLiquidity, thresholds.minLiquidityUsd, false),
-    ];
-
-    const driftingDims = dimensions.filter(d => d.isDrifting);
-    const overallDriftPct = dimensions.length > 0
-      ? Math.round((driftingDims.length / dimensions.length) * 100)
-      : 0;
-    const isDrifting = driftingDims.length > 0;
-
-    let message: string;
-    if (!isDrifting) {
-      message = `Portfolio aligns with ${profile.statedPreference} risk preference.`;
     } else {
-      const driftNames = driftingDims.map(d => d.dimension).join(', ');
-      message = `Detected drift in ${driftNames}. Portfolio no longer matches ${profile.statedPreference} profile.`;
+      const dimensions: DriftDimension[] = [
+        evaluateDimension('concentration', actualConcentration, thresholds.maxConcentrationPct, true),
+        evaluateDimension('volatility', actualVolatility, thresholds.maxVolatilityPct, true),
+        evaluateDimension('liquidity', actualLiquidity, thresholds.minLiquidityUsd, false),
+      ];
+
+      const driftingDims = dimensions.filter(d => d.isDrifting);
+      const overallDriftPct = dimensions.length > 0
+        ? Math.round((driftingDims.length / dimensions.length) * 100)
+        : 0;
+      const isDrifting = driftingDims.length > 0;
+
+      let message: string;
+      if (!isDrifting) {
+        message = `Portfolio aligns with ${profile.statedPreference} risk preference.`;
+      } else {
+        const driftNames = driftingDims.map(d => d.dimension).join(', ');
+        message = `Detected drift in ${driftNames}. Portfolio no longer matches ${profile.statedPreference} profile.`;
+      }
+
+      result = {
+        userId: profile.userId,
+        statedPreference: profile.statedPreference,
+        overallDriftPct,
+        isDrifting,
+        dimensions,
+        message,
+        detectedAt: new Date().toISOString(),
+      };
     }
+
+    // Persist snapshot
+    if (this.prisma) {
+      const snapshot = await this.recordDrift(result, reason);
+      result.id = snapshot.id;
+    }
+
+    return result;
+  }
+
+  async recordDrift(drift: DriftResult, reason: string): Promise<DriftSnapshot> {
+    if (!this.prisma) {
+      throw new Error('Prisma client not initialized');
+    }
+
+    const record = await this.prisma.riskPreferenceDriftSnapshot.create({
+      data: {
+        userId: drift.userId,
+        statedPreference: drift.statedPreference,
+        overallDriftPct: drift.overallDriftPct,
+        isDrifting: drift.isDrifting,
+        dimensionData: JSON.stringify(drift.dimensions),
+        reason,
+      },
+    });
 
     return {
-      userId: profile.userId,
-      statedPreference: profile.statedPreference,
-      overallDriftPct,
-      isDrifting,
-      dimensions,
-      message,
-      detectedAt: new Date().toISOString(),
+      ...record,
+      createdAt: record.createdAt.toISOString(),
+      dimensionData: record.dimensionData,
     };
+  }
+
+  async resetDrift(
+    userId: string,
+    preference: RiskPreference,
+    reason: string,
+  ): Promise<DriftSnapshot> {
+    return this.recordDrift(
+      {
+        userId,
+        statedPreference: preference,
+        overallDriftPct: 0,
+        isDrifting: false,
+        dimensions: [],
+        message: `Risk preference reset to ${preference}: ${reason}`,
+        detectedAt: new Date().toISOString(),
+      },
+      reason,
+    );
+  }
+
+  async getDriftHistory(userId: string, limit: number = 10): Promise<DriftSnapshot[]> {
+    if (!this.prisma) {
+      return [];
+    }
+
+    const records = await this.prisma.riskPreferenceDriftSnapshot.findMany({
+      where: { userId },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+    });
+
+    return records.map(r => ({
+      ...r,
+      createdAt: r.createdAt.toISOString(),
+    }));
   }
 
   getThresholdsForPreference(preference: RiskPreference) {


### PR DESCRIPTION
Closes #1004

## Description

Adds persistence, reset capability, and historical tracking to the risk preference drift system. Previously the drift detection was entirely stateless — now every drift detection is recorded as a snapshot with timestamp and reason, resets are logged with an audit reason, and the dashboard can display recent history.

## Changes

### Server: New Prisma Model
- `RiskPreferenceDriftSnapshot` — id, userId, statedPreference, overallDriftPct, isDrifting, dimensionData (JSON), reason, createdAt

### Server: Updated Service (`riskPreferenceDriftService.ts`)
- `detectDrift()` now async — persists snapshot with reason (default `"auto_detected"`)
- `recordDrift()` — persists a drift result to the database
- `resetDrift(userId, preference, reason)` — records a reset snapshot with audit reason
- `getDriftHistory(userId, limit)` — returns recent drift snapshots ordered by time desc

### Server: New API Endpoints (`routes/risk.ts`)
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/risk/drift/reset` | Reset drift with a recorded reason |
| GET | `/api/risk/drift/history/:userId` | Get recent drift history (query: limit) |

### Client: New Service (`riskPreferenceDriftService.ts`)
- `detectDrift()` — calls POST /api/risk/drift/detect
- `resetDrift()` — calls POST /api/risk/drift/reset
- `getDriftHistory()` — calls GET /api/risk/drift/history/:userId

### Client: Updated Dashboard Component
- History panel with toggle button (clock icon)
- "Reset Drift" button with modal to enter reset reason
- Reason recorded in snapshot for audit trail
- Refresh button to update drift + history