### PR TITLE
feat: add bounded cache invalidation for yield source registry updates

### DIFF
--- a/server/src/services/__tests__/yieldSourceRegistryService.test.ts
+++ b/server/src/services/__tests__/yieldSourceRegistryService.test.ts
@@ -3,6 +3,7 @@ import {
   summarizeSourceHealth,
   toSourceHealth,
   getSourceHealthRegistry,
+  invalidateSourceCache,
   SOURCE_HEALTH_THRESHOLDS,
   type SourceHealthInput,
   type SourceHealthSummary,
@@ -131,6 +132,7 @@ describe("toSourceHealth", () => {
     expect(summary.reliabilityScore).toBe(89); // rounded
     expect(summary.uptimePct).toBeCloseTo(98.5, 1);
     expect(summary.status).toBe("healthy");
+    expect(summary.cacheVersion).toBe(0);
   });
 
   it("flags stale when the last fetch is far in the past", () => {
@@ -151,11 +153,11 @@ describe("toSourceHealth", () => {
 describe("summarizeSourceHealth", () => {
   it("counts every status bucket", () => {
     const sources = [
-      { status: "healthy" },
-      { status: "healthy" },
-      { status: "degraded" },
-      { status: "unavailable" },
-    ] as SourceHealthSummary[];
+      { status: "healthy", cacheVersion: 1 } as SourceHealthSummary,
+      { status: "healthy", cacheVersion: 1 } as SourceHealthSummary,
+      { status: "degraded", cacheVersion: 1 } as SourceHealthSummary,
+      { status: "unavailable", cacheVersion: 1 } as SourceHealthSummary,
+    ];
     expect(summarizeSourceHealth(sources)).toEqual({
       healthy: 2,
       degraded: 1,
@@ -185,5 +187,37 @@ describe("getSourceHealthRegistry", () => {
         source.status,
       );
     }
+  });
+
+  it("exposes cacheVersion and cacheAge in diagnostics", async () => {
+    const registry = await getSourceHealthRegistry();
+    expect(typeof registry.cacheVersion).toBe("number");
+    expect(registry.cacheVersion).toBeGreaterThanOrEqual(1);
+    expect(typeof registry.cacheAge).toBe("number");
+    expect(registry.cacheAge).toBeGreaterThanOrEqual(0);
+
+    for (const source of registry.sources) {
+      expect(source.cacheVersion).toBe(registry.cacheVersion);
+    }
+  });
+
+  it("invalidateSourceCache increments cacheVersion", async () => {
+    const before = await getSourceHealthRegistry();
+    const versionBefore = before.cacheVersion;
+
+    invalidateSourceCache();
+
+    const after = await getSourceHealthRegistry();
+    expect(after.cacheVersion).toBeGreaterThan(versionBefore);
+  });
+
+  it("invalidateSourceCache with specific provider id refreshes version", async () => {
+    const before = await getSourceHealthRegistry();
+    const versionBefore = before.cacheVersion;
+
+    invalidateSourceCache("blend_api");
+
+    const after = await getSourceHealthRegistry();
+    expect(after.cacheVersion).toBeGreaterThan(versionBefore);
   });
 });

--- a/server/src/services/yieldSourceRegistryService.ts
+++ b/server/src/services/yieldSourceRegistryService.ts
@@ -11,6 +11,7 @@
  * than the engine's internal reliability tiers.
  */
 
+import NodeCache from "node-cache";
 import {
   yieldReliabilityEngine,
   type DataSourceReliability,
@@ -37,6 +38,7 @@ export interface SourceHealthSummary {
   consecutiveFailures: number;
   failureReason: string | null;
   trend: DataSourceReliability["trend"];
+  cacheVersion: number;
 }
 
 export interface SourceHealthRegistry {
@@ -44,6 +46,8 @@ export interface SourceHealthRegistry {
   totalSources: number;
   counts: Record<SourceHealthStatus, number>;
   sources: SourceHealthSummary[];
+  cacheVersion: number;
+  cacheAge: number;
 }
 
 // ── Classification thresholds ─────────────────────────────────────────────
@@ -174,6 +178,7 @@ export function toSourceHealth(
     consecutiveFailures: signals.consecutiveFailures,
     failureReason,
     trend: reliability.trend,
+    cacheVersion: 0,
   };
 }
 
@@ -205,22 +210,98 @@ const REGISTERED_SOURCES: Array<{ id: string; name: string; source: string }> =
     { id: "coingecko", name: "CoinGecko", source: "oracle" },
   ];
 
+// ── Bounded cache ─────────────────────────────────────────────────────────
+// Each registry entry is cached with a version number. When source metadata or
+// health status changes the affected entries are invalidated so the next read
+// produces fresh data.  The cache is bounded by TTL and maximum size.
+
+const CACHE_TTL_SECONDS = 5 * 60; // 5 minutes
+const CACHE_MAX_KEYS = 100;
+
+interface CacheEntry {
+  summary: SourceHealthSummary;
+  cachedAt: number;
+}
+
+const registryCache = new NodeCache({
+  stdTTL: CACHE_TTL_SECONDS,
+  maxKeys: CACHE_MAX_KEYS,
+  checkperiod: 120,
+});
+
+let globalCacheVersion = 1;
+
+function nextCacheVersion(): number {
+  globalCacheVersion += 1;
+  return globalCacheVersion;
+}
+
+/**
+ * Invalidate cache entries for one or all yield sources.
+ * Call this when source metadata or health status changes upstream.
+ *
+ * @param providerId - Optional specific provider to invalidate. Omitting
+ *                     invalidates the entire registry cache.
+ */
+export function invalidateSourceCache(providerId?: string): void {
+  if (providerId) {
+    registryCache.del(`registry:${providerId}`);
+  } else {
+    registryCache.flushAll();
+  }
+  nextCacheVersion();
+}
+
 /**
  * Read-only health registry for every registered yield data source.
+ * Results are cached with versioning and automatically invalidated on TTL
+ * expiry or when {@link invalidateSourceCache} is called.
  */
 export async function getSourceHealthRegistry(): Promise<SourceHealthRegistry> {
+  const now = Date.now();
+
+  // Attempt a full-registry cache hit.
+  const cachedRegistry = registryCache.get<{
+    sources: SourceHealthSummary[];
+    cachedAt: number;
+  }>("registry:full");
+  if (cachedRegistry) {
+    return {
+      generatedAt: new Date(now).toISOString(),
+      totalSources: cachedRegistry.sources.length,
+      counts: summarizeSourceHealth(cachedRegistry.sources),
+      sources: cachedRegistry.sources,
+      cacheVersion: globalCacheVersion,
+      cacheAge: Math.round((now - cachedRegistry.cachedAt) / 1000),
+    };
+  }
+
   const reliabilityScores =
     await yieldReliabilityEngine.getReliabilityScores(REGISTERED_SOURCES);
 
-  const now = Date.now();
   const sources = reliabilityScores
     .map((reliability) => toSourceHealth(reliability, now))
     .sort((a, b) => a.reliabilityScore - b.reliabilityScore);
+
+  // Assign cache version to each entry and store individually.
+  const version = globalCacheVersion;
+  for (const source of sources) {
+    source.cacheVersion = version;
+    registryCache.set(
+      `registry:${source.providerId}`,
+      { summary: source, cachedAt: now } satisfies CacheEntry,
+    );
+  }
+
+  // Store the full result for bulk reads.
+  registryCache.set("registry:full", { sources, cachedAt: now });
 
   return {
     generatedAt: new Date(now).toISOString(),
     totalSources: sources.length,
     counts: summarizeSourceHealth(sources),
     sources,
+    cacheVersion: version,
+    cacheAge: 0,
   };
 }


### PR DESCRIPTION
Closes #981

## Summary
- Added cache versioning for yield source registry entries with per-provider and full-registry caching backed by node-cache
- Exposed `cacheVersion` and `cacheAge` fields in the registry response for diagnostic visibility
- Added exported `invalidateSourceCache(providerId?)` function to invalidate affected records when source metadata or health status changes

## Testing
- Updated existing tests to assert the new `cacheVersion` field on source summaries
- Added tests verifying `cacheVersion` and `cacheAge` are exposed in diagnostics
- Added tests confirming `invalidateSourceCache` increments `cacheVersion` for both full and targeted invalidation