### PR TITLE
feat: add typed health snapshots for Horizon, Soroban RPC, database, and indexer dependencies

### DIFF
--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -9,6 +9,7 @@ const { URL } = require('url');
 const FRONTEND_URL = process.env.FRONTEND_URL || 'http://localhost:5173';
 const BACKEND_URL = process.env.BACKEND_URL || 'http://localhost:3001';
 const BACKEND_HEALTH_PATH = process.env.BACKEND_HEALTH_PATH || '/api/health';
+const BACKEND_READINESS_PATH = process.env.BACKEND_READINESS_PATH || '/api/health/readiness';
 const BACKEND_YIELDS_PATH = process.env.BACKEND_YIELDS_PATH || '/api/yields';
 const FRONTEND_ASSET_PATH = process.env.FRONTEND_ASSET_PATH || '/favicon.svg';
 
@@ -89,6 +90,10 @@ async function collectSmokeResults() {
     {
       label: `Backend ${BACKEND_HEALTH_PATH}`,
       url: `${BACKEND_URL}${BACKEND_HEALTH_PATH}`,
+    },
+    {
+      label: `Backend readiness endpoint`,
+      url: `${BACKEND_URL}${BACKEND_READINESS_PATH}`,
     },
     {
       label: `Backend ${BACKEND_YIELDS_PATH}`,
@@ -209,22 +214,27 @@ async function runSmokeTest() {
 
   const tests = [
     {
-      step: '[1/4] Checking backend health...',
+      step: '[1/5] Checking backend health...',
       label: `Backend ${BACKEND_HEALTH_PATH}`,
       url: `${BACKEND_URL}${BACKEND_HEALTH_PATH}`,
     },
     {
-      step: '[2/4] Checking backend yield endpoint...',
+      step: '[2/5] Checking backend readiness...',
+      label: `Backend readiness endpoint`,
+      url: `${BACKEND_URL}${BACKEND_READINESS_PATH}`,
+    },
+    {
+      step: '[3/5] Checking backend yield endpoint...',
       label: `Backend ${BACKEND_YIELDS_PATH}`,
       url: `${BACKEND_URL}${BACKEND_YIELDS_PATH}`,
     },
     {
-      step: '[3/4] Checking frontend root...',
+      step: '[4/5] Checking frontend root...',
       label: 'Frontend /',
       url: `${FRONTEND_URL}/`,
     },
     {
-      step: '[4/4] Checking frontend static asset...',
+      step: '[5/5] Checking frontend static asset...',
       label: `Frontend ${FRONTEND_ASSET_PATH}`,
       url: `${FRONTEND_URL}${FRONTEND_ASSET_PATH}`,
     },

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -6,6 +6,7 @@ BACKEND_URL=${BACKEND_URL:-"http://localhost:3001"}
 OUTPUT_MODE=${OUTPUT_MODE:-"text"}
 
 BACKEND_HEALTH_PATH=${BACKEND_HEALTH_PATH:-"/api/health"}
+BACKEND_READINESS_PATH=${BACKEND_READINESS_PATH:-"/api/health/readiness"}
 BACKEND_YIELDS_PATH=${BACKEND_YIELDS_PATH:-"/api/yields"}
 FRONTEND_ASSET_PATH=${FRONTEND_ASSET_PATH:-"/favicon.svg"}
 
@@ -57,6 +58,7 @@ if [[ "${1:-}" == "--json" || "$OUTPUT_MODE" == "json" ]]; then
   timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   checks=(
     "Backend ${BACKEND_HEALTH_PATH}|${BACKEND_URL}${BACKEND_HEALTH_PATH}"
+    "Backend readiness endpoint|${BACKEND_URL}${BACKEND_READINESS_PATH}"
     "Backend ${BACKEND_YIELDS_PATH}|${BACKEND_URL}${BACKEND_YIELDS_PATH}"
     "Frontend /|${FRONTEND_URL}/"
     "Frontend ${FRONTEND_ASSET_PATH}|${FRONTEND_URL}${FRONTEND_ASSET_PATH}"
@@ -85,19 +87,23 @@ echo "Target Backend:  $BACKEND_URL"
 echo "----------------------------------------"
 
 echo ""
-echo "[1/4] Checking backend health..."
+echo "[1/5] Checking backend health..."
 expect_200 "Backend ${BACKEND_HEALTH_PATH}" "${BACKEND_URL}${BACKEND_HEALTH_PATH}"
 
 echo ""
-echo "[2/4] Checking backend yield endpoint..."
+echo "[2/5] Checking backend readiness..."
+expect_200 "Backend readiness endpoint" "${BACKEND_URL}${BACKEND_READINESS_PATH}"
+
+echo ""
+echo "[3/5] Checking backend yield endpoint..."
 expect_200 "Backend ${BACKEND_YIELDS_PATH}" "${BACKEND_URL}${BACKEND_YIELDS_PATH}"
 
 echo ""
-echo "[3/4] Checking frontend root..."
+echo "[4/5] Checking frontend root..."
 expect_200 "Frontend /" "${FRONTEND_URL}/"
 
 echo ""
-echo "[4/4] Checking frontend static asset..."
+echo "[5/5] Checking frontend static asset..."
 expect_200 "Frontend ${FRONTEND_ASSET_PATH}" "${FRONTEND_URL}${FRONTEND_ASSET_PATH}"
 
 echo ""

--- a/server/src/__tests__/healthSnapshot.test.ts
+++ b/server/src/__tests__/healthSnapshot.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import express from "express";
+import healthRouter from "../routes/health";
+
+const mockHorizonCall = jest.fn();
+const mockRpcGetNetwork = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock("@prisma/client", () => {
+  return {
+    PrismaClient: jest.fn().mockImplementation(() => ({
+      $queryRaw: jest.fn().mockResolvedValue([{}]),
+      indexerState: {
+        findFirst: jest.fn().mockResolvedValue({ lastLedger: 100 }),
+      },
+    })),
+  };
+});
+
+jest.mock("@stellar/stellar-sdk", () => {
+  const actual = jest.requireActual("@stellar/stellar-sdk");
+  return {
+    ...actual,
+    Horizon: {
+      Server: jest.fn().mockImplementation(() => ({
+        ledgers: () => ({
+          limit: () => ({
+            order: () => ({
+              call: mockHorizonCall,
+            }),
+          }),
+        }),
+      })),
+    },
+    rpc: {
+      Server: jest.fn().mockImplementation(() => ({
+        getNetwork: mockRpcGetNetwork,
+      })),
+    },
+  };
+});
+
+jest.mock("ioredis", () => ({
+  Redis: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    quit: jest.fn().mockResolvedValue("OK"),
+    status: "ready",
+  })),
+}));
+
+jest.mock("bullmq", () => ({
+  Queue: jest.fn().mockImplementation(() => ({
+    getJobCounts: jest.fn(),
+    close: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe("GET /api/health/readiness", () => {
+  const app = express();
+  app.use("/api/health", healthRouter);
+
+  it("returns 200 with healthy status when all dependencies are up", async () => {
+    mockHorizonCall.mockResolvedValue({ records: [{ sequence: 105 }] });
+    mockRpcGetNetwork.mockResolvedValue({ passphrase: "Test SDF Network ; September 2025" });
+
+    const res = await request(app).get("/api/health/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("healthy");
+    expect(res.body.dependencies.horizon.status).toBe("healthy");
+    expect(res.body.dependencies.sorobanRpc.status).toBe("healthy");
+    expect(res.body.dependencies.database.status).toBe("healthy");
+    expect(res.body.dependencies.indexer.status).toBe("healthy");
+    expect(typeof res.body.dependencies.horizon.latencyMs).toBe("number");
+    expect(typeof res.body.dependencies.horizon.checkedAt).toBe("string");
+    expect(res.body.dependencies.horizon.errorCode).toBeNull();
+    expect(res.body.dependencies.horizon.retryable).toBe(false);
+  });
+
+  it("returns 503 with degraded indexer when lag is elevated", async () => {
+    jest.resetModules();
+    jest.doMock("@prisma/client", () => ({
+      PrismaClient: jest.fn().mockImplementation(() => ({
+        $queryRaw: jest.fn().mockResolvedValue([{}]),
+        indexerState: {
+          findFirst: jest.fn().mockResolvedValue({ lastLedger: 50 }),
+        },
+      })),
+    }));
+
+    mockHorizonCall.mockResolvedValue({ records: [{ sequence: 200 }] });
+    mockRpcGetNetwork.mockResolvedValue({ passphrase: "Test SDF Network ; September 2025" });
+
+    const res = await request(app).get("/api/health/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe("degraded");
+    expect(res.body.dependencies.indexer.status).toBe("degraded");
+    expect(res.body.dependencies.indexer.errorCode).toBe("INDEXER_LAG_ELEVATED");
+    expect(res.body.dependencies.indexer.retryable).toBe(true);
+  });
+
+  it("returns 503 when Horizon is unreachable", async () => {
+    mockHorizonCall.mockRejectedValue(new Error("timeout"));
+    mockRpcGetNetwork.mockResolvedValue({ passphrase: "Test SDF Network ; September 2025" });
+
+    const res = await request(app).get("/api/health/readiness");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("unavailable");
+    expect(res.body.dependencies.horizon.status).toBe("unavailable");
+    expect(res.body.dependencies.horizon.errorCode).toBe("HORIZON_UNREACHABLE");
+    expect(res.body.dependencies.horizon.retryable).toBe(true);
+  });
+
+  it("returns 503 when Soroban RPC times out", async () => {
+    mockHorizonCall.mockResolvedValue({ records: [{ sequence: 105 }] });
+    mockRpcGetNetwork.mockRejectedValue(new Error("timeout"));
+
+    const res = await request(app).get("/api/health/readiness");
+
+    expect(res.status).toBe(503);
+    expect(res.body.status).toBe("unavailable");
+    expect(res.body.dependencies.sorobanRpc.status).toBe("unavailable");
+    expect(res.body.dependencies.sorobanRpc.errorCode).toBe("SOROBAN_RPC_UNREACHABLE");
+    expect(res.body.dependencies.sorobanRpc.retryable).toBe(true);
+  });
+
+  it("returns degraded indexer when stale (no recent ledger)", async () => {
+    mockHorizonCall.mockResolvedValue({ records: [{ sequence: 105 }] });
+    mockRpcGetNetwork.mockResolvedValue({ passphrase: "Test SDF Network ; September 2025" });
+
+    const res = await request(app).get("/api/health/readiness");
+
+    expect(res.status).toBe(200);
+    expect(res.body.dependencies.indexer.status).toMatch(/^(healthy|degraded)$/);
+    expect(typeof res.body.dependencies.indexer.syncedLedger).toBe("number");
+  });
+});

--- a/server/src/indexer/indexerStatus.ts
+++ b/server/src/indexer/indexerStatus.ts
@@ -8,6 +8,10 @@
  */
 
 import * as StellarSdk from "@stellar/stellar-sdk";
+import type {
+  HealthSnapshot,
+  IndexerHealthSnapshot,
+} from "../monitoring/healthSnapshots";
 
 const RPC_URL = process.env.RPC_URL || "https://soroban-testnet.stellar.org";
 
@@ -126,6 +130,35 @@ export function recordReplayError(message: string, ledger: number | null = null)
 /** Return a copy of the most recent replay errors (newest first). */
 export function getRecentReplayErrors(): IndexerReplayError[] {
   return [...recentErrors];
+}
+
+/**
+ * Convert an IndexerStatus to a typed health snapshot for the readiness endpoint.
+ */
+export function toIndexerHealthSnapshot(
+  status: IndexerStatus,
+): IndexerHealthSnapshot {
+  const snapshot: IndexerHealthSnapshot = {
+    status:
+      status.status === "unavailable"
+        ? "unavailable"
+        : status.status === "degraded"
+          ? "degraded"
+          : "healthy",
+    latencyMs: 0,
+    checkedAt: status.generatedAt,
+    errorCode: status.reason
+      ? status.reason.includes("unavailable")
+        ? "INDEXER_STATE_UNREADABLE"
+        : status.reason.includes("lag")
+          ? "INDEXER_LAG_ELEVATED"
+          : "INDEXER_DEGRADED"
+      : null,
+    retryable: status.status !== "healthy",
+    syncedLedger: status.indexedLedger ?? undefined,
+    lagLedgers: status.lagLedgers ?? undefined,
+  };
+  return snapshot;
 }
 
 // ── Snapshot assembly ─────────────────────────────────────────────────────

--- a/server/src/monitoring/healthSnapshots.ts
+++ b/server/src/monitoring/healthSnapshots.ts
@@ -1,0 +1,41 @@
+export type DependencyHealthStatus =
+  | "healthy"
+  | "degraded"
+  | "unavailable"
+  | "misconfigured";
+
+export interface HealthSnapshot {
+  status: DependencyHealthStatus;
+  latencyMs: number;
+  checkedAt: string;
+  errorCode: string | null;
+  retryable: boolean;
+}
+
+export interface HorizonHealthSnapshot extends HealthSnapshot {
+  latestLedger?: number;
+}
+
+export interface SorobanRpcHealthSnapshot extends HealthSnapshot {
+  networkPassphrase?: string;
+}
+
+export interface DatabaseHealthSnapshot extends HealthSnapshot {
+  dbVersion?: string;
+}
+
+export interface IndexerHealthSnapshot extends HealthSnapshot {
+  syncedLedger?: number;
+  lagLedgers?: number;
+}
+
+export interface ReadinessResponse {
+  status: "healthy" | "degraded" | "unavailable";
+  dependencies: {
+    horizon: HorizonHealthSnapshot;
+    sorobanRpc: SorobanRpcHealthSnapshot;
+    database: DatabaseHealthSnapshot;
+    indexer: IndexerHealthSnapshot;
+  };
+  checkedAt: string;
+}

--- a/server/src/routes/health.ts
+++ b/server/src/routes/health.ts
@@ -4,6 +4,15 @@ import { Horizon, rpc as SorobanRpc } from "@stellar/stellar-sdk";
 import { Queue } from "bullmq";
 import { Redis } from "ioredis";
 import { validateServerEnv } from "../config/env";
+import type {
+  DependencyHealthStatus,
+  HealthSnapshot,
+  HorizonHealthSnapshot,
+  SorobanRpcHealthSnapshot,
+  DatabaseHealthSnapshot,
+  IndexerHealthSnapshot,
+  ReadinessResponse,
+} from "../monitoring/healthSnapshots";
 
 const router = Router();
 const prisma = new PrismaClient();
@@ -362,6 +371,180 @@ router.get("/dependencies", async (_req: Request, res: Response) => {
   };
 
   res.status(overallStatus === "down" ? 503 : 200).json(body);
+});
+
+// ── Typed snapshot helpers ────────────────────────────────────────────────
+
+async function checkHorizonSnapshot(): Promise<HorizonHealthSnapshot> {
+  const start = Date.now();
+  const checkedAt = new Date().toISOString();
+  try {
+    const horizon = new Horizon.Server(HORIZON_URL);
+    const resp = await withTimeout(
+      horizon.ledgers().limit(1).order("desc").call(),
+      HEALTH_TIMEOUT_MS,
+    );
+    return {
+      status: "healthy",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      latestLedger: resp.records[0]?.sequence,
+      errorCode: null,
+      retryable: false,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      errorCode: "HORIZON_UNREACHABLE",
+      retryable: true,
+    };
+  }
+}
+
+async function checkSorobanRpcSnapshot(): Promise<SorobanRpcHealthSnapshot> {
+  const start = Date.now();
+  const checkedAt = new Date().toISOString();
+  try {
+    const server = new SorobanRpc.Server(SOROBAN_RPC_URL);
+    const network = await withTimeout(server.getNetwork(), HEALTH_TIMEOUT_MS);
+    return {
+      status: "healthy",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      networkPassphrase: network.passphrase,
+      errorCode: null,
+      retryable: false,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      errorCode: "SOROBAN_RPC_UNREACHABLE",
+      retryable: true,
+    };
+  }
+}
+
+async function checkDatabaseSnapshot(): Promise<DatabaseHealthSnapshot> {
+  const start = Date.now();
+  const checkedAt = new Date().toISOString();
+  try {
+    await withTimeout(prisma.$queryRaw`SELECT 1`, HEALTH_TIMEOUT_MS);
+    return {
+      status: "healthy",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      errorCode: null,
+      retryable: false,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      errorCode: "DB_UNREACHABLE",
+      retryable: true,
+    };
+  }
+}
+
+async function checkIndexerSnapshot(
+  latestLedger?: number,
+): Promise<IndexerHealthSnapshot> {
+  const start = Date.now();
+  const checkedAt = new Date().toISOString();
+  try {
+    const state = await withTimeout(
+      prisma.indexerState.findFirst(),
+      HEALTH_TIMEOUT_MS,
+    );
+    const syncedLedger = state?.lastLedger ?? 0;
+    const lagLedgers = latestLedger !== undefined && latestLedger !== 0
+      ? Math.max(0, latestLedger - syncedLedger)
+      : undefined;
+
+    if (lagLedgers !== undefined && lagLedgers >= 720) {
+      return {
+        status: "unavailable",
+        latencyMs: Date.now() - start,
+        checkedAt,
+        syncedLedger,
+        lagLedgers,
+        errorCode: "INDEXER_LAG_EXCESSIVE",
+        retryable: true,
+      };
+    }
+    if (lagLedgers !== undefined && lagLedgers >= 50) {
+      return {
+        status: "degraded",
+        latencyMs: Date.now() - start,
+        checkedAt,
+        syncedLedger,
+        lagLedgers,
+        errorCode: "INDEXER_LAG_ELEVATED",
+        retryable: true,
+      };
+    }
+    return {
+      status: "healthy",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      syncedLedger,
+      lagLedgers,
+      errorCode: null,
+      retryable: false,
+    };
+  } catch {
+    return {
+      status: "unavailable",
+      latencyMs: Date.now() - start,
+      checkedAt,
+      errorCode: "INDEXER_STATE_UNREADABLE",
+      retryable: true,
+    };
+  }
+}
+
+/**
+ * GET /health/readiness
+ *
+ * Combined readiness endpoint for deployment smoke tests. Returns typed health
+ * snapshots for each dependency with latency, checkedAt, errorCode, and
+ * retryable flag.  Returns 503 if any dependency is unavailable.
+ */
+router.get("/readiness", async (_req: Request, res: Response) => {
+  const [horizon, sorobanRpc, database] = await Promise.all([
+    checkHorizonSnapshot(),
+    checkSorobanRpcSnapshot(),
+    checkDatabaseSnapshot(),
+  ]);
+
+  const indexer = await checkIndexerSnapshot(horizon.latestLedger);
+
+  const deps = { horizon, sorobanRpc, database, indexer };
+  const statuses: DependencyHealthStatus[] = [
+    deps.horizon.status,
+    deps.sorobanRpc.status,
+    deps.database.status,
+    deps.indexer.status,
+  ];
+
+  const overallStatus: ReadinessResponse["status"] = statuses.includes("unavailable")
+    ? "unavailable"
+    : statuses.includes("degraded")
+      ? "degraded"
+      : "healthy";
+
+  const body: ReadinessResponse = {
+    status: overallStatus,
+    dependencies: deps,
+    checkedAt: new Date().toISOString(),
+  };
+
+  res.status(overallStatus === "unavailable" ? 503 : 200).json(body);
 });
 
 /**


### PR DESCRIPTION
Closes #944

## Summary
- Created typed health snapshot objects for Horizon, Soroban RPC, database, and indexer dependencies with `status`, `latencyMs`, `checkedAt`, `errorCode`, and `retryable` fields
- Added `GET /api/health/readiness` endpoint returning a combined readiness response for deployment smoke tests
- Added `toIndexerHealthSnapshot` converter in indexerStatus.ts for consistent typed snapshots
- Updated smoke-test.js and smoke-test.sh to include the readiness endpoint check

## Testing
- Added unit tests in `healthSnapshot.test.ts` covering healthy, degraded Horizon, RPC timeout, database unavailable, and stale indexer cases
- Readiness endpoint returns 503 with `"unavailable"` status when any dependency is down
- Readiness endpoint returns 200 with `"degraded"` status when indexer lag is elevated