### PR TITLE
feat(client/rewards/charts): monotonic activity timeline ordering, rewards artifact manifest & APY stale-data indicators

### DIFF
--- a/backend/rewards/src/__tests__/generateTree.test.ts
+++ b/backend/rewards/src/__tests__/generateTree.test.ts
@@ -1,10 +1,14 @@
 import {
   calculateRewards,
   generateWeeklyDistribution,
+  generateWeeklyDistributionWithManifest,
   getUserProof,
+  buildArtifactManifest,
+  validateArtifactManifest,
   type UserRewardInput,
+  type RewardArtifactManifest,
 } from "../generateTree";
-import { verifyProof } from "../merkleTree";
+import { generateMerkleTree, verifyProof, type RewardEntry } from "../merkleTree";
 
 // ── calculateRewards ────────────────────────────────────────────────────
 
@@ -142,5 +146,224 @@ describe("getUserProof", () => {
     const proof = getUserProof("GNONEXISTENT", dist);
 
     expect(proof).toBeNull();
+  });
+});
+
+// ── buildArtifactManifest (#997) ────────────────────────────────────────
+
+describe("buildArtifactManifest", () => {
+  const entries: RewardEntry[] = [
+    { index: 0, address: "GADDR1", amount: "5000" },
+    { index: 1, address: "GADDR2", amount: "3000" },
+    { index: 2, address: "GADDR3", amount: "2000" },
+  ];
+  const result = generateMerkleTree(entries);
+  const fixedNow = new Date("2026-07-01T12:00:00.000Z");
+
+  it("manifest includes the correct merkleRoot", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: "1.0.0",
+      sourceCommit: "abc1234",
+    });
+    expect(manifest.merkleRoot).toBe(result.root);
+  });
+
+  it("manifest includes the correct campaignId", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: "1.0.0",
+      sourceCommit: "abc1234",
+    });
+    expect(manifest.campaignId).toBe("2026-W27");
+  });
+
+  it("manifest recipientCount equals entries length", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest.recipientCount).toBe(3);
+  });
+
+  it("manifest totalAmount is the sum of all entry amounts", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest.totalAmount).toBe("10000");
+  });
+
+  it("manifest generatedAt is the ISO timestamp of now", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest.generatedAt).toBe("2026-07-01T12:00:00.000Z");
+  });
+
+  it("manifest inputHash is a 64-char hex string", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest.inputHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("manifest inputHash changes when entries change", () => {
+    const manifest1 = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    const differentEntries: RewardEntry[] = [
+      { index: 0, address: "GADDR1", amount: "9000" },
+    ];
+    const differentResult = generateMerkleTree(differentEntries);
+    const manifest2 = buildArtifactManifest("2026-W27", differentEntries, differentResult, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest1.inputHash).not.toBe(manifest2.inputHash);
+  });
+
+  it("manifest toolVersion and sourceCommit are passed through from options", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: "2.3.1",
+      sourceCommit: "deadbeef",
+    });
+    expect(manifest.toolVersion).toBe("2.3.1");
+    expect(manifest.sourceCommit).toBe("deadbeef");
+  });
+
+  it("manifest toolVersion and sourceCommit are null when explicitly set to null", () => {
+    const manifest = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: null,
+      sourceCommit: null,
+    });
+    expect(manifest.toolVersion).toBeNull();
+    expect(manifest.sourceCommit).toBeNull();
+  });
+
+  it("manifest is deterministic: same inputs produce the same manifest", () => {
+    const opts = { now: fixedNow, toolVersion: "1.0.0", sourceCommit: "abc" };
+    const m1 = buildArtifactManifest("2026-W27", entries, result, opts);
+    const m2 = buildArtifactManifest("2026-W27", entries, result, opts);
+    expect(m1).toEqual(m2);
+  });
+});
+
+// ── validateArtifactManifest (#997) ─────────────────────────────────────
+
+describe("validateArtifactManifest", () => {
+  const entries: RewardEntry[] = [
+    { index: 0, address: "GADDR1", amount: "5000" },
+    { index: 1, address: "GADDR2", amount: "3000" },
+  ];
+  const result = generateMerkleTree(entries);
+  const fixedNow = new Date("2026-07-01T12:00:00.000Z");
+
+  function makeManifest(overrides: Partial<RewardArtifactManifest> = {}): RewardArtifactManifest {
+    const base = buildArtifactManifest("2026-W27", entries, result, {
+      now: fixedNow,
+      toolVersion: "1.0.0",
+      sourceCommit: "abc1234",
+    });
+    return { ...base, ...overrides };
+  }
+
+  it("returns null for a valid manifest", () => {
+    const manifest = makeManifest();
+    expect(validateArtifactManifest(manifest, entries, result)).toBeNull();
+  });
+
+  it("returns an error string when merkleRoot mismatches", () => {
+    const manifest = makeManifest({ merkleRoot: "f".repeat(64) });
+    const error = validateArtifactManifest(manifest, entries, result);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/merkleRoot mismatch/i);
+  });
+
+  it("returns an error string when inputHash mismatches", () => {
+    const manifest = makeManifest({ inputHash: "0".repeat(64) });
+    const error = validateArtifactManifest(manifest, entries, result);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/inputHash mismatch/i);
+  });
+
+  it("returns an error string when recipientCount mismatches", () => {
+    const manifest = makeManifest({ recipientCount: 99 });
+    const error = validateArtifactManifest(manifest, entries, result);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/recipientCount mismatch/i);
+  });
+
+  it("returns an error string when totalAmount mismatches", () => {
+    const manifest = makeManifest({ totalAmount: "1" });
+    const error = validateArtifactManifest(manifest, entries, result);
+    expect(error).not.toBeNull();
+    expect(error).toMatch(/totalAmount mismatch/i);
+  });
+});
+
+// ── generateWeeklyDistributionWithManifest (#997) ───────────────────────
+
+describe("generateWeeklyDistributionWithManifest", () => {
+  const users: UserRewardInput[] = [
+    { address: "GADDR1", shares: "500", totalShares: "1000" },
+    { address: "GADDR2", shares: "500", totalShares: "1000" },
+  ];
+  const fixedNow = new Date("2026-07-01T12:00:00.000Z");
+
+  it("returns result and manifest with matching root", () => {
+    const { result, manifest } = generateWeeklyDistributionWithManifest(
+      "2026-W27",
+      users,
+      "10000",
+      { now: fixedNow, toolVersion: null, sourceCommit: null },
+    );
+    expect(manifest.merkleRoot).toBe(result.root);
+  });
+
+  it("manifest validates successfully against its own result", () => {
+    const entries = [
+      { index: 0, address: "GADDR1", amount: "5000" },
+      { index: 1, address: "GADDR2", amount: "5000" },
+    ];
+    const { result, manifest } = generateWeeklyDistributionWithManifest(
+      "2026-W27",
+      users,
+      "10000",
+      { now: fixedNow, toolVersion: null, sourceCommit: null },
+    );
+    expect(validateArtifactManifest(manifest, entries, result)).toBeNull();
+  });
+
+  it("manifest has the correct campaignId", () => {
+    const { manifest } = generateWeeklyDistributionWithManifest(
+      "2026-W27",
+      users,
+      "10000",
+      { now: fixedNow, toolVersion: null, sourceCommit: null },
+    );
+    expect(manifest.campaignId).toBe("2026-W27");
+  });
+
+  it("manifest totalAmount equals totalWeeklyReward for equal shares", () => {
+    const { manifest } = generateWeeklyDistributionWithManifest(
+      "2026-W27",
+      users,
+      "10000",
+      { now: fixedNow, toolVersion: null, sourceCommit: null },
+    );
+    // 2 users with equal shares get 5000 each → total 10000
+    expect(manifest.totalAmount).toBe("10000");
   });
 });

--- a/backend/rewards/src/generateTree.ts
+++ b/backend/rewards/src/generateTree.ts
@@ -1,3 +1,5 @@
+import { createHash } from "crypto";
+import { execSync } from "child_process";
 import {
   generateMerkleTree,
   verifyProof,
@@ -17,6 +19,160 @@ export interface UserRewardInput {
   shares: string;
   /** Total vault shares. */
   totalShares: string;
+}
+
+// ─── Artifact Manifest (#997) ─────────────────────────────────────────────────
+
+/**
+ * Provenance manifest attached to a generated reward artifact.
+ * Records exactly which inputs produced a given Merkle root so that
+ * maintainers (and auditors) can re-derive the root from the raw inputs
+ * and confirm it matches. The manifest is meant to be stored alongside
+ * the distribution artifact (e.g. written to the same output directory).
+ */
+export interface RewardArtifactManifest {
+  /** Unique identifier for the distribution campaign (e.g. "2026-W22"). */
+  campaignId: string;
+  /** The Merkle root that was produced from the inputs below. */
+  merkleRoot: string;
+  /**
+   * SHA-256 hex digest of the canonical JSON representation of the input
+   * RewardEntry array (sorted by index, serialised as
+   * `JSON.stringify(entries)`). Anyone with the original input file can
+   * recompute this hash and compare it to detect tampering.
+   */
+  inputHash: string;
+  /** Total number of recipients included in this distribution. */
+  recipientCount: number;
+  /** Sum of all reward amounts (in stroops) as a string to avoid precision loss. */
+  totalAmount: string;
+  /** ISO-8601 UTC timestamp when the artifact was generated. */
+  generatedAt: string;
+  /**
+   * Semantic version of the rewards tool that produced this artifact.
+   * Sourced from package.json at generation time when available.
+   */
+  toolVersion: string | null;
+  /**
+   * Short SHA of the git commit that was checked out when the artifact was
+   * generated. Null when not inside a git repository or when git is
+   * unavailable.
+   */
+  sourceCommit: string | null;
+}
+
+/** Options for artifact manifest generation. */
+export interface GenerateManifestOptions {
+  /** Override the current UTC timestamp (useful in tests). */
+  now?: Date;
+  /** Override the tool version (defaults to package.json version). */
+  toolVersion?: string | null;
+  /** Override the source commit (defaults to `git rev-parse --short HEAD`). */
+  sourceCommit?: string | null;
+}
+
+/**
+ * Read the package version from `package.json` in this workspace.
+ * Returns null if the file cannot be read or has no version field.
+ */
+function readToolVersion(): string | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require("../../package.json") as { version?: unknown };
+    return typeof pkg.version === "string" ? pkg.version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Retrieve the short git commit SHA for the current HEAD.
+ * Returns null when not inside a git repository or git is unavailable.
+ */
+function readSourceCommit(): string | null {
+  try {
+    return execSync("git rev-parse --short HEAD", { stdio: ["ignore", "pipe", "ignore"] })
+      .toString()
+      .trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute the SHA-256 input hash over the canonical JSON of the entries.
+ * The canonical form is `JSON.stringify(entries)` where entries are passed
+ * as-is (callers should ensure they are sorted by index for reproducibility).
+ */
+function computeInputHash(entries: RewardEntry[]): string {
+  return createHash("sha256")
+    .update(JSON.stringify(entries))
+    .digest("hex");
+}
+
+/**
+ * Build a provenance manifest for a reward distribution artifact.
+ *
+ * @param campaignId - Stable campaign identifier (e.g. "2026-W22").
+ * @param entries    - The exact RewardEntry array that was fed to `generateMerkleTree`.
+ * @param result     - The MerkleTreeResult returned by `generateMerkleTree`.
+ * @param options    - Optional overrides for timestamp, version, and commit.
+ */
+export function buildArtifactManifest(
+  campaignId: string,
+  entries: RewardEntry[],
+  result: MerkleTreeResult,
+  options: GenerateManifestOptions = {},
+): RewardArtifactManifest {
+  const totalAmount = entries
+    .reduce((sum, e) => sum + BigInt(e.amount), BigInt(0))
+    .toString();
+
+  return {
+    campaignId,
+    merkleRoot: result.root,
+    inputHash: computeInputHash(entries),
+    recipientCount: entries.length,
+    totalAmount,
+    generatedAt: (options.now ?? new Date()).toISOString(),
+    toolVersion: "toolVersion" in options ? (options.toolVersion ?? null) : readToolVersion(),
+    sourceCommit: "sourceCommit" in options ? (options.sourceCommit ?? null) : readSourceCommit(),
+  };
+}
+
+/**
+ * Validate an existing manifest against a set of RewardEntries and a
+ * MerkleTreeResult.  Returns null on success or a human-readable error
+ * string describing the first violation found.
+ *
+ * Use this as the basis of the `validate-manifest` CLI command (see index.ts).
+ */
+export function validateArtifactManifest(
+  manifest: RewardArtifactManifest,
+  entries: RewardEntry[],
+  result: MerkleTreeResult,
+): string | null {
+  if (manifest.merkleRoot !== result.root) {
+    return `merkleRoot mismatch: manifest has "${manifest.merkleRoot}" but computed root is "${result.root}"`;
+  }
+
+  const expectedInputHash = computeInputHash(entries);
+  if (manifest.inputHash !== expectedInputHash) {
+    return `inputHash mismatch: manifest has "${manifest.inputHash}" but computed hash is "${expectedInputHash}"`;
+  }
+
+  if (manifest.recipientCount !== entries.length) {
+    return `recipientCount mismatch: manifest has ${manifest.recipientCount} but entries has ${entries.length}`;
+  }
+
+  const expectedTotal = entries
+    .reduce((sum, e) => sum + BigInt(e.amount), BigInt(0))
+    .toString();
+  if (manifest.totalAmount !== expectedTotal) {
+    return `totalAmount mismatch: manifest has "${manifest.totalAmount}" but computed total is "${expectedTotal}"`;
+  }
+
+  return null;
 }
 
 /**
@@ -71,6 +227,29 @@ export function generateWeeklyDistribution(
 ): MerkleTreeResult {
   const entries = calculateRewards(users, totalWeeklyReward);
   return generateMerkleTree(entries);
+}
+
+/**
+ * Full pipeline with provenance: calculate rewards, generate Merkle tree,
+ * and attach a manifest recording the campaign, input hash, totals, and
+ * tool/commit metadata.
+ *
+ * @param campaignId        - Stable campaign identifier (e.g. "2026-W22").
+ * @param users             - Array of user share balances.
+ * @param totalWeeklyReward - Total $YIELD to distribute in stroops.
+ * @param options           - Optional overrides for manifest fields.
+ * @returns The tree result and its provenance manifest.
+ */
+export function generateWeeklyDistributionWithManifest(
+  campaignId: string,
+  users: UserRewardInput[],
+  totalWeeklyReward: string,
+  options: GenerateManifestOptions = {},
+): { result: MerkleTreeResult; manifest: RewardArtifactManifest } {
+  const entries = calculateRewards(users, totalWeeklyReward);
+  const result = generateMerkleTree(entries);
+  const manifest = buildArtifactManifest(campaignId, entries, result, options);
+  return { result, manifest };
 }
 
 /**

--- a/backend/rewards/src/index.ts
+++ b/backend/rewards/src/index.ts
@@ -19,9 +19,16 @@ export type {
 export {
   calculateRewards,
   generateWeeklyDistribution,
+  generateWeeklyDistributionWithManifest,
   getUserProof,
+  buildArtifactManifest,
+  validateArtifactManifest,
 } from "./generateTree";
-export type { UserRewardInput } from "./generateTree";
+export type {
+  UserRewardInput,
+  RewardArtifactManifest,
+  GenerateManifestOptions,
+} from "./generateTree";
 
 export {
   summarizeRewardScheduleHealth,

--- a/client/src/components/charts/ApyHistoryChart.tsx
+++ b/client/src/components/charts/ApyHistoryChart.tsx
@@ -1,26 +1,38 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, Clock, RefreshCw } from "lucide-react";
 import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 import { apiUrl } from "../../lib/api";
+import { computeDecayedFreshnessConfidence } from "../dashboard/freshnessDecay";
 
 type TimeRange = "1W" | "1M" | "All";
+
+/** Threshold (ms) beyond which an APY sample is considered stale. Matches ApyDashboard convention. */
+const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 interface HistoricalApyPoint {
   date: string;
   apy: number;
+  /** ISO-8601 timestamp when this data point was fetched from the source. */
+  fetchedAt?: string;
+  /** Computed freshness confidence [0, 1]; populated during normalisation. */
+  freshnessConfidence?: number;
+  /** True when the point is considered unusable due to age. */
+  stale?: boolean;
 }
 
 interface ApiHistoryPoint {
   date?: unknown;
   apy?: unknown;
+  fetchedAt?: unknown;
 }
 
 function formatAxisDate(date: string) {
@@ -45,7 +57,13 @@ function filterHistory(history: HistoricalApyPoint[], range: TimeRange) {
 
 const rangeOptions: TimeRange[] = ["1W", "1M", "All"];
 
-function normalizeHistoryPoint(point: ApiHistoryPoint): HistoricalApyPoint | null {
+function normalizeFetchedAt(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : value;
+}
+
+function normalizeHistoryPoint(point: ApiHistoryPoint, now = Date.now()): HistoricalApyPoint | null {
   if (typeof point.date !== "string") {
     return null;
   }
@@ -60,7 +78,124 @@ function normalizeHistoryPoint(point: ApiHistoryPoint): HistoricalApyPoint | nul
     return null;
   }
 
-  return { date: point.date, apy };
+  const fetchedAt = normalizeFetchedAt(point.fetchedAt);
+  const fetchedTime = fetchedAt ? new Date(fetchedAt).getTime() : now;
+  const ageMs = now - fetchedTime;
+  const { confidence, unusable } = computeDecayedFreshnessConfidence(ageMs);
+
+  return {
+    date: point.date,
+    apy,
+    fetchedAt,
+    freshnessConfidence: confidence,
+    stale: unusable || ageMs > STALE_THRESHOLD_MS,
+  };
+}
+
+// ── Source health summary for tooltip (#1005) ─────────────────────────────────
+
+interface SourceHealthSummary {
+  /** Number of data points in the visible range. */
+  total: number;
+  /** Number of stale points. */
+  staleCount: number;
+  /** Average freshness confidence across all points (0–1). */
+  avgConfidence: number;
+  /** True when every visible point is stale beyond the threshold. */
+  allStale: boolean;
+}
+
+function computeSourceHealth(points: HistoricalApyPoint[]): SourceHealthSummary {
+  if (points.length === 0) {
+    return { total: 0, staleCount: 0, avgConfidence: 0, allStale: false };
+  }
+  const staleCount = points.filter((p) => p.stale).length;
+  const avgConfidence =
+    points.reduce((sum, p) => sum + (p.freshnessConfidence ?? 1), 0) / points.length;
+  return {
+    total: points.length,
+    staleCount,
+    avgConfidence,
+    allStale: staleCount === points.length,
+  };
+}
+
+// ── Custom Tooltip with source health metadata (#1005) ────────────────────────
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: HistoricalApyPoint }>;
+  label?: string;
+  sourceHealth: SourceHealthSummary;
+}
+
+function CustomTooltip({ active, payload, label, sourceHealth }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0].payload;
+  const apy = payload[0].value;
+  const confidence = point.freshnessConfidence ?? 1;
+  const isStale = point.stale ?? false;
+
+  const fetchedAgo = point.fetchedAt
+    ? Math.max(0, Math.round((Date.now() - new Date(point.fetchedAt).getTime()) / 60_000))
+    : null;
+
+  const dateLabel = label
+    ? new Date(label).toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
+
+  return (
+    <div
+      style={{
+        backgroundColor: "rgba(15, 23, 42, 0.94)",
+        border: "1px solid rgba(148, 163, 184, 0.2)",
+        borderRadius: "16px",
+        boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
+        padding: "12px 16px",
+        minWidth: 200,
+      }}
+    >
+      <p style={{ color: "#94a3b8", fontSize: 12, marginBottom: 6 }}>{dateLabel}</p>
+      <p style={{ color: "#6C5DD3", fontWeight: 700, fontSize: 16, marginBottom: 4 }}>
+        {apy.toFixed(2)}% APY
+      </p>
+
+      {/* Per-point freshness */}
+      {isStale ? (
+        <p style={{ color: "#f87171", fontSize: 11, display: "flex", alignItems: "center", gap: 4 }}>
+          ⚠ Stale sample
+          {fetchedAgo !== null && ` · fetched ${fetchedAgo}m ago`}
+        </p>
+      ) : (
+        <p style={{ color: "#86efac", fontSize: 11 }}>
+          ✓ Fresh · {Math.round(confidence * 100)}% confidence
+          {fetchedAgo !== null && ` · ${fetchedAgo}m ago`}
+        </p>
+      )}
+
+      {/* Source health summary */}
+      <div style={{ borderTop: "1px solid rgba(148,163,184,0.15)", marginTop: 8, paddingTop: 8 }}>
+        <p style={{ color: "#94a3b8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2 }}>
+          Series health
+        </p>
+        <p style={{ color: "#94a3b8", fontSize: 11 }}>
+          {sourceHealth.staleCount}/{sourceHealth.total} stale points
+        </p>
+        <p style={{ color: "#94a3b8", fontSize: 11 }}>
+          Avg confidence: {Math.round(sourceHealth.avgConfidence * 100)}%
+        </p>
+        {sourceHealth.allStale && (
+          <p style={{ color: "#f87171", fontSize: 11, marginTop: 2 }}>All series data is stale</p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export default function ApyHistoryChart() {
@@ -85,8 +220,9 @@ export default function ApyHistoryChart() {
 
       const raw = await response.json();
       const rows = Array.isArray(raw) ? raw : [];
+      const now = Date.now();
       const normalized = rows
-        .map((row) => normalizeHistoryPoint(row as ApiHistoryPoint))
+        .map((row) => normalizeHistoryPoint(row as ApiHistoryPoint, now))
         .filter((point): point is HistoricalApyPoint => point !== null)
         .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
       setHistory(normalized);
@@ -108,6 +244,17 @@ export default function ApyHistoryChart() {
   const filteredHistory = useMemo(
     () => filterHistory(history, range),
     [history, range],
+  );
+
+  const sourceHealth = useMemo(
+    () => computeSourceHealth(filteredHistory),
+    [filteredHistory],
+  );
+
+  // Indices of stale points — used to render ReferenceLine stale markers
+  const stalePointDates = useMemo(
+    () => filteredHistory.filter((p) => p.stale).map((p) => p.date),
+    [filteredHistory],
   );
 
   return (
@@ -138,6 +285,35 @@ export default function ApyHistoryChart() {
         </div>
       </div>
 
+      {/* Stale series banner — shown when every visible point is stale (#1005) */}
+      {!loading && !error && sourceHealth.allStale && filteredHistory.length > 0 && (
+        <div
+          className="mb-4 flex items-center gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-300"
+          role="status"
+          aria-label="All APY history data is stale"
+          data-testid="apy-history-all-stale-banner"
+        >
+          <AlertTriangle size={16} aria-hidden="true" />
+          <span>All visible data is stale. Chart may not reflect current market conditions.</span>
+        </div>
+      )}
+
+      {/* Partial stale banner — some but not all points are stale */}
+      {!loading && !error && !sourceHealth.allStale && sourceHealth.staleCount > 0 && filteredHistory.length > 0 && (
+        <div
+          className="mb-4 flex items-center gap-2 rounded-xl border border-yellow-500/20 bg-yellow-500/5 p-2.5 text-xs text-yellow-300"
+          role="status"
+          aria-label={`${sourceHealth.staleCount} of ${sourceHealth.total} APY history points are stale`}
+          data-testid="apy-history-partial-stale-banner"
+        >
+          <Clock size={14} aria-hidden="true" />
+          <span>
+            {sourceHealth.staleCount} of {sourceHealth.total} data points are stale ·{" "}
+            avg. confidence {Math.round(sourceHealth.avgConfidence * 100)}%
+          </span>
+        </div>
+      )}
+
       <div className="h-[320px] w-full sm:h-[360px]">
         {loading ? (
           <div className="h-full w-full rounded-lg border border-white/10 bg-white/[0.02] p-5">
@@ -162,6 +338,18 @@ export default function ApyHistoryChart() {
               <RefreshCw size={14} className={retrying ? "animate-spin" : ""} />
               Retry
             </button>
+          </div>
+        ) : sourceHealth.allStale && filteredHistory.length > 0 ? (
+          /* All-stale empty state (#1005) */
+          <div
+            className="h-full w-full rounded-lg border border-amber-500/30 bg-amber-500/10 px-6 py-8 flex flex-col items-center justify-center text-center"
+            data-testid="apy-history-all-stale-empty"
+          >
+            <AlertTriangle size={24} className="text-amber-300 mb-3" />
+            <p className="text-amber-200 font-semibold">All APY history is stale</p>
+            <p className="text-amber-300/80 text-sm mt-1 max-w-sm">
+              Source data has not been refreshed within the expected window. Chart may not reflect current market conditions.
+            </p>
           </div>
         ) : filteredHistory.length === 0 ? (
           <div className="h-full w-full rounded-lg border border-white/10 bg-white/[0.02] px-6 py-8 flex flex-col items-center justify-center text-center">
@@ -198,22 +386,21 @@ export default function ApyHistoryChart() {
                 tickLine={false}
                 width={54}
               />
+
+              {/* Stale sample markers — vertical reference lines at each stale date (#1005) */}
+              {stalePointDates.map((date) => (
+                <ReferenceLine
+                  key={date}
+                  x={date}
+                  stroke="rgba(251, 191, 36, 0.35)"
+                  strokeWidth={1}
+                  strokeDasharray="3 3"
+                  aria-label={`Stale data point at ${date}`}
+                />
+              ))}
+
               <Tooltip
-                formatter={(value: number) => [`${value.toFixed(2)}%`, "APY"]}
-                labelFormatter={(label) =>
-                  new Date(label).toLocaleDateString("en-US", {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                    year: "numeric",
-                  })
-                }
-                contentStyle={{
-                  backgroundColor: "rgba(15, 23, 42, 0.94)",
-                  border: "1px solid rgba(148, 163, 184, 0.2)",
-                  borderRadius: "16px",
-                  boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
-                }}
+                content={<CustomTooltip sourceHealth={sourceHealth} />}
                 cursor={{ stroke: "rgba(108, 93, 211, 0.6)", strokeWidth: 1 }}
               />
               <Line
@@ -221,7 +408,28 @@ export default function ApyHistoryChart() {
                 dataKey="apy"
                 stroke="#6C5DD3"
                 strokeWidth={3}
-                dot={{ r: 0 }}
+                dot={(props) => {
+                  const { cx, cy, payload } = props as {
+                    cx: number;
+                    cy: number;
+                    payload: HistoricalApyPoint;
+                  };
+                  if (payload.stale) {
+                    return (
+                      <circle
+                        key={`stale-dot-${payload.date}`}
+                        cx={cx}
+                        cy={cy}
+                        r={4}
+                        fill="rgba(251, 191, 36, 0.7)"
+                        stroke="rgba(251, 191, 36, 0.9)"
+                        strokeWidth={1.5}
+                        aria-label={`Stale APY sample on ${payload.date}`}
+                      />
+                    );
+                  }
+                  return <circle key={`dot-${payload.date}`} cx={cx} cy={cy} r={0} fill="none" />;
+                }}
                 activeDot={{
                   r: 5,
                   stroke: "#ffffff",

--- a/client/src/components/charts/__tests__/ApyHistoryStaleIndicators.test.tsx
+++ b/client/src/components/charts/__tests__/ApyHistoryStaleIndicators.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * ApyHistoryStaleIndicators.test.tsx — Issue #1005
+ *
+ * Tests for stale-data indicators in ApyHistoryChart:
+ *
+ * 1. Recent data (fresh fetchedAt) → no stale banner shown.
+ * 2. All data stale beyond threshold → all-stale empty state shown.
+ * 3. Mixed data (some stale, some fresh) → partial stale banner shown.
+ * 4. fetchedAt missing → treated as fresh (no stale indicator).
+ * 5. Chart renders normally alongside partial stale banner (not hidden).
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ApyHistoryChart from "../ApyHistoryChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="chart-container">{children}</div>
+  ),
+  LineChart: ({ children }: { children: ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  CartesianGrid: () => <div data-testid="grid" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Line: () => <div data-testid="line" />,
+  ReferenceLine: ({ x }: { x: string }) => (
+    <div data-testid="stale-reference-line" data-date={x} />
+  ),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+/** Returns an ISO timestamp that is `minutesAgo` minutes in the past. */
+function minutesAgo(n: number): string {
+  return new Date(Date.now() - n * 60_000).toISOString();
+}
+
+describe("ApyHistoryChart — stale-data indicators (#1005)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("1. fresh data (recent fetchedAt) → no stale banner shown, chart renders", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0, fetchedAt: minutesAgo(1) },
+        { date: "2026-06-02", apy: 8.5, fetchedAt: minutesAgo(2) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-partial-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+  });
+
+  it("2. all data stale → all-stale empty state shown instead of chart", async () => {
+    // fetchedAt is 60 minutes ago → well beyond the 5-minute stale threshold
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0, fetchedAt: minutesAgo(60) },
+        { date: "2026-06-02", apy: 8.5, fetchedAt: minutesAgo(60) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("apy-history-all-stale-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+    expect(screen.queryByText(/No APY history points available/i)).not.toBeInTheDocument();
+  });
+
+  it("3. mixed freshness → partial stale banner shown alongside chart", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 7.0, fetchedAt: minutesAgo(60) }, // stale
+        { date: "2026-06-02", apy: 8.0, fetchedAt: minutesAgo(1) },  // fresh
+        { date: "2026-06-03", apy: 9.0, fetchedAt: minutesAgo(2) },  // fresh
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    // Chart should still render
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    // Partial stale banner should appear
+    expect(screen.getByTestId("apy-history-partial-stale-banner")).toBeInTheDocument();
+    // All-stale states should NOT appear
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+  });
+
+  it("4. fetchedAt missing → treated as fresh, no stale indicator", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0 },  // no fetchedAt
+        { date: "2026-06-02", apy: 8.5 },  // no fetchedAt
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-partial-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+  });
+
+  it("5. partial stale banner includes stale count and total point count", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 6.0, fetchedAt: minutesAgo(60) }, // stale
+        { date: "2026-06-02", apy: 7.0, fetchedAt: minutesAgo(1) },  // fresh
+        { date: "2026-06-03", apy: 8.0, fetchedAt: minutesAgo(1) },  // fresh
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    const banner = await screen.findByTestId("apy-history-partial-stale-banner");
+    expect(banner).toBeInTheDocument();
+    // Banner text should mention 1 stale out of 3 points
+    expect(banner.textContent).toMatch(/1 of 3/);
+  });
+
+  it("6. stale reference lines rendered for each stale point", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 7.0, fetchedAt: minutesAgo(60) }, // stale
+        { date: "2026-06-02", apy: 8.0, fetchedAt: minutesAgo(1) },  // fresh
+        { date: "2026-06-03", apy: 7.5, fetchedAt: minutesAgo(60) }, // stale
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    await screen.findByTestId("line-chart");
+    const refLines = screen.getAllByTestId("stale-reference-line");
+    expect(refLines).toHaveLength(2);
+    expect(refLines[0]).toHaveAttribute("data-date", "2026-06-01");
+    expect(refLines[1]).toHaveAttribute("data-date", "2026-06-03");
+  });
+
+  it("7. empty API response still shows empty state, not stale state", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByText(/No APY history points available/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+  });
+
+  it("8. HTTP error → error UI shown, not stale UI", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByText(/Unable to load APY history/i)).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/charts_v2/ApyHistoryChart.tsx
+++ b/client/src/components/charts_v2/ApyHistoryChart.tsx
@@ -1,26 +1,38 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, RefreshCw } from "lucide-react";
+import { AlertTriangle, Clock, RefreshCw } from "lucide-react";
 import {
   CartesianGrid,
   Line,
   LineChart,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
 import { apiUrl } from "../../lib/api";
+import { computeDecayedFreshnessConfidence } from "../dashboard/freshnessDecay";
 
 type TimeRange = "1W" | "1M" | "All";
+
+/** Threshold (ms) beyond which an APY sample is considered stale. */
+const STALE_THRESHOLD_MS = 5 * 60 * 1000; // 5 minutes
 
 interface HistoricalApyPoint {
   date: string;
   apy: number;
+  /** ISO-8601 timestamp when this data point was fetched from the source. */
+  fetchedAt?: string;
+  /** Computed freshness confidence [0, 1]; populated during normalisation. */
+  freshnessConfidence?: number;
+  /** True when the point is considered unusable due to age. */
+  stale?: boolean;
 }
 
 interface ApiHistoryPoint {
   date?: unknown;
   apy?: unknown;
+  fetchedAt?: unknown;
 }
 
 function formatAxisDate(date: string) {
@@ -45,7 +57,13 @@ function filterHistory(history: HistoricalApyPoint[], range: TimeRange) {
 
 const rangeOptions: TimeRange[] = ["1W", "1M", "All"];
 
-function normalizeHistoryPoint(point: ApiHistoryPoint): HistoricalApyPoint | null {
+function normalizeFetchedAt(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : value;
+}
+
+function normalizeHistoryPoint(point: ApiHistoryPoint, now = Date.now()): HistoricalApyPoint | null {
   if (typeof point.date !== "string") {
     return null;
   }
@@ -60,7 +78,111 @@ function normalizeHistoryPoint(point: ApiHistoryPoint): HistoricalApyPoint | nul
     return null;
   }
 
-  return { date: point.date, apy };
+  const fetchedAt = normalizeFetchedAt(point.fetchedAt);
+  const fetchedTime = fetchedAt ? new Date(fetchedAt).getTime() : now;
+  const ageMs = now - fetchedTime;
+  const { confidence, unusable } = computeDecayedFreshnessConfidence(ageMs);
+
+  return {
+    date: point.date,
+    apy,
+    fetchedAt,
+    freshnessConfidence: confidence,
+    stale: unusable || ageMs > STALE_THRESHOLD_MS,
+  };
+}
+
+interface SourceHealthSummary {
+  total: number;
+  staleCount: number;
+  avgConfidence: number;
+  allStale: boolean;
+}
+
+function computeSourceHealth(points: HistoricalApyPoint[]): SourceHealthSummary {
+  if (points.length === 0) {
+    return { total: 0, staleCount: 0, avgConfidence: 0, allStale: false };
+  }
+  const staleCount = points.filter((p) => p.stale).length;
+  const avgConfidence =
+    points.reduce((sum, p) => sum + (p.freshnessConfidence ?? 1), 0) / points.length;
+  return {
+    total: points.length,
+    staleCount,
+    avgConfidence,
+    allStale: staleCount === points.length,
+  };
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: HistoricalApyPoint }>;
+  label?: string;
+  sourceHealth: SourceHealthSummary;
+}
+
+function CustomTooltip({ active, payload, label, sourceHealth }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+
+  const point = payload[0].payload;
+  const apy = payload[0].value;
+  const confidence = point.freshnessConfidence ?? 1;
+  const isStale = point.stale ?? false;
+
+  const fetchedAgo = point.fetchedAt
+    ? Math.max(0, Math.round((Date.now() - new Date(point.fetchedAt).getTime()) / 60_000))
+    : null;
+
+  const dateLabel = label
+    ? new Date(label).toLocaleDateString("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : "";
+
+  return (
+    <div
+      style={{
+        backgroundColor: "rgba(15, 23, 42, 0.94)",
+        border: "1px solid rgba(148, 163, 184, 0.2)",
+        borderRadius: "16px",
+        boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
+        padding: "12px 16px",
+        minWidth: 200,
+      }}
+    >
+      <p style={{ color: "#94a3b8", fontSize: 12, marginBottom: 6 }}>{dateLabel}</p>
+      <p style={{ color: "#6C5DD3", fontWeight: 700, fontSize: 16, marginBottom: 4 }}>
+        {apy.toFixed(2)}% APY
+      </p>
+      {isStale ? (
+        <p style={{ color: "#f87171", fontSize: 11 }}>
+          ⚠ Stale sample{fetchedAgo !== null && ` · fetched ${fetchedAgo}m ago`}
+        </p>
+      ) : (
+        <p style={{ color: "#86efac", fontSize: 11 }}>
+          ✓ Fresh · {Math.round(confidence * 100)}% confidence
+          {fetchedAgo !== null && ` · ${fetchedAgo}m ago`}
+        </p>
+      )}
+      <div style={{ borderTop: "1px solid rgba(148,163,184,0.15)", marginTop: 8, paddingTop: 8 }}>
+        <p style={{ color: "#94a3b8", fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2 }}>
+          Series health
+        </p>
+        <p style={{ color: "#94a3b8", fontSize: 11 }}>
+          {sourceHealth.staleCount}/{sourceHealth.total} stale points
+        </p>
+        <p style={{ color: "#94a3b8", fontSize: 11 }}>
+          Avg confidence: {Math.round(sourceHealth.avgConfidence * 100)}%
+        </p>
+        {sourceHealth.allStale && (
+          <p style={{ color: "#f87171", fontSize: 11, marginTop: 2 }}>All series data is stale</p>
+        )}
+      </div>
+    </div>
+  );
 }
 
 export default function ApyHistoryChart() {
@@ -85,8 +207,9 @@ export default function ApyHistoryChart() {
 
       const raw = await response.json();
       const rows = Array.isArray(raw) ? raw : [];
+      const now = Date.now();
       const normalized = rows
-        .map((row) => normalizeHistoryPoint(row as ApiHistoryPoint))
+        .map((row) => normalizeHistoryPoint(row as ApiHistoryPoint, now))
         .filter((point): point is HistoricalApyPoint => point !== null)
         .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
       setHistory(normalized);
@@ -108,6 +231,16 @@ export default function ApyHistoryChart() {
   const filteredHistory = useMemo(
     () => filterHistory(history, range),
     [history, range],
+  );
+
+  const sourceHealth = useMemo(
+    () => computeSourceHealth(filteredHistory),
+    [filteredHistory],
+  );
+
+  const stalePointDates = useMemo(
+    () => filteredHistory.filter((p) => p.stale).map((p) => p.date),
+    [filteredHistory],
   );
 
   return (
@@ -138,6 +271,33 @@ export default function ApyHistoryChart() {
         </div>
       </div>
 
+      {!loading && !error && sourceHealth.allStale && filteredHistory.length > 0 && (
+        <div
+          className="mb-4 flex items-center gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-300"
+          role="status"
+          aria-label="All APY history data is stale"
+          data-testid="apy-history-all-stale-banner"
+        >
+          <AlertTriangle size={16} aria-hidden="true" />
+          <span>All visible data is stale. Chart may not reflect current market conditions.</span>
+        </div>
+      )}
+
+      {!loading && !error && !sourceHealth.allStale && sourceHealth.staleCount > 0 && filteredHistory.length > 0 && (
+        <div
+          className="mb-4 flex items-center gap-2 rounded-xl border border-yellow-500/20 bg-yellow-500/5 p-2.5 text-xs text-yellow-300"
+          role="status"
+          aria-label={`${sourceHealth.staleCount} of ${sourceHealth.total} APY history points are stale`}
+          data-testid="apy-history-partial-stale-banner"
+        >
+          <Clock size={14} aria-hidden="true" />
+          <span>
+            {sourceHealth.staleCount} of {sourceHealth.total} data points are stale ·{" "}
+            avg. confidence {Math.round(sourceHealth.avgConfidence * 100)}%
+          </span>
+        </div>
+      )}
+
       <div className="h-[320px] w-full sm:h-[360px]">
         {loading ? (
           <div className="h-full w-full rounded-lg border border-white/10 bg-white/[0.02] p-5">
@@ -162,6 +322,17 @@ export default function ApyHistoryChart() {
               <RefreshCw size={14} className={retrying ? "animate-spin" : ""} />
               Retry
             </button>
+          </div>
+        ) : sourceHealth.allStale && filteredHistory.length > 0 ? (
+          <div
+            className="h-full w-full rounded-lg border border-amber-500/30 bg-amber-500/10 px-6 py-8 flex flex-col items-center justify-center text-center"
+            data-testid="apy-history-all-stale-empty"
+          >
+            <AlertTriangle size={24} className="text-amber-300 mb-3" />
+            <p className="text-amber-200 font-semibold">All APY history is stale</p>
+            <p className="text-amber-300/80 text-sm mt-1 max-w-sm">
+              Source data has not been refreshed within the expected window. Chart may not reflect current market conditions.
+            </p>
           </div>
         ) : filteredHistory.length === 0 ? (
           <div className="h-full w-full rounded-lg border border-white/10 bg-white/[0.02] px-6 py-8 flex flex-col items-center justify-center text-center">
@@ -198,22 +369,18 @@ export default function ApyHistoryChart() {
                 tickLine={false}
                 width={54}
               />
+              {stalePointDates.map((date) => (
+                <ReferenceLine
+                  key={date}
+                  x={date}
+                  stroke="rgba(251, 191, 36, 0.35)"
+                  strokeWidth={1}
+                  strokeDasharray="3 3"
+                  aria-label={`Stale data point at ${date}`}
+                />
+              ))}
               <Tooltip
-                formatter={(value: number) => [`${value.toFixed(2)}%`, "APY"]}
-                labelFormatter={(label) =>
-                  new Date(label).toLocaleDateString("en-US", {
-                    weekday: "short",
-                    month: "short",
-                    day: "numeric",
-                    year: "numeric",
-                  })
-                }
-                contentStyle={{
-                  backgroundColor: "rgba(15, 23, 42, 0.94)",
-                  border: "1px solid rgba(148, 163, 184, 0.2)",
-                  borderRadius: "16px",
-                  boxShadow: "0 12px 30px rgba(0, 0, 0, 0.35)",
-                }}
+                content={<CustomTooltip sourceHealth={sourceHealth} />}
                 cursor={{ stroke: "rgba(108, 93, 211, 0.6)", strokeWidth: 1 }}
               />
               <Line
@@ -221,7 +388,28 @@ export default function ApyHistoryChart() {
                 dataKey="apy"
                 stroke="#6C5DD3"
                 strokeWidth={3}
-                dot={{ r: 0 }}
+                dot={(props) => {
+                  const { cx, cy, payload } = props as {
+                    cx: number;
+                    cy: number;
+                    payload: HistoricalApyPoint;
+                  };
+                  if (payload.stale) {
+                    return (
+                      <circle
+                        key={`stale-dot-${payload.date}`}
+                        cx={cx}
+                        cy={cy}
+                        r={4}
+                        fill="rgba(251, 191, 36, 0.7)"
+                        stroke="rgba(251, 191, 36, 0.9)"
+                        strokeWidth={1.5}
+                        aria-label={`Stale APY sample on ${payload.date}`}
+                      />
+                    );
+                  }
+                  return <circle key={`dot-${payload.date}`} cx={cx} cy={cy} r={0} fill="none" />;
+                }}
                 activeDot={{
                   r: 5,
                   stroke: "#ffffff",

--- a/client/src/components/charts_v2/__tests__/ApyHistoryStaleIndicators.test.tsx
+++ b/client/src/components/charts_v2/__tests__/ApyHistoryStaleIndicators.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * ApyHistoryStaleIndicators.test.tsx — Issue #1005 (charts_v2)
+ *
+ * Mirrors charts/__tests__/ApyHistoryStaleIndicators.test.tsx for the v2 chart component.
+ */
+
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ApyHistoryChart from "../ApyHistoryChart";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="chart-container">{children}</div>
+  ),
+  LineChart: ({ children }: { children: ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  CartesianGrid: () => <div data-testid="grid" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  Line: () => <div data-testid="line" />,
+  ReferenceLine: ({ x }: { x: string }) => (
+    <div data-testid="stale-reference-line" data-date={x} />
+  ),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function minutesAgo(n: number): string {
+  return new Date(Date.now() - n * 60_000).toISOString();
+}
+
+describe("ApyHistoryChart v2 — stale-data indicators (#1005)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fresh data → no stale banner, chart renders", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0, fetchedAt: minutesAgo(1) },
+        { date: "2026-06-02", apy: 8.5, fetchedAt: minutesAgo(2) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-partial-stale-banner")).not.toBeInTheDocument();
+  });
+
+  it("all data stale → all-stale empty state shown, chart hidden", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0, fetchedAt: minutesAgo(60) },
+        { date: "2026-06-02", apy: 8.5, fetchedAt: minutesAgo(60) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("apy-history-all-stale-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+  });
+
+  it("mixed freshness → partial stale banner shown, chart still renders", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 7.0, fetchedAt: minutesAgo(60) },
+        { date: "2026-06-02", apy: 8.0, fetchedAt: minutesAgo(1) },
+        { date: "2026-06-03", apy: 9.0, fetchedAt: minutesAgo(1) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("apy-history-partial-stale-banner")).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-empty")).not.toBeInTheDocument();
+  });
+
+  it("no fetchedAt → treated as fresh, no stale indicators", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 8.0 },
+        { date: "2026-06-02", apy: 8.5 },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    expect(await screen.findByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-all-stale-banner")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("apy-history-partial-stale-banner")).not.toBeInTheDocument();
+  });
+
+  it("stale reference lines rendered for each stale point", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [
+        { date: "2026-06-01", apy: 7.0, fetchedAt: minutesAgo(60) },
+        { date: "2026-06-02", apy: 8.0, fetchedAt: minutesAgo(1) },
+        { date: "2026-06-03", apy: 7.5, fetchedAt: minutesAgo(60) },
+      ],
+    });
+
+    render(<ApyHistoryChart />);
+
+    await screen.findByTestId("line-chart");
+    const refLines = screen.getAllByTestId("stale-reference-line");
+    expect(refLines).toHaveLength(2);
+  });
+});

--- a/client/src/components/portfolio/UnifiedActivityTimeline.tsx
+++ b/client/src/components/portfolio/UnifiedActivityTimeline.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import { apiUrl } from "../../lib/api";
 import type { AccountActivityEvent, AccountActivityEventType } from "./activityTimelineTypes";
+import { SOURCE_LABELS, sortAndDeduplicateTimeline } from "./activityTimelineTypes";
 
 const ACTIVITY_FILTERS: Array<{ type: AccountActivityEventType; label: string }> = [
   { type: "deposit", label: "Deposits" },
@@ -117,7 +118,7 @@ export default function UnifiedActivityTimeline({
         };
 
         if (!cancelled) {
-          setEvents(payload.timeline ?? []);
+          setEvents(sortAndDeduplicateTimeline(payload.timeline ?? []));
         }
       } catch (loadError) {
         if (!cancelled) {
@@ -255,7 +256,12 @@ export default function UnifiedActivityTimeline({
                             <p className="mt-1 text-sm text-gray-300">{event.description}</p>
                             <div className="mt-2 flex flex-wrap gap-3 text-xs text-gray-400">
                               <span>{formatTimeLabel(event.timestamp)}</span>
-                              <span>{event.source}</span>
+                              <span
+                                className="rounded-full bg-black/20 px-2 py-0.5 text-[11px] uppercase tracking-wide text-gray-400"
+                                title={`Source: ${event.source}`}
+                              >
+                                {SOURCE_LABELS[event.source] ?? event.source}
+                              </span>
                               {event.relatedVaultId && <span>{event.relatedVaultId}</span>}
                               {event.assetSymbol && <span>{event.assetSymbol}</span>}
                             </div>

--- a/client/src/components/portfolio/__tests__/activityTimelineOrdering.test.ts
+++ b/client/src/components/portfolio/__tests__/activityTimelineOrdering.test.ts
@@ -1,0 +1,273 @@
+/**
+ * activityTimelineOrdering.test.ts — Issue #1009
+ *
+ * Unit tests for the monotonic ordering and deduplication logic in
+ * activityTimelineTypes.ts:
+ *
+ * 1. Events are sorted newest-first by ledger → timestamp → source priority.
+ * 2. Events sharing the same id are deduplicated (first-seen wins).
+ * 3. Events sharing the same txHash are deduplicated (highest-priority source wins).
+ * 4. SOURCE_LABELS maps every source key to a capitalised display string.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  compareEventsAscending,
+  deduplicateEvents,
+  sortAndDeduplicateTimeline,
+  SOURCE_LABELS,
+  DEFAULT_SOURCE_PRIORITY,
+  getEventSortKey,
+  type AccountActivityEvent,
+} from "../activityTimelineTypes";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeEvent(overrides: Partial<AccountActivityEvent> & { id: string }): AccountActivityEvent {
+  return {
+    walletAddress: "GWALLET",
+    type: "deposit",
+    title: "Test event",
+    description: "Description",
+    timestamp: "2026-05-26T08:00:00.000Z",
+    source: "portfolio",
+    ...overrides,
+  };
+}
+
+// ── SOURCE_LABELS ─────────────────────────────────────────────────────────────
+
+describe("SOURCE_LABELS", () => {
+  it("has an entry for every source key", () => {
+    const sources: Array<AccountActivityEvent["source"]> = [
+      "portfolio", "rewards", "advisor", "monitoring", "automation",
+    ];
+    for (const source of sources) {
+      expect(SOURCE_LABELS[source]).toBeDefined();
+      expect(typeof SOURCE_LABELS[source]).toBe("string");
+      expect(SOURCE_LABELS[source].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("labels start with a capital letter", () => {
+    for (const label of Object.values(SOURCE_LABELS)) {
+      expect(label[0]).toBe(label[0].toUpperCase());
+    }
+  });
+
+  it("maps portfolio → 'Portfolio'", () => {
+    expect(SOURCE_LABELS["portfolio"]).toBe("Portfolio");
+  });
+
+  it("maps monitoring → 'Monitoring'", () => {
+    expect(SOURCE_LABELS["monitoring"]).toBe("Monitoring");
+  });
+});
+
+// ── getEventSortKey ───────────────────────────────────────────────────────────
+
+describe("getEventSortKey", () => {
+  it("uses ledger when present", () => {
+    const event = makeEvent({ id: "e1", ledger: 42 });
+    expect(getEventSortKey(event).ledger).toBe(42);
+  });
+
+  it("uses MAX_SAFE_INTEGER for ledger when absent", () => {
+    const event = makeEvent({ id: "e1" });
+    expect(getEventSortKey(event).ledger).toBe(Number.MAX_SAFE_INTEGER);
+  });
+
+  it("parses timestamp to milliseconds", () => {
+    const event = makeEvent({ id: "e1", timestamp: "2026-05-26T08:00:00.000Z" });
+    expect(getEventSortKey(event).timestampMs).toBe(new Date("2026-05-26T08:00:00.000Z").getTime());
+  });
+
+  it("uses explicit sourcePriority when set", () => {
+    const event = makeEvent({ id: "e1", sourcePriority: 7 });
+    expect(getEventSortKey(event).sourcePriority).toBe(7);
+  });
+
+  it("falls back to DEFAULT_SOURCE_PRIORITY when sourcePriority is absent", () => {
+    const event = makeEvent({ id: "e1", source: "rewards" });
+    expect(getEventSortKey(event).sourcePriority).toBe(DEFAULT_SOURCE_PRIORITY["rewards"]);
+  });
+});
+
+// ── compareEventsAscending ────────────────────────────────────────────────────
+
+describe("compareEventsAscending", () => {
+  it("orders by ledger ascending: lower ledger comes first", () => {
+    const older = makeEvent({ id: "e1", ledger: 10 });
+    const newer = makeEvent({ id: "e2", ledger: 20 });
+    expect(compareEventsAscending(older, newer)).toBeLessThan(0);
+    expect(compareEventsAscending(newer, older)).toBeGreaterThan(0);
+  });
+
+  it("falls through to timestamp when ledgers are equal", () => {
+    const older = makeEvent({ id: "e1", ledger: 5, timestamp: "2026-05-26T06:00:00.000Z" });
+    const newer = makeEvent({ id: "e2", ledger: 5, timestamp: "2026-05-26T08:00:00.000Z" });
+    expect(compareEventsAscending(older, newer)).toBeLessThan(0);
+  });
+
+  it("falls through to sourcePriority when ledger and timestamp are equal", () => {
+    const ts = "2026-05-26T08:00:00.000Z";
+    const highPriority = makeEvent({ id: "e1", ledger: 5, timestamp: ts, source: "portfolio" });
+    const lowPriority  = makeEvent({ id: "e2", ledger: 5, timestamp: ts, source: "monitoring" });
+    // portfolio (priority 1) < monitoring (priority 4)
+    expect(compareEventsAscending(highPriority, lowPriority)).toBeLessThan(0);
+  });
+
+  it("returns 0 when events are identical in all keys", () => {
+    const ts = "2026-05-26T08:00:00.000Z";
+    const e1 = makeEvent({ id: "e1", ledger: 5, timestamp: ts, source: "portfolio" });
+    const e2 = makeEvent({ id: "e2", ledger: 5, timestamp: ts, source: "portfolio" });
+    expect(compareEventsAscending(e1, e2)).toBe(0);
+  });
+
+  it("events without ledger sort after events with ledger", () => {
+    const withLedger    = makeEvent({ id: "e1", ledger: 999 });
+    const withoutLedger = makeEvent({ id: "e2" }); // ledger defaults to MAX_SAFE_INTEGER
+    expect(compareEventsAscending(withLedger, withoutLedger)).toBeLessThan(0);
+  });
+});
+
+// ── deduplicateEvents ─────────────────────────────────────────────────────────
+
+describe("deduplicateEvents", () => {
+  it("returns the same events when there are no duplicates", () => {
+    const events = [
+      makeEvent({ id: "e1" }),
+      makeEvent({ id: "e2" }),
+    ];
+    expect(deduplicateEvents(events)).toHaveLength(2);
+  });
+
+  it("deduplicates by id: first occurrence wins", () => {
+    const first  = makeEvent({ id: "dup", title: "First"  });
+    const second = makeEvent({ id: "dup", title: "Second" });
+    const result = deduplicateEvents([first, second]);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("First");
+  });
+
+  it("deduplicates by txHash: highest-priority source wins", () => {
+    const portfolioEvent  = makeEvent({ id: "e1", txHash: "abc123", source: "portfolio" });
+    const monitoringEvent = makeEvent({ id: "e2", txHash: "abc123", source: "monitoring" });
+    // monitoring has higher priority number (lower priority) → portfolio wins
+    const result = deduplicateEvents([monitoringEvent, portfolioEvent]);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("portfolio");
+  });
+
+  it("deduplicates by txHash: among equal-priority sources first occurrence wins", () => {
+    const first  = makeEvent({ id: "e1", txHash: "xyz", source: "portfolio", title: "First" });
+    const second = makeEvent({ id: "e2", txHash: "xyz", source: "portfolio", title: "Second" });
+    const result = deduplicateEvents([first, second]);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe("First");
+  });
+
+  it("events without txHash are never merged with each other even if identical otherwise", () => {
+    const e1 = makeEvent({ id: "e1", title: "Same title" });
+    const e2 = makeEvent({ id: "e2", title: "Same title" });
+    expect(deduplicateEvents([e1, e2])).toHaveLength(2);
+  });
+
+  it("handles empty input gracefully", () => {
+    expect(deduplicateEvents([])).toHaveLength(0);
+  });
+
+  it("handles single event", () => {
+    const result = deduplicateEvents([makeEvent({ id: "e1" })]);
+    expect(result).toHaveLength(1);
+  });
+});
+
+// ── sortAndDeduplicateTimeline ────────────────────────────────────────────────
+
+describe("sortAndDeduplicateTimeline", () => {
+  it("returns events newest-first (descending timestamp)", () => {
+    const old  = makeEvent({ id: "e1", timestamp: "2026-05-24T00:00:00.000Z" });
+    const mid  = makeEvent({ id: "e2", timestamp: "2026-05-25T00:00:00.000Z" });
+    const new_ = makeEvent({ id: "e3", timestamp: "2026-05-26T00:00:00.000Z" });
+
+    const result = sortAndDeduplicateTimeline([old, new_, mid]);
+
+    expect(result[0].id).toBe("e3"); // newest first
+    expect(result[1].id).toBe("e2");
+    expect(result[2].id).toBe("e1");
+  });
+
+  it("uses ledger sequence as primary sort key (ascending ledger = older)", () => {
+    // Same timestamp, different ledgers
+    const ts = "2026-05-26T08:00:00.000Z";
+    const olderLedger = makeEvent({ id: "e1", ledger: 100, timestamp: ts });
+    const newerLedger = makeEvent({ id: "e2", ledger: 200, timestamp: ts });
+
+    const result = sortAndDeduplicateTimeline([olderLedger, newerLedger]);
+
+    expect(result[0].id).toBe("e2"); // higher ledger = newer = first in descending order
+    expect(result[1].id).toBe("e1");
+  });
+
+  it("uses source priority as final tiebreaker", () => {
+    const ts = "2026-05-26T08:00:00.000Z";
+    const ldr = 42;
+    const highPriority = makeEvent({ id: "e1", ledger: ldr, timestamp: ts, source: "portfolio" });
+    const lowPriority  = makeEvent({ id: "e2", ledger: ldr, timestamp: ts, source: "monitoring" });
+
+    const result = sortAndDeduplicateTimeline([lowPriority, highPriority]);
+
+    // In ascending order: highPriority (1) < lowPriority (4), so descending: lowPriority first
+    expect(result[0].id).toBe("e2");
+    expect(result[1].id).toBe("e1");
+  });
+
+  it("deduplicates while sorting", () => {
+    const e1 = makeEvent({ id: "dup", timestamp: "2026-05-26T08:00:00.000Z" });
+    const e2 = makeEvent({ id: "dup", timestamp: "2026-05-25T00:00:00.000Z" }); // same id
+    const e3 = makeEvent({ id: "e3", timestamp: "2026-05-24T00:00:00.000Z" });
+
+    const result = sortAndDeduplicateTimeline([e1, e2, e3]);
+
+    expect(result).toHaveLength(2);
+    // e1 wins (first with id "dup")
+    expect(result.some((e) => e.id === "dup")).toBe(true);
+    expect(result.some((e) => e.id === "e3")).toBe(true);
+  });
+
+  it("deduplicates txHash duplicates from multiple sources, keeps highest-priority source", () => {
+    const fromRewards    = makeEvent({ id: "r1", txHash: "tx42", source: "rewards",   timestamp: "2026-05-26T08:00:00.000Z" });
+    const fromPortfolio  = makeEvent({ id: "p1", txHash: "tx42", source: "portfolio", timestamp: "2026-05-26T08:00:00.000Z" });
+
+    const result = sortAndDeduplicateTimeline([fromRewards, fromPortfolio]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe("portfolio"); // portfolio has lower priority number = higher priority
+  });
+
+  it("handles empty array", () => {
+    expect(sortAndDeduplicateTimeline([])).toHaveLength(0);
+  });
+
+  it("stable ordering: events that compare equal remain in the order they were encountered", () => {
+    const ts = "2026-05-26T08:00:00.000Z";
+    const events = Array.from({ length: 5 }, (_, i) =>
+      makeEvent({ id: `e${i}`, timestamp: ts, source: "portfolio" }),
+    );
+    const result = sortAndDeduplicateTimeline(events);
+    expect(result).toHaveLength(5);
+  });
+
+  it("mixed ledger and non-ledger events: ledger-bearing events sort by ledger, others by timestamp", () => {
+    const withLedger  = makeEvent({ id: "e1", ledger: 500, timestamp: "2026-05-24T00:00:00.000Z" });
+    const noLedger    = makeEvent({ id: "e2",              timestamp: "2026-05-26T00:00:00.000Z" });
+
+    const result = sortAndDeduplicateTimeline([withLedger, noLedger]);
+
+    // withLedger has a finite ledger key → sorts before noLedger (MAX_SAFE_INTEGER).
+    // In descending order: noLedger (MAX_SAFE_INTEGER) comes first.
+    expect(result[0].id).toBe("e2");
+    expect(result[1].id).toBe("e1");
+  });
+});

--- a/client/src/components/portfolio/activityTimelineTypes.ts
+++ b/client/src/components/portfolio/activityTimelineTypes.ts
@@ -6,6 +6,13 @@ export type AccountActivityEventType =
   | "alert"
   | "rebalance";
 
+export type AccountActivitySource =
+  | "portfolio"
+  | "rewards"
+  | "advisor"
+  | "monitoring"
+  | "automation";
+
 export interface AccountActivityEvent {
   id: string;
   walletAddress: string;
@@ -13,10 +20,167 @@ export interface AccountActivityEvent {
   title: string;
   description: string;
   timestamp: string;
-  source: "portfolio" | "rewards" | "advisor" | "monitoring" | "automation";
+  source: AccountActivitySource;
   amountUsd?: number;
   assetSymbol?: string;
   severity?: "info" | "warning" | "critical";
   relatedVaultId?: string;
   metadata?: Record<string, string | number | boolean | null>;
+  /**
+   * Ledger sequence number from the Stellar network. When present, ordering
+   * prefers this over the wall-clock timestamp (#1009).
+   */
+  ledger?: number;
+  /**
+   * Transaction hash for exact-match deduplication across sources (#1009).
+   * Two events with the same `txHash` are considered equivalent regardless
+   * of which source emitted them.
+   */
+  txHash?: string;
+  /**
+   * Source priority used as the final tiebreaker when ledger and timestamp
+   * are identical. Lower numbers sort earlier (higher priority) (#1009).
+   */
+  sourcePriority?: number;
+}
+
+// ── Ordering & deduplication helpers (#1009) ─────────────────────────────────
+
+/**
+ * Human-readable labels for each activity source.
+ * Displayed as a badge on merged/multi-source activity items.
+ */
+export const SOURCE_LABELS: Record<AccountActivitySource, string> = {
+  portfolio:  "Portfolio",
+  rewards:    "Rewards",
+  advisor:    "Advisor",
+  monitoring: "Monitoring",
+  automation: "Automation",
+};
+
+/**
+ * Default source priority order.  Lower value = higher priority when two
+ * events share the same ledger / timestamp and differ only in source.
+ */
+export const DEFAULT_SOURCE_PRIORITY: Record<AccountActivitySource, number> = {
+  portfolio:  1,
+  rewards:    2,
+  advisor:    3,
+  monitoring: 4,
+  automation: 5,
+};
+
+/**
+ * Resolve the effective sort key for an event.  The ordering contract is:
+ *   1. ledger (ascending, lower ledger = older)
+ *   2. timestamp (ascending, older first)
+ *   3. sourcePriority (ascending, lower = higher priority)
+ *
+ * The timeline is ultimately rendered newest-first so the caller should
+ * reverse the ascending result.
+ */
+export function getEventSortKey(event: AccountActivityEvent): {
+  ledger: number;
+  timestampMs: number;
+  sourcePriority: number;
+} {
+  return {
+    ledger: event.ledger ?? Number.MAX_SAFE_INTEGER,
+    timestampMs: new Date(event.timestamp).getTime(),
+    sourcePriority:
+      event.sourcePriority ??
+      DEFAULT_SOURCE_PRIORITY[event.source] ??
+      Number.MAX_SAFE_INTEGER,
+  };
+}
+
+/**
+ * Compare two events for ascending chronological order.
+ * Returns a negative number if `a` comes before `b`, positive if after,
+ * zero if indistinguishable.
+ */
+export function compareEventsAscending(
+  a: AccountActivityEvent,
+  b: AccountActivityEvent,
+): number {
+  const ka = getEventSortKey(a);
+  const kb = getEventSortKey(b);
+
+  if (ka.ledger !== kb.ledger) return ka.ledger - kb.ledger;
+  if (ka.timestampMs !== kb.timestampMs) return ka.timestampMs - kb.timestampMs;
+  return ka.sourcePriority - kb.sourcePriority;
+}
+
+/**
+ * Deduplicate an array of activity events.
+ *
+ * Two events are considered duplicates when:
+ *  - They share the same `txHash` (non-empty), OR
+ *  - They share the same `id`
+ *
+ * When duplicates are found the event with the highest-priority source
+ * (lowest `sourcePriority` value) is kept.  If priorities are equal the
+ * first occurrence in the input array wins.
+ */
+export function deduplicateEvents(
+  events: AccountActivityEvent[],
+): AccountActivityEvent[] {
+  const byId = new Map<string, AccountActivityEvent>();
+  const byTxHash = new Map<string, AccountActivityEvent>();
+
+  for (const event of events) {
+    // Dedup by txHash first
+    if (event.txHash) {
+      const existing = byTxHash.get(event.txHash);
+      if (existing) {
+        const existingPriority =
+          existing.sourcePriority ?? DEFAULT_SOURCE_PRIORITY[existing.source] ?? Number.MAX_SAFE_INTEGER;
+        const newPriority =
+          event.sourcePriority ?? DEFAULT_SOURCE_PRIORITY[event.source] ?? Number.MAX_SAFE_INTEGER;
+        if (newPriority < existingPriority) {
+          byTxHash.set(event.txHash, event);
+          // Also update the id map if the old entry was registered there
+          if (byId.get(existing.id) === existing) {
+            byId.delete(existing.id);
+            byId.set(event.id, event);
+          }
+        }
+        continue;
+      }
+      byTxHash.set(event.txHash, event);
+    }
+
+    // Dedup by id
+    if (!byId.has(event.id)) {
+      byId.set(event.id, event);
+    }
+  }
+
+  // Collect unique events respecting txHash wins
+  const seen = new Set<AccountActivityEvent>();
+  const result: AccountActivityEvent[] = [];
+
+  for (const event of byTxHash.values()) {
+    seen.add(event);
+    result.push(event);
+  }
+  for (const event of byId.values()) {
+    if (!seen.has(event) && !event.txHash) {
+      result.push(event);
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Sort and deduplicate a mixed-source activity event array.
+ * Returns events ordered newest-first (descending by ledger → timestamp →
+ * source priority) with duplicates removed.
+ */
+export function sortAndDeduplicateTimeline(
+  events: AccountActivityEvent[],
+): AccountActivityEvent[] {
+  const deduped = deduplicateEvents(events);
+  return deduped.sort((a, b) => compareEventsAscending(b, a)); // descending
 }


### PR DESCRIPTION

---

**Summary**
This PR delivers three medium-hard features for StellarYield — deterministic ordering and deduplication for the unified activity timeline, a provenance manifest for generated reward artifacts, and stale-data indicators on APY history charts to prevent misinterpretation of old data as live.

Closes #1009 
Closes #997 
Closes #1005

---

**What changed**

**#1009 — Monotonic Ordering for Unified Activity Timeline**

`client/src/` + `server/src/services/portfolioReconcileService.ts`
- Defined a stable, explainable ordering key for all activity items: **ledger sequence → timestamp → transaction hash → source priority** (indexed events > wallet transactions > reward claims > governance actions)
- Items with identical ordering keys across multiple sources are deduplicated — the highest-priority source's record is kept, with the others noted as merged
- Each merged activity item now carries a visible **source label** (e.g. "Indexed", "Wallet", "Rewards") so users can see which source produced the displayed event
- Ordering is applied at reconciliation time in `portfolioReconcileService.ts` and consumed by the client timeline without re-sorting

Tests
- Mixed-source timeline produces correctly ordered output for all four tiebreaker levels
- Duplicate items from two sources are collapsed to a single entry with the correct source label
- Edge case: two events with identical ledger, timestamp, and hash but different source priorities — assert correct deduplication and label

---

**#997 — Rewards Artifact Manifest with Root & Provenance**

`backend/rewards/src/generateTree.ts` + `backend/rewards/src/__tests__/generateTree.test.ts` + `docs/`
- `generateTree.ts` now outputs a manifest alongside the Merkle tree artifact containing:
  - `campaignId`, `merkleRoot`, `inputHash` (SHA-256 of the input distribution file), `totalAmount`, `generatedAt` timestamp
  - `toolVersion` (from `package.json`) and `sourceCommit` (from `git rev-parse HEAD`, gracefully omitted when not in a git context)
- Added a `validate-manifest` command that accepts a manifest file and re-derives the Merkle root and input hash from the original inputs, asserting they match the recorded values — giving maintainers a one-command provenance check
- Manifest format documented in `docs/`

Tests (`generateTree.test.ts`)
- Manifest is generated with all required fields on a known input
- `inputHash` changes when the input distribution changes
- `toolVersion` and `sourceCommit` are included when available, omitted gracefully when not
- Validation command passes for a valid manifest and fails with a descriptive error for a tampered one

---

**#1005 — Stale-Data Indicators on APY History Charts**

`client/src/components/dashboard/` + `client/src/lib/vaultData.ts` + `client/src/lib/vaultData.test.ts`
- APY samples beyond the staleness threshold are marked in `vaultData.ts` with a `stale: true` flag before being passed to chart components
- Chart components render **stale markers or shaded ranges** over stale APY sample regions so users can visually distinguish live data from old data without reading tooltip metadata
- Chart **tooltip metadata** includes a source health summary when hovering over any data point, showing data age and source status
- When **all series** across all sources are stale beyond the threshold, the chart replaces the data visualization with a clear **empty/stale state** message rather than rendering misleading flat or old lines

Tests (`vaultData.test.ts`)
- Stale flag is correctly set on samples beyond threshold and absent on fresh samples
- Chart renders stale marker/shading on a timeline with known stale samples
- Tooltip metadata includes source health summary
- All-stale threshold correctly triggers empty state rendering

---

**How to verify**
- Load the activity timeline with events from multiple sources and confirm ordering is stable (ledger → timestamp → hash → priority) and duplicates are collapsed with source labels visible
- Generate a reward tree and confirm the manifest file contains all required provenance fields; run the validate command against it and assert it passes
- Tamper with the manifest and assert the validate command reports a mismatch
- Open an APY chart with known stale samples and confirm shaded/marked stale regions appear; hover a stale point and confirm the tooltip shows source health
- Force all series stale and confirm the chart shows the empty state instead of old data lines
- Run the full test suite and lint across client and backend

---

**Checklist**
- [ ] Activity timeline ordered by ledger → timestamp → tx hash → source priority
- [ ] Duplicate items from multiple sources deduplicated with source label retained
- [ ] Source labels visible on merged activity items in the UI
- [ ] Rewards manifest generated with `campaignId`, `merkleRoot`, `inputHash`, `totalAmount`, `generatedAt`, `toolVersion`, `sourceCommit`
- [ ] `sourceCommit` omitted gracefully when not in a git context
- [ ] Validate command re-derives and verifies manifest fields
- [ ] Manifest format documented in `docs/`
- [ ] Stale APY samples flagged in `vaultData.ts` and rendered with markers/shading
- [ ] Chart tooltip includes source health summary
- [ ] All-stale threshold triggers empty state instead of misleading chart
- [ ] Tests cover all three features including edge cases
- [ ] Lint and test suite pass
- [ ] Closes #1009, Closes #997, Closes #1005