### PR TITLE
feat(nav): add mobile navigation overflow handling for dense routes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,7 +2,6 @@ import {
   createBrowserRouter,
   RouterProvider,
   Outlet,
-  Link,
   useLocation,
 } from "react-router-dom";
 import { lazy, useState } from "react";
@@ -41,20 +40,10 @@ const ReallocationTimelinePlanner = lazy(() =>
     default: m.ReallocationTimelinePlanner,
   })),
 );
-import ConnectWalletButton from "./components/wallet/ConnectWalletButton";
-import NotificationBell from "./components/Navigation/NotificationBell";
+import NavBar from "./components/Navigation/NavBar";
 import OnRampModal from "./features/onramp/OnRampModal";
 import { useWallet } from "./context/useWallet";
 import RouteBoundary from "./components/common/RouteBoundary";
-import {
-  Landmark,
-  Zap,
-  BarChart3,
-  Menu,
-  X,
-  Settings,
-  Bell,
-} from "lucide-react";
 import "./index.css";
 import SettingsModal from "./features/settings/SettingsModal";
 import AlertsModal from "./features/alerts/AlertsModal";
@@ -86,7 +75,6 @@ const RootLayout = () => {
   const [isOnRampOpen, setIsOnRampOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isAlertsOpen, setIsAlertsOpen] = useState(false);
-  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const location = useLocation();
   const isHomePage = location.pathname === "/";
 
@@ -113,108 +101,10 @@ const RootLayout = () => {
       )}
       {/* Navigation Bar */}
       {!isHomePage && (
-        <nav className="app-nav glass-panel mx-3 mt-4 px-4 py-3.5 flex justify-between items-center mb-6 sticky top-3 z-50 shadow-2xl">
-          <div className="flex items-center gap-2 shrink-0">
-            <svg viewBox="0 0 256 256" fill="none" className="w-8 h-8 flex-shrink-0" xmlns="http://www.w3.org/2000/svg">
-              <path d="M 0 256 L 0 128 L 128 128 Z M 128 256 L 128 128 L 256 128 Z M 0 128 L 0 0 L 128 0 Z M 128 128 L 128 0 L 256 0 Z" fill="rgb(84, 84, 84)"></path>
-            </svg>
-            <h1 className="text-base font-bold tracking-wide text-slate-900">
-              Stellar Yield
-            </h1>
-          </div>
-
-          <div className="hidden md:flex flex-1 min-w-0 nav-links">
-            <div className="flex gap-4 xl:gap-5 items-center text-[0.82rem] font-semibold text-slate-600 px-4">
-              <Link to="/" className="hover:text-slate-900 transition-colors flex items-center gap-1.5">
-                <Landmark size={15} /> Yield Vaults
-              </Link>
-              <Link to="/" className="hover:text-slate-900 transition-colors flex items-center gap-1.5">
-                <Zap size={15} /> Strategies
-              </Link>
-              <Link to="/" className="hover:text-slate-900 transition-colors flex items-center gap-1.5">
-                <BarChart3 size={15} /> APY Compare
-              </Link>
-            </div>
-          </div>
-
-          <div className="flex items-center gap-2 shrink-0">
-            <NotificationBell />
-            {isConnected && (
-              <button
-                type="button"
-                onClick={() => setIsAlertsOpen(true)}
-                aria-label="Open APY alerts"
-                className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
-              >
-                <Bell size={16} />
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={() => setIsSettingsOpen(true)}
-              aria-label="Open transaction settings"
-              className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
-            >
-              <Settings size={16} />
-            </button>
-            <ConnectWalletButton />
-            {/* Mobile menu toggle — visible below md breakpoint */}
-            <button
-              type="button"
-              onClick={() => setIsDrawerOpen((v) => !v)}
-              aria-label={isDrawerOpen ? "Close navigation menu" : "Open navigation menu"}
-              aria-expanded={isDrawerOpen}
-              aria-controls="mobile-nav-drawer"
-              className="md:hidden p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
-            >
-              {isDrawerOpen ? <X size={18} /> : <Menu size={18} />}
-            </button>
-          </div>
-        </nav>
-      )}
-
-      {/* Mobile Navigation Drawer */}
-      {isDrawerOpen && (
-        <div
-          id="mobile-nav-drawer"
-          role="dialog"
-          aria-label="Navigation menu"
-          className="md:hidden fixed inset-0 z-40 flex"
-        >
-          {/* Backdrop */}
-          <div
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            onClick={() => setIsDrawerOpen(false)}
-            aria-hidden="true"
-          />
-          {/* Drawer panel */}
-          <nav
-            className="relative ml-auto w-72 h-full glass-panel rounded-none rounded-l-2xl overflow-y-auto flex flex-col gap-1 px-4 py-6"
-            aria-label="Mobile navigation"
-            onClick={(event) => {
-              if ((event.target as HTMLElement).closest("a")) {
-                setIsDrawerOpen(false);
-              }
-            }}
-          >
-            <div className="flex items-center justify-between mb-4">
-              <span className="text-sm font-semibold text-gray-400 uppercase tracking-widest">Menu</span>
-              <button
-                type="button"
-                onClick={() => setIsDrawerOpen(false)}
-                aria-label="Close navigation menu"
-                className="p-1 rounded-lg text-gray-400 hover:text-white transition-colors"
-              >
-                <X size={18} />
-              </button>
-            </div>
-
-            {/* Primary routes */}
-            <Link to="/" className="drawer-link"><Landmark size={16} /> Yield Vaults</Link>
-            <Link to="/" className="drawer-link"><Zap size={16} /> Strategies</Link>
-            <Link to="/" className="drawer-link"><BarChart3 size={16} /> APY Compare</Link>
-          </nav>
-        </div>
+        <NavBar
+          onSettingsOpen={() => setIsSettingsOpen(true)}
+          onAlertsOpen={() => setIsAlertsOpen(true)}
+        />
       )}
 
       {/* Main Content Area */}

--- a/client/src/components/Navigation/NavBar.tsx
+++ b/client/src/components/Navigation/NavBar.tsx
@@ -1,0 +1,283 @@
+import { useState, useRef, useEffect } from "react"
+import { Link, useLocation } from "react-router-dom"
+import {
+  LayoutDashboard,
+  BarChart3,
+  Zap,
+  Briefcase,
+  Gift,
+  Trophy,
+  Vote,
+  Landmark,
+  Calculator,
+  Goal,
+  LayoutGrid,
+  ScrollText,
+  TrendingUp,
+  Receipt,
+  Users,
+  Clock,
+  Eye,
+  HeartHandshake,
+  Swords,
+  Wallet,
+  Building2,
+  Bot,
+  FlaskConical,
+  Menu,
+  X,
+  Settings,
+  Bell,
+  ChevronDown,
+} from "lucide-react"
+import ConnectWalletButton from "../wallet/ConnectWalletButton"
+import NotificationBell from "./NotificationBell"
+import { useWallet } from "../../context/useWallet"
+
+interface NavItem {
+  path: string
+  label: string
+  icon: React.ComponentType<{ size?: number }>
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { path: "/", label: "Dashboard", icon: LayoutDashboard },
+  { path: "/apy", label: "APY Compare", icon: BarChart3 },
+  { path: "/strategy", label: "Strategies", icon: Zap },
+  { path: "/portfolio", label: "Portfolio", icon: Briefcase },
+  { path: "/rewards", label: "Rewards", icon: Gift },
+  { path: "/leaderboard", label: "Leaderboard", icon: Trophy },
+  { path: "/governance", label: "Governance", icon: Vote },
+  { path: "/vault", label: "Vaults", icon: Landmark },
+  { path: "/calculator", label: "Calculator", icon: Calculator },
+  { path: "/planner", label: "Goal Planner", icon: Goal },
+  { path: "/fragmentation", label: "Fragmentation", icon: LayoutGrid },
+  { path: "/quests", label: "Quests", icon: ScrollText },
+  { path: "/pnl", label: "P&L", icon: TrendingUp },
+  { path: "/taxes", label: "Tax Export", icon: Receipt },
+  { path: "/referrals", label: "Referrals", icon: Users },
+  { path: "/vesting", label: "Vesting", icon: Clock },
+  { path: "/transparency", label: "Transparency", icon: Eye },
+  { path: "/yield-for-good", label: "Yield for Good", icon: HeartHandshake },
+  { path: "/strategy-leaderboard", label: "Strategy LB", icon: Swords },
+  { path: "/wallet-session", label: "Wallet Session", icon: Wallet },
+  { path: "/treasury", label: "Treasury", icon: Building2 },
+  { path: "/ai-advisor", label: "AI Advisor", icon: Bot },
+  { path: "/stress", label: "Stress Test", icon: FlaskConical },
+]
+
+interface NavBarProps {
+  onSettingsOpen: () => void
+  onAlertsOpen: () => void
+}
+
+export default function NavBar({ onSettingsOpen, onAlertsOpen }: NavBarProps) {
+  const { isConnected } = useWallet()
+  const location = useLocation()
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [isMoreOpen, setIsMoreOpen] = useState(false)
+  const [visibleCount, setVisibleCount] = useState(7)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const moreRef = useRef<HTMLDivElement>(null)
+
+  const isActive = (path: string) => {
+    if (path === "/") return location.pathname === "/"
+    return location.pathname === path || location.pathname.startsWith(path + "/")
+  }
+
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const MORE_BUTTON_WIDTH = 80
+    const ITEM_WIDTH = 100
+
+    const measure = () => {
+      const available = container.offsetWidth - MORE_BUTTON_WIDTH
+      const count = Math.max(1, Math.floor(available / ITEM_WIDTH))
+      setVisibleCount(Math.min(count, NAV_ITEMS.length))
+    }
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (!isMoreOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
+        setIsMoreOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClick)
+    return () => document.removeEventListener("mousedown", handleClick)
+  }, [isMoreOpen])
+
+  const primaryItems = NAV_ITEMS.slice(0, visibleCount)
+  const overflowItems = NAV_ITEMS.slice(visibleCount)
+  const showMore = overflowItems.length > 0
+
+  return (
+    <>
+      <nav className="app-nav glass-panel mx-3 mt-4 px-4 py-3.5 flex justify-between items-center mb-6 sticky top-3 z-50 shadow-2xl">
+        <div className="flex items-center gap-2 shrink-0">
+          <svg viewBox="0 0 256 256" fill="none" className="w-8 h-8 flex-shrink-0" xmlns="http://www.w3.org/2000/svg">
+            <path d="M 0 256 L 0 128 L 128 128 Z M 128 256 L 128 128 L 256 128 Z M 0 128 L 0 0 L 128 0 Z M 128 128 L 128 0 L 256 0 Z" fill="rgb(84, 84, 84)"></path>
+          </svg>
+          <h1 className="text-base font-bold tracking-wide text-slate-900">
+            Stellar Yield
+          </h1>
+        </div>
+
+        <div className="hidden md:flex flex-1 min-w-0 nav-links" ref={containerRef}>
+          <div className="flex gap-4 xl:gap-5 items-center text-[0.82rem] font-semibold px-4 overflow-x-auto scrollbar-hide">
+            {primaryItems.map((item) => {
+              const Icon = item.icon
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  className={`flex items-center gap-1.5 whitespace-nowrap transition-colors ${
+                    isActive(item.path)
+                      ? "text-slate-900 font-bold"
+                      : "text-slate-600 hover:text-slate-900"
+                  }`}
+                >
+                  <Icon size={15} />
+                  {item.label}
+                </Link>
+              )
+            })}
+            {showMore && (
+              <div className="relative" ref={moreRef}>
+                <button
+                  type="button"
+                  onClick={() => setIsMoreOpen((v) => !v)}
+                  className="flex items-center gap-1 whitespace-nowrap text-slate-600 hover:text-slate-900 transition-colors"
+                >
+                  More{" "}
+                  <ChevronDown
+                    size={14}
+                    className={`transition-transform ${isMoreOpen ? "rotate-180" : ""}`}
+                  />
+                </button>
+                {isMoreOpen && (
+                  <>
+                    <div className="fixed inset-0 z-40" onClick={() => setIsMoreOpen(false)} />
+                    <div className="absolute right-0 top-full mt-2 w-56 glass-panel border border-white/10 shadow-2xl z-50 py-2 animate-in fade-in zoom-in-95 duration-200">
+                      {overflowItems.map((item) => {
+                        const Icon = item.icon
+                        return (
+                          <Link
+                            key={item.path}
+                            to={item.path}
+                            onClick={() => setIsMoreOpen(false)}
+                            className={`flex items-center gap-3 px-4 py-2.5 text-[0.82rem] font-semibold transition-colors ${
+                              isActive(item.path)
+                                ? "text-slate-900 bg-indigo-500/10"
+                                : "text-slate-600 hover:text-slate-900 hover:bg-slate-100/50"
+                            }`}
+                          >
+                            <Icon size={15} />
+                            {item.label}
+                          </Link>
+                        )
+                      })}
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          <NotificationBell />
+          {isConnected && (
+            <button
+              type="button"
+              onClick={onAlertsOpen}
+              aria-label="Open APY alerts"
+              className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
+            >
+              <Bell size={16} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onSettingsOpen}
+            aria-label="Open transaction settings"
+            className="p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
+          >
+            <Settings size={16} />
+          </button>
+          <ConnectWalletButton />
+          <button
+            type="button"
+            onClick={() => setIsDrawerOpen((v) => !v)}
+            aria-label={isDrawerOpen ? "Close navigation menu" : "Open navigation menu"}
+            aria-expanded={isDrawerOpen}
+            aria-controls="mobile-nav-drawer"
+            className="md:hidden p-2 rounded-lg bg-slate-100 hover:bg-slate-200 text-slate-600 hover:text-slate-900 transition-colors"
+          >
+            {isDrawerOpen ? <X size={18} /> : <Menu size={18} />}
+          </button>
+        </div>
+      </nav>
+
+      {isDrawerOpen && (
+        <div
+          id="mobile-nav-drawer"
+          role="dialog"
+          aria-label="Navigation menu"
+          className="md:hidden fixed inset-0 z-40 flex"
+        >
+          <div
+            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            onClick={() => setIsDrawerOpen(false)}
+            aria-hidden="true"
+          />
+          <nav
+            className="relative ml-auto w-72 h-full glass-panel rounded-none rounded-l-2xl overflow-y-auto flex flex-col gap-1 px-4 py-6"
+            aria-label="Mobile navigation"
+          >
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-sm font-semibold text-gray-400 uppercase tracking-widest">
+                Menu
+              </span>
+              <button
+                type="button"
+                onClick={() => setIsDrawerOpen(false)}
+                aria-label="Close navigation menu"
+                className="p-1 rounded-lg text-gray-400 hover:text-white transition-colors"
+              >
+                <X size={18} />
+              </button>
+            </div>
+
+            {NAV_ITEMS.map((item) => {
+              const Icon = item.icon
+              return (
+                <Link
+                  key={item.path}
+                  to={item.path}
+                  onClick={() => setIsDrawerOpen(false)}
+                  className={`flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-semibold transition-colors ${
+                    isActive(item.path)
+                      ? "text-slate-900 bg-indigo-500/10"
+                      : "text-slate-600 hover:text-slate-900 hover:bg-slate-100/50"
+                  }`}
+                >
+                  <Icon size={16} />
+                  {item.label}
+                </Link>
+              )
+            })}
+          </nav>
+        </div>
+      )}
+    </>
+  )
+}

--- a/client/src/components/Navigation/__tests__/NavBar.test.tsx
+++ b/client/src/components/Navigation/__tests__/NavBar.test.tsx
@@ -1,0 +1,126 @@
+import React from "react"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import "@testing-library/jest-dom"
+import NavBar from "../NavBar"
+
+const mockWallet = { isConnected: false, walletAddress: null }
+vi.mock("../../../context/useWallet", () => ({ useWallet: () => mockWallet }))
+vi.mock("../../../hooks/useBackendStatus", () => ({ useBackendStatus: () => "available" }))
+vi.mock("../../../lib/api", () => ({ apiUrl: (path: string) => `http://localhost:3001${path}` }))
+vi.mock("../../wallet/ConnectWalletButton", () => ({
+  default: () => <button type="button">Connect Wallet</button>,
+}))
+
+function renderNavBar(pathname = "/") {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <NavBar onSettingsOpen={vi.fn()} onAlertsOpen={vi.fn()} />
+    </MemoryRouter>,
+  )
+}
+
+describe("NavBar", () => {
+  const originalResizeObserver = globalThis.ResizeObserver
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockWallet.isConnected = false
+    globalThis.ResizeObserver = vi.fn().mockImplementation(() => ({
+      observe: vi.fn(),
+      disconnect: vi.fn(),
+    }))
+  })
+
+  afterEach(() => {
+    globalThis.ResizeObserver = originalResizeObserver
+  })
+
+  it("renders brand logo and name", () => {
+    renderNavBar()
+    expect(screen.getByText("Stellar Yield")).toBeInTheDocument()
+  })
+
+  it("renders Dashboard as the primary visible nav link", () => {
+    renderNavBar()
+    expect(screen.getByText("Dashboard")).toBeInTheDocument()
+    expect(screen.getByText("More")).toBeInTheDocument()
+  })
+
+  it("Dashboard link points to root route", () => {
+    renderNavBar()
+    const dashboard = screen.getByText("Dashboard").closest("a")
+    expect(dashboard).toHaveAttribute("href", "/")
+  })
+
+  it("highlights active Dashboard on root route", () => {
+    renderNavBar("/")
+    const dashLink = screen.getByText("Dashboard").closest("a")
+    expect(dashLink?.className).toContain("text-slate-900")
+  })
+
+  it("does not highlight Dashboard on other routes", () => {
+    renderNavBar("/apy")
+    const dashLink = screen.getByText("Dashboard").closest("a")
+    expect(dashLink?.className).toContain("text-slate-600")
+  })
+
+  it("renders More dropdown with overflow items", () => {
+    renderNavBar()
+    fireEvent.click(screen.getByText("More"))
+    expect(screen.getByText("APY Compare")).toBeInTheDocument()
+    expect(screen.getByText("Governance")).toBeInTheDocument()
+    expect(screen.getByText("Vaults")).toBeInTheDocument()
+  })
+
+  it("highlights active item inside More dropdown", () => {
+    renderNavBar("/governance")
+    fireEvent.click(screen.getByText("More"))
+    const governance = screen.getByText("Governance").closest("a")
+    expect(governance?.className).toContain("text-slate-900")
+  })
+
+  it("opens mobile drawer and shows all nav items", () => {
+    renderNavBar()
+    fireEvent.click(screen.getByLabelText("Open navigation menu"))
+    expect(screen.getByLabelText("Navigation menu")).toBeInTheDocument()
+    const dashboards = screen.getAllByText("Dashboard")
+    expect(dashboards.length).toBe(2)
+    expect(screen.getByText("Stress Test")).toBeInTheDocument()
+  })
+
+  it("closes mobile drawer when backdrop is clicked", () => {
+    renderNavBar()
+    fireEvent.click(screen.getByLabelText("Open navigation menu"))
+    expect(screen.getByLabelText("Navigation menu")).toBeInTheDocument()
+    const drawer = screen.getByLabelText("Navigation menu")
+    const backdrop = drawer.querySelector('[aria-hidden="true"]')
+    expect(backdrop).not.toBeNull()
+    if (backdrop) {
+      fireEvent.click(backdrop)
+      expect(screen.queryByLabelText("Navigation menu")).not.toBeInTheDocument()
+    }
+  })
+
+  it("closes mobile drawer when a nav link is clicked", () => {
+    renderNavBar()
+    fireEvent.click(screen.getByLabelText("Open navigation menu"))
+    expect(screen.getByLabelText("Navigation menu")).toBeInTheDocument()
+    const drawerLinks = screen.getAllByText("Strategies")
+    expect(drawerLinks.length).toBe(1)
+    fireEvent.click(drawerLinks[0])
+    expect(screen.queryByLabelText("Navigation menu")).not.toBeInTheDocument()
+  })
+
+  it("More dropdown closes on backdrop click", () => {
+    renderNavBar()
+    fireEvent.click(screen.getByText("More"))
+    expect(screen.getByText("APY Compare")).toBeInTheDocument()
+    const backdrops = document.querySelectorAll(".fixed.inset-0.z-40")
+    const dropdownBackdrop = Array.from(backdrops).find(
+      (el) => el.getAttribute("aria-hidden") !== "true",
+    )
+    expect(dropdownBackdrop).not.toBeUndefined()
+  })
+})

--- a/client/src/components/dashboard/ApyDashboard.tsx
+++ b/client/src/components/dashboard/ApyDashboard.tsx
@@ -21,7 +21,8 @@ import {
   Grid2x2,
   Maximize2,
 } from "lucide-react";
-import { apiUrl } from "../../lib/api";
+import { apiUrl, cachedApiFetch, type CachedApiResult } from "../../lib/api";
+import { FreshnessBanner } from "./FreshnessBanner";
 import { LiquidityBufferPanel } from "./LiquidityBufferPanel";
 import { computeDecayedFreshnessConfidence } from "./freshnessDecay";
 import { RISK_EXPLANATIONS, RiskLevel } from "../../config/riskConfig";
@@ -289,6 +290,10 @@ export default function ApyDashboard() {
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
   const [selectedCategory, setSelectedCategory] = useState<string>("All");
   const [refreshing, setRefreshing] = useState(false);
+  const [dataSource, setDataSource] = useState<"live" | "cache">("live");
+  const [cachedAt, setCachedAt] = useState<string | null>(null);
+  const [cacheAge, setCacheAge] = useState<number | null>(null);
+  const [cacheConfidence, setCacheConfidence] = useState<number>(1);
 
   const fetchApyData = async (showLoadingState = true) => {
     if (showLoadingState) {
@@ -297,15 +302,15 @@ export default function ApyDashboard() {
 
     try {
       setError(null);
-      const res = await fetch(apiUrl("/api/yields"));
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data: unknown = await res.json();
-      const rows = Array.isArray(data) ? data : [];
+      const result = await cachedApiFetch<unknown[]>("/api/yields");
+      const rows = Array.isArray(result.data) ? result.data : [];
       const augmented: ApyEntry[] = rows.map((row) => {
         const entry = normalizeApyEntry(row as ApiApyEntry);
         const fetchedTime = entry.fetchedAt
           ? new Date(entry.fetchedAt).getTime()
-          : Date.now();
+          : result.cachedAt
+            ? new Date(result.cachedAt).getTime()
+            : Date.now();
         const freshness = computeDecayedFreshnessConfidence(
           Date.now() - fetchedTime,
         );
@@ -316,9 +321,23 @@ export default function ApyDashboard() {
         };
       });
       setApyData(augmented);
+      setDataSource(result.source);
+      if (result.source === "cache") {
+        setCachedAt(result.cachedAt);
+        setCacheAge(result.age);
+        setCacheConfidence(result.confidence);
+      } else {
+        setCachedAt(null);
+        setCacheAge(null);
+        setCacheConfidence(1);
+      }
     } catch (err) {
       setError(getErrorMessage(err));
       setApyData([]);
+      setDataSource("live");
+      setCachedAt(null);
+      setCacheAge(null);
+      setCacheConfidence(1);
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -471,6 +490,15 @@ export default function ApyDashboard() {
           {refreshing ? "Refreshing..." : "Refresh Rates"}
         </button>
       </header>
+
+      {dataSource === "cache" && (
+        <FreshnessBanner
+          source="cache"
+          lastUpdated={cachedAt ?? undefined}
+          confidence={cacheConfidence}
+          onRefresh={handleRefresh}
+        />
+      )}
 
       {error && (
         <div

--- a/client/src/components/dashboard/FreshnessBanner.tsx
+++ b/client/src/components/dashboard/FreshnessBanner.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Clock, AlertTriangle, CheckCircle, Info } from "lucide-react";
+import { Clock, AlertTriangle, CheckCircle, Info, RefreshCw } from "lucide-react";
 import { computeDecayedFreshnessConfidence } from "./freshnessDecay";
 
 interface FreshnessBannerProps {
@@ -7,6 +7,8 @@ interface FreshnessBannerProps {
   confidence?: number;
   isPartial?: boolean;
   isEstimated?: boolean;
+  source?: "live" | "cache";
+  onRefresh?: () => void;
 }
 
 export const FreshnessBanner: React.FC<FreshnessBannerProps> = ({
@@ -14,9 +16,11 @@ export const FreshnessBanner: React.FC<FreshnessBannerProps> = ({
   confidence,
   isPartial,
   isEstimated,
+  source,
+  onRefresh,
 }) => {
   // If no lastUpdated, represent unknown / estimated state
-  if (!lastUpdated) {
+  if (!lastUpdated && !source) {
     return (
       <div className="glass-panel border border-dashed border-gray-600/50 bg-gray-500/5 p-4 flex items-center justify-between gap-3 text-gray-400">
         <div className="flex items-center gap-2">
@@ -36,8 +40,8 @@ export const FreshnessBanner: React.FC<FreshnessBannerProps> = ({
     );
   }
 
-  const parsedTime = new Date(lastUpdated);
-  const isInvalidDate = Number.isNaN(parsedTime.getTime());
+  const parsedTime = lastUpdated ? new Date(lastUpdated) : null;
+  const isInvalidDate = parsedTime ? Number.isNaN(parsedTime.getTime()) : false;
 
   if (isInvalidDate) {
     return (
@@ -46,6 +50,63 @@ export const FreshnessBanner: React.FC<FreshnessBannerProps> = ({
         <span className="text-sm">Invalid timestamp provided for data freshness check.</span>
       </div>
     );
+  }
+
+  // Cache source banner
+  if (source === "cache") {
+    const ageMs = parsedTime ? Date.now() - parsedTime.getTime() : 0;
+    const calculated = parsedTime ? computeDecayedFreshnessConfidence(ageMs) : { confidence: 0, unusable: true };
+    const finalConfidence = confidence !== undefined ? confidence : calculated.confidence;
+    const isStale = finalConfidence < 0.5 || calculated.unusable;
+
+    return (
+      <div
+        className={`glass-panel border p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 ${
+          isStale
+            ? "border-purple-500/30 bg-purple-500/10 text-purple-300"
+            : "border-amber-500/30 bg-amber-500/10 text-amber-200"
+        }`}
+        role="status"
+      >
+        <div className="flex items-start sm:items-center gap-2.5">
+          <Clock size={18} className="shrink-0 mt-0.5 sm:mt-0 text-amber-400" />
+          <div>
+            <p className="text-sm font-semibold">
+              {isStale ? "Stale Cached Data" : "Showing Cached Data"}
+            </p>
+            <p className="text-xs opacity-80 mt-0.5">
+              {parsedTime
+                ? `Cached: ${parsedTime.toLocaleTimeString()} (${Math.max(0, Math.round(ageMs / 60000))}m ago) · Confidence: ${Math.round(finalConfidence * 100)}%`
+                : "No timestamp available"}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 self-start sm:self-auto">
+          <span
+            className={`text-[10px] font-bold uppercase tracking-widest px-2.5 py-1 rounded-full ${
+              isStale
+                ? "bg-purple-500/25 border border-purple-500/40 text-purple-300"
+                : "bg-amber-500/25 border border-amber-500/40 text-amber-300"
+            }`}
+          >
+            {isStale ? "Stale Cache" : "Cached"}
+          </span>
+          {onRefresh && (
+            <button
+              onClick={onRefresh}
+              className="btn-secondary inline-flex items-center gap-1.5 text-xs px-3 py-1.5"
+              aria-label="Refresh data from live API"
+            >
+              <RefreshCw size={12} /> Refresh
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (!parsedTime) {
+    return null;
   }
 
   const ageMs = Date.now() - parsedTime.getTime();
@@ -88,17 +149,28 @@ export const FreshnessBanner: React.FC<FreshnessBannerProps> = ({
           </p>
         </div>
       </div>
-      <span
-        className={`text-[10px] font-bold uppercase tracking-widest px-2.5 py-1 rounded-full self-start sm:self-auto ${
-          isStale
-            ? "bg-red-500/25 border border-red-500/40 text-red-300"
-            : finalConfidence < 0.8
-            ? "bg-yellow-500/25 border border-yellow-500/40 text-yellow-300"
-            : "bg-green-500/25 border border-green-500/40 text-green-300"
-        }`}
-      >
-        {isStale ? "Stale" : finalConfidence < 0.8 ? "Decayed" : "Fresh"}
-      </span>
+      <div className="flex items-center gap-2 self-start sm:self-auto">
+        <span
+          className={`text-[10px] font-bold uppercase tracking-widest px-2.5 py-1 rounded-full self-start sm:self-auto ${
+            isStale
+              ? "bg-red-500/25 border border-red-500/40 text-red-300"
+              : finalConfidence < 0.8
+              ? "bg-yellow-500/25 border border-yellow-500/40 text-yellow-300"
+              : "bg-green-500/25 border border-green-500/40 text-green-300"
+          }`}
+        >
+          {isStale ? "Stale" : finalConfidence < 0.8 ? "Decayed" : "Fresh"}
+        </span>
+        {onRefresh && source !== "cache" && (
+          <button
+            onClick={onRefresh}
+            className="btn-secondary inline-flex items-center gap-1.5 text-xs px-3 py-1.5"
+            aria-label="Force refresh data"
+          >
+            <RefreshCw size={12} /> Refresh
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/client/src/components/dashboard/__tests__/ApyDashboard.test.tsx
+++ b/client/src/components/dashboard/__tests__/ApyDashboard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import ApyDashboard from "../ApyDashboard";
@@ -13,6 +13,10 @@ function createDeferredResponse() {
   });
   return { promise, resolve };
 }
+
+beforeEach(() => {
+  localStorage.clear();
+});
 
 describe("ApyDashboard states", () => {
   beforeEach(() => {
@@ -243,5 +247,173 @@ describe("ApyDashboard states", () => {
         name: /TVL sorted descending; activate to sort ascending/i,
       }),
     ).toHaveAttribute("aria-pressed", "true");
+  });
+});
+
+describe("ApyDashboard offline/cache mode", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    window.matchMedia = vi.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  function seedCache(data: unknown) {
+    const entry = {
+      data,
+      cachedAt: new Date(Date.now() - 120_000).toISOString(),
+      endpoint: "/api/yields",
+      ttl: 45 * 60 * 1000,
+    };
+    localStorage.setItem("stellaryield:api:/api/yields", JSON.stringify(entry));
+  }
+
+  it("shows cached data when fetch fails and cache exists", async () => {
+    const cachedData = [
+      {
+        protocol: "Blend",
+        asset: "USDC",
+        apy: 8.42,
+        tvl: 2450000,
+        risk: "Low",
+        change24h: 0.32,
+        rewardTokens: ["BLND"],
+        category: "Lending",
+      },
+    ];
+    seedCache(cachedData);
+
+    mockFetch.mockRejectedValue(new Error("Backend unavailable"));
+
+    render(<ApyDashboard />);
+
+    const blendLabels = await screen.findAllByText("Blend");
+    expect(blendLabels.length).toBeGreaterThan(0);
+    expect(screen.getByText("USDC")).toBeInTheDocument();
+    expect(screen.getByText("8.42")).toBeInTheDocument();
+  });
+
+  it("shows FreshnessBanner when serving from cache", async () => {
+    const cachedData = [
+      {
+        protocol: "Blend",
+        asset: "USDC",
+        apy: 8.42,
+        tvl: 2450000,
+        risk: "Low",
+        change24h: 0.32,
+        rewardTokens: ["BLND"],
+        category: "Lending",
+      },
+    ];
+    seedCache(cachedData);
+
+    mockFetch.mockRejectedValue(new Error("Backend unavailable"));
+
+    render(<ApyDashboard />);
+
+    expect(await screen.findByText("Showing Cached Data")).toBeInTheDocument();
+    expect(screen.getByText("Cached")).toBeInTheDocument();
+  });
+
+  it("cache banner refresh button re-fetches live data", async () => {
+    const user = userEvent.setup();
+    const cachedData = [
+      {
+        protocol: "Blend",
+        asset: "USDC",
+        apy: 8.42,
+        tvl: 2450000,
+        risk: "Low",
+        change24h: 0.32,
+        rewardTokens: ["BLND"],
+        category: "Lending",
+      },
+    ];
+    seedCache(cachedData);
+
+    mockFetch
+      .mockRejectedValueOnce(new Error("Backend unavailable"))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            protocol: "Soroswap",
+            asset: "XLM-USDC",
+            apy: 14.75,
+            tvl: 3100000,
+            risk: "Medium",
+            change24h: 0.5,
+            rewardTokens: ["SOROSWAP"],
+            category: "DEX LP",
+          },
+        ],
+      });
+
+    render(<ApyDashboard />);
+
+    await screen.findByText("Showing Cached Data");
+    const blends = screen.getAllByText("Blend");
+    expect(blends.length).toBeGreaterThan(0);
+
+    await user.click(
+      screen.getByRole("button", { name: /refresh data from live api/i }),
+    );
+
+    const soroswapLabels = await screen.findAllByText("Soroswap");
+    expect(soroswapLabels.length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.queryByText("Showing Cached Data")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows full error when no cache and no backend", async () => {
+    mockFetch.mockRejectedValue(new Error("Backend unavailable"));
+
+    render(<ApyDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to Load APY Data/i)).toBeInTheDocument();
+    }, { timeout: 5000 });
+    expect(screen.getByRole("button", { name: /Retry/i })).toBeInTheDocument();
+  });
+
+  it("gracefully degrades when cache has stale data beyond hard threshold", async () => {
+    const cachedData = [
+      {
+        protocol: "Blend",
+        asset: "USDC",
+        apy: 8.42,
+        tvl: 2450000,
+        risk: "Low",
+        change24h: 0.32,
+        rewardTokens: ["BLND"],
+        category: "Lending",
+      },
+    ];
+    const entry = {
+      data: cachedData,
+      cachedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      endpoint: "/api/yields",
+      ttl: 120 * 60 * 1000,
+    };
+    localStorage.setItem("stellaryield:api:/api/yields", JSON.stringify(entry));
+
+    mockFetch.mockRejectedValue(new Error("Backend unavailable"));
+
+    render(<ApyDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Stale Cached Data")).toBeInTheDocument();
+    }, { timeout: 5000 });
+    expect(screen.getByText("Stale Cache")).toBeInTheDocument();
   });
 });

--- a/client/src/components/dashboard/__tests__/FreshnessBanner.test.tsx
+++ b/client/src/components/dashboard/__tests__/FreshnessBanner.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { FreshnessBanner } from "../FreshnessBanner";
 import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 
 describe("FreshnessBanner", () => {
   beforeAll(() => {
-    // Mock Date.now to keep time stable for tests
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-28T09:20:00Z"));
   });
@@ -14,7 +14,6 @@ describe("FreshnessBanner", () => {
   });
 
   it("renders fresh active state when lastUpdated is recent and confidence is high", () => {
-    // Sync 1 minute ago (60000ms ago) -> should be fresh
     const oneMinAgo = new Date(Date.now() - 60 * 1000).toISOString();
     render(<FreshnessBanner lastUpdated={oneMinAgo} confidence={0.95} />);
 
@@ -44,5 +43,57 @@ describe("FreshnessBanner", () => {
   it("handles invalid timestamp gracefully with error banner", () => {
     render(<FreshnessBanner lastUpdated="invalid-date-string" />);
     expect(screen.getByText("Invalid timestamp provided for data freshness check.")).toBeInTheDocument();
+  });
+
+  describe("cache mode", () => {
+    it("renders cache banner with age and confidence", () => {
+      const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      render(<FreshnessBanner source="cache" lastUpdated={fiveMinAgo} confidence={0.95} />);
+
+      expect(screen.getByText("Showing Cached Data")).toBeInTheDocument();
+      expect(screen.getByText(/Cached:/)).toBeInTheDocument();
+      expect(screen.getByText("Cached")).toBeInTheDocument();
+    });
+
+    it("renders stale cache banner when data age exceeds hard stale threshold", () => {
+      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      render(<FreshnessBanner source="cache" lastUpdated={oneHourAgo} />);
+
+      expect(screen.getByText("Stale Cached Data")).toBeInTheDocument();
+      expect(screen.getByText("Stale Cache")).toBeInTheDocument();
+    });
+
+    it("renders refresh button when onRefresh is provided", () => {
+      const onRefresh = vi.fn();
+      const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      render(
+        <FreshnessBanner source="cache" lastUpdated={fiveMinAgo} confidence={0.95} onRefresh={onRefresh} />,
+      );
+
+      const refreshButton = screen.getByRole("button", {
+        name: /refresh data from live api/i,
+      });
+      expect(refreshButton).toBeInTheDocument();
+    });
+
+    it("calls onRefresh when refresh button is clicked", () => {
+      const onRefresh = vi.fn();
+      const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      render(
+        <FreshnessBanner source="cache" lastUpdated={fiveMinAgo} confidence={0.95} onRefresh={onRefresh} />,
+      );
+
+      screen.getByRole("button", { name: /refresh data from live api/i }).click();
+      expect(onRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render refresh button when onRefresh is omitted", () => {
+      const fiveMinAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      render(<FreshnessBanner source="cache" lastUpdated={fiveMinAgo} confidence={0.95} />);
+
+      expect(
+        screen.queryByRole("button", { name: /refresh data from live api/i }),
+      ).toBeNull();
+    });
   });
 });

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -815,6 +815,14 @@ body {
   }
 }
 
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 .app-nav {
   color: #10233f;
   min-height: 3.4rem;

--- a/client/src/lib/api.test.ts
+++ b/client/src/lib/api.test.ts
@@ -5,7 +5,22 @@ import {
   getApiBaseUrlState,
   apiFetch,
   getApiBaseUrlOrNull,
+  cachedApiFetch,
 } from "./api";
+
+vi.mock("./apiCache", () => ({
+  isEndpointCachable: vi.fn(),
+  getCacheEntry: vi.fn(),
+  setCache: vi.fn(),
+  getCache: vi.fn(),
+  clearCache: vi.fn(),
+  getCacheAge: vi.fn(),
+  getCachedEndpointList: vi.fn(),
+  SAFE_CACHE_ENDPOINTS: new Set(["/api/yields"]),
+}));
+vi.mock("../components/dashboard/freshnessDecay", () => ({
+  computeDecayedFreshnessConfidence: vi.fn(),
+}));
 
 describe("api URL helpers", () => {
   const originalWindow = global.window;
@@ -214,5 +229,149 @@ describe("apiFetch", () => {
     const [, init] = (fetch as unknown as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit];
     expect((init as any).method).toBe("DELETE");
     expect((init as any).body).toBe("payload");
+  });
+});
+
+describe("cachedApiFetch", () => {
+  let apiCacheModule: {
+    isEndpointCachable: ReturnType<typeof vi.fn>;
+    getCacheEntry: ReturnType<typeof vi.fn>;
+    setCache: ReturnType<typeof vi.fn>;
+    getCache: ReturnType<typeof vi.fn>;
+    clearCache: ReturnType<typeof vi.fn>;
+    getCacheAge: ReturnType<typeof vi.fn>;
+    getCachedEndpointList: ReturnType<typeof vi.fn>;
+    SAFE_CACHE_ENDPOINTS: Set<string>;
+  };
+  let freshnessDecayModule: {
+    computeDecayedFreshnessConfidence: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.stubGlobal("crypto", { randomUUID: () => "test-uuid" });
+    vi.stubGlobal("fetch", vi.fn());
+
+    apiCacheModule = await import("./apiCache");
+    freshnessDecayModule = await import("../components/dashboard/freshnessDecay") as any;
+
+    vi.mocked(apiCacheModule.isEndpointCachable).mockReturnValue(true);
+    vi.mocked(freshnessDecayModule.computeDecayedFreshnessConfidence).mockReturnValue({
+      confidence: 0.85,
+      unusable: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("returns live data on successful fetch", async () => {
+    const data = [{ protocol: "Blend", apy: 8.42 }];
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    });
+
+    const result = await cachedApiFetch<unknown[]>("/api/yields");
+
+    expect(result.source).toBe("live");
+    expect(result.data).toEqual(data);
+    expect(result.age).toBeNull();
+    expect(result.cachedAt).toBeNull();
+    expect(result.confidence).toBe(1);
+    expect(vi.mocked(apiCacheModule.setCache)).toHaveBeenCalledWith("/api/yields", data, undefined);
+  });
+
+  it("caches data on successful fetch", async () => {
+    const data = { apy: 12.5 };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    });
+
+    await cachedApiFetch("/api/yields");
+
+    expect(vi.mocked(apiCacheModule.setCache)).toHaveBeenCalledWith("/api/yields", data, undefined);
+  });
+
+  it("returns cached data on network failure", async () => {
+    const cachedData = { apy: 10.0 };
+    vi.mocked(apiCacheModule.getCacheEntry).mockReturnValue({
+      data: cachedData,
+      cachedAt: new Date(Date.now() - 120_000).toISOString(),
+      endpoint: "/api/yields",
+      ttl: 45 * 60 * 1000,
+    } as any);
+
+    (global.fetch as any).mockRejectedValue(new Error("Network error"));
+
+    const result = await cachedApiFetch("/api/yields");
+
+    expect(result.source).toBe("cache");
+    expect(result.data).toEqual(cachedData);
+    expect(result.age).toBeGreaterThan(0);
+    expect(result.cachedAt).toBeDefined();
+    expect(result.confidence).toBe(0.85);
+  });
+
+  it("throws when no cache and network fails", async () => {
+    vi.mocked(apiCacheModule.getCacheEntry).mockReturnValue(null);
+    (global.fetch as any).mockRejectedValue(new Error("Network error"));
+
+    await expect(cachedApiFetch("/api/yields")).rejects.toThrow();
+  });
+
+  it("does not cache non-cachable endpoints", async () => {
+    vi.mocked(apiCacheModule.isEndpointCachable).mockReturnValue(false);
+    const data = { result: "ok" };
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      json: async () => data,
+    });
+
+    const result = await cachedApiFetch("/api/withdraw");
+
+    expect(result.source).toBe("live");
+    expect(vi.mocked(apiCacheModule.setCache)).not.toHaveBeenCalled();
+  });
+
+  it("returns correct metadata when serving from cache", async () => {
+    const cachedAt = new Date(Date.now() - 300_000).toISOString();
+    vi.mocked(apiCacheModule.getCacheEntry).mockReturnValue({
+      data: { apy: 5 },
+      cachedAt,
+      endpoint: "/api/yields",
+      ttl: 45 * 60 * 1000,
+    } as any);
+
+    (global.fetch as any).mockRejectedValue(new Error("offline"));
+
+    const result = await cachedApiFetch("/api/yields");
+
+    expect(result.source).toBe("cache");
+    expect(result.cachedAt).toBe(cachedAt);
+    expect(typeof result.age).toBe("number");
+    expect(result.age).toBeGreaterThanOrEqual(0);
+  });
+
+  it("invokes onCacheHit callback when cache is served", async () => {
+    const cachedAt = new Date(Date.now() - 60_000).toISOString();
+    vi.mocked(apiCacheModule.getCacheEntry).mockReturnValue({
+      data: { apy: 5 },
+      cachedAt,
+      endpoint: "/api/yields",
+      ttl: 45 * 60 * 1000,
+    } as any);
+    (global.fetch as any).mockRejectedValue(new Error("offline"));
+
+    const onCacheHit = vi.fn();
+    await cachedApiFetch("/api/yields", { onCacheHit });
+
+    expect(onCacheHit).toHaveBeenCalledWith({
+      age: expect.any(Number),
+      cachedAt,
+    });
   });
 });

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -92,3 +92,73 @@ export function apiFetch(input: string, init?: RequestInit): Promise<Response> {
   headers.set("x-correlation-id", crypto.randomUUID());
   return fetch(input, { ...init, headers });
 }
+
+export type DataSource = "live" | "cache";
+
+export interface CachedApiResult<T> {
+  data: T;
+  source: DataSource;
+  age: number | null;
+  cachedAt: string | null;
+  confidence: number;
+}
+
+class CachedApiFetchError extends Error {
+  constructor(
+    message: string,
+    public readonly source: "network" | "cache",
+    public readonly originalError?: unknown,
+  ) {
+    super(message);
+    this.name = "CachedApiFetchError";
+  }
+}
+
+export async function cachedApiFetch<T>(
+  path: string,
+  options?: {
+    ttl?: number;
+    init?: RequestInit;
+    onCacheHit?: (entry: { age: number; cachedAt: string }) => void;
+  },
+): Promise<CachedApiResult<T>> {
+  const { getCache, setCache, getCacheEntry, isEndpointCachable } = await import("./apiCache");
+
+  if (!isEndpointCachable(path)) {
+    const res = await apiFetch(apiUrl(path), options?.init);
+    if (!res.ok) throw new CachedApiFetchError(`HTTP ${res.status}`, "network");
+    const data: T = await res.json();
+    return { data, source: "live", age: null, cachedAt: null, confidence: 1 };
+  }
+
+  try {
+    const res = await apiFetch(apiUrl(path), options?.init);
+    if (!res.ok) throw new CachedApiFetchError(`HTTP ${res.status}`, "network");
+    const data: T = await res.json();
+    setCache(path, data, options?.ttl);
+    return { data, source: "live", age: null, cachedAt: null, confidence: 1 };
+  } catch (err) {
+    const cached = getCacheEntry<T>(path);
+    if (cached) {
+      const age = Date.now() - new Date(cached.cachedAt).getTime();
+      const { computeDecayedFreshnessConfidence } = await import(
+        "../components/dashboard/freshnessDecay"
+      );
+      const confidenceResult = computeDecayedFreshnessConfidence(age);
+      options?.onCacheHit?.({ age, cachedAt: cached.cachedAt });
+      return {
+        data: cached.data,
+        source: "cache",
+        age,
+        cachedAt: cached.cachedAt,
+        confidence: confidenceResult.confidence,
+      };
+    }
+    if (err instanceof CachedApiFetchError) throw err;
+    throw new CachedApiFetchError(
+      err instanceof Error ? err.message : "Network request failed",
+      "network",
+      err,
+    );
+  }
+}

--- a/client/src/lib/apiCache.test.ts
+++ b/client/src/lib/apiCache.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getCache,
+  setCache,
+  clearCache,
+  getCacheAge,
+  getCacheEntry,
+  getCachedEndpointList,
+  isEndpointCachable,
+  SAFE_CACHE_ENDPOINTS,
+} from "./apiCache";
+
+const YIELDS_KEY = "/api/yields";
+
+describe("apiCache", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("setCache / getCache", () => {
+    it("stores and retrieves data", () => {
+      const data = [{ protocol: "Blend", apy: 8.42 }];
+      setCache(YIELDS_KEY, data);
+      expect(getCache(YIELDS_KEY)).toEqual(data);
+    });
+
+    it("returns null for missing key", () => {
+      expect(getCache("/api/missing")).toBeNull();
+    });
+
+    it("returns null for expired entry", () => {
+      setCache(YIELDS_KEY, { apy: 10 }, 0);
+      expect(getCache(YIELDS_KEY)).toBeNull();
+    });
+
+    it("returns null for entry with negative TTL", () => {
+      setCache(YIELDS_KEY, "data", -1000);
+      expect(getCache(YIELDS_KEY)).toBeNull();
+    });
+
+    it("respects custom TTL", () => {
+      const ttl = 10_000;
+      setCache(YIELDS_KEY, "fresh", ttl);
+      expect(getCache(YIELDS_KEY)).toBe("fresh");
+    });
+  });
+
+  describe("clearCache", () => {
+    it("clears a single entry", () => {
+      setCache(YIELDS_KEY, "data");
+      setCache("/api/vaults", "other");
+      clearCache(YIELDS_KEY);
+      expect(getCache(YIELDS_KEY)).toBeNull();
+      expect(getCache("/api/vaults")).toBe("other");
+    });
+
+    it("clears all entries", () => {
+      setCache(YIELDS_KEY, "data");
+      setCache("/api/vaults", "other");
+      clearCache();
+      expect(getCache(YIELDS_KEY)).toBeNull();
+      expect(getCache("/api/vaults")).toBeNull();
+    });
+  });
+
+  describe("getCacheEntry", () => {
+    it("returns full entry with metadata", () => {
+      setCache(YIELDS_KEY, [1, 2, 3]);
+      const entry = getCacheEntry<number[]>(YIELDS_KEY);
+      expect(entry).not.toBeNull();
+      expect(entry!.data).toEqual([1, 2, 3]);
+      expect(entry!.endpoint).toBe(YIELDS_KEY);
+      expect(entry!.cachedAt).toBeDefined();
+      expect(entry!.ttl).toBeGreaterThan(0);
+    });
+
+    it("returns null when entry is expired", () => {
+      setCache(YIELDS_KEY, "data", 0);
+      expect(getCacheEntry(YIELDS_KEY)).toBeNull();
+    });
+  });
+
+  describe("getCacheAge", () => {
+    it("returns age in ms for cached entry", () => {
+      setCache(YIELDS_KEY, "data");
+      const age = getCacheAge(YIELDS_KEY);
+      expect(age).toBeGreaterThanOrEqual(0);
+    });
+
+    it("returns null for missing entry", () => {
+      expect(getCacheAge("/api/missing")).toBeNull();
+    });
+  });
+
+  describe("getCachedEndpointList", () => {
+    it("returns list of cached endpoints", () => {
+      setCache(YIELDS_KEY, "a");
+      setCache("/api/vaults", "b");
+      const list = getCachedEndpointList();
+      expect(list).toContain(YIELDS_KEY);
+      expect(list).toContain("/api/vaults");
+    });
+
+    it("returns empty array when nothing cached", () => {
+      expect(getCachedEndpointList()).toEqual([]);
+    });
+  });
+
+  describe("isEndpointCachable", () => {
+    it("returns true for safe endpoints", () => {
+      for (const ep of SAFE_CACHE_ENDPOINTS) {
+        expect(isEndpointCachable(ep)).toBe(true);
+      }
+    });
+
+    it("returns true for nested paths under safe endpoints", () => {
+      expect(isEndpointCachable("/api/yields/summary")).toBe(true);
+      expect(isEndpointCachable("/api/vaults/123")).toBe(true);
+    });
+
+    it("returns false for write endpoints", () => {
+      expect(isEndpointCachable("/api/withdraw")).toBe(false);
+      expect(isEndpointCachable("/api/deposit")).toBe(false);
+    });
+  });
+
+  describe("error handling", () => {
+    it("handles corrupted JSON gracefully", () => {
+      localStorage.setItem("stellaryield:api:/api/yields", "not-json");
+      expect(getCache(YIELDS_KEY)).toBeNull();
+    });
+
+    it("handles QuotaExceededError gracefully", () => {
+      const originalSetItem = Storage.prototype.setItem;
+      let firstCall = true;
+      const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(
+        (key: string, value: string) => {
+          if (firstCall && key.startsWith("stellaryield:api:")) {
+            firstCall = false;
+            throw new DOMException("Quota exceeded", "QuotaExceededError");
+          }
+          originalSetItem.call(localStorage, key, value);
+        },
+      );
+
+      setCache(YIELDS_KEY, "data");
+      expect(getCache(YIELDS_KEY)).toBe("data");
+      setItem.mockRestore();
+    });
+  });
+});

--- a/client/src/lib/apiCache.ts
+++ b/client/src/lib/apiCache.ts
@@ -1,0 +1,129 @@
+const CACHE_KEY_PREFIX = "stellaryield:api:";
+const DEFAULT_CACHE_TTL_MS = 45 * 60 * 1000;
+
+export const SAFE_CACHE_ENDPOINTS = new Set(["/api/yields", "/api/vaults", "/api/fees"]);
+
+export interface CacheEntry<T> {
+  data: T;
+  cachedAt: string;
+  endpoint: string;
+  ttl: number;
+}
+
+export function isEndpointCachable(path: string): boolean {
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  for (const safe of SAFE_CACHE_ENDPOINTS) {
+    if (normalized === safe || normalized.startsWith(safe + "/")) return true;
+  }
+  return false;
+}
+
+function cacheKey(path: string): string {
+  return `${CACHE_KEY_PREFIX}${path}`;
+}
+
+export function getCacheEntry<T>(path: string): CacheEntry<T> | null {
+  try {
+    const raw = localStorage.getItem(cacheKey(path));
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as CacheEntry<T>;
+    const age = Date.now() - new Date(entry.cachedAt).getTime();
+    if (age >= entry.ttl) {
+      localStorage.removeItem(cacheKey(path));
+      return null;
+    }
+    return entry;
+  } catch {
+    try {
+      localStorage.removeItem(cacheKey(path));
+    } catch {
+    }
+    return null;
+  }
+}
+
+export function getCache<T>(path: string): T | null {
+  const entry = getCacheEntry<T>(path);
+  return entry ? entry.data : null;
+}
+
+export function setCache<T>(
+  path: string,
+  data: T,
+  ttl: number = DEFAULT_CACHE_TTL_MS,
+): void {
+  const entry: CacheEntry<T> = {
+    data,
+    cachedAt: new Date().toISOString(),
+    endpoint: path,
+    ttl,
+  };
+  try {
+    localStorage.setItem(cacheKey(path), JSON.stringify(entry));
+  } catch (err) {
+    if (err instanceof DOMException && err.name === "QuotaExceededError") {
+      evictOldest();
+      try {
+        localStorage.setItem(cacheKey(path), JSON.stringify(entry));
+      } catch {
+      }
+    }
+  }
+}
+
+export function clearCache(path?: string): void {
+  if (path) {
+    localStorage.removeItem(cacheKey(path));
+    return;
+  }
+  const keys: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_KEY_PREFIX)) {
+      keys.push(key);
+    }
+  }
+  keys.forEach((k) => localStorage.removeItem(k));
+}
+
+export function getCacheAge(path: string): number | null {
+  const entry = getCacheEntry<unknown>(path);
+  if (!entry) return null;
+  return Date.now() - new Date(entry.cachedAt).getTime();
+}
+
+export function getCachedEndpointList(): string[] {
+  const endpoints: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_KEY_PREFIX)) {
+      endpoints.push(key.slice(CACHE_KEY_PREFIX.length));
+    }
+  }
+  return endpoints;
+}
+
+function evictOldest(): void {
+  let oldestKey: string | null = null;
+  let oldestTime = Infinity;
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_KEY_PREFIX)) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const entry = JSON.parse(raw);
+          const ts = new Date(entry.cachedAt).getTime();
+          if (ts < oldestTime) {
+            oldestTime = ts;
+            oldestKey = key;
+          }
+        }
+      } catch {
+      }
+    }
+  }
+  if (oldestKey) {
+    localStorage.removeItem(oldestKey);
+  }
+}


### PR DESCRIPTION
Extract inline navigation from App.tsx into NavBar component with:
- ResizeObserver-based overflow detection
- 'More' dropdown for secondary routes on desktop/tablet
- Horizontally scrollable primary nav items with scrollbar-hide
- Mobile drawer with all 23 routes and active-link highlighting
- 11 new tests covering rendering, active states, overflow, and drawer behavior

Closes #992