### PR TITLE
fix(ui): resilient unavailable-backend handling in IndexerCheckpointPanel and alertsApi

### DIFF
--- a/client/src/features/alerts/alertsApi.ts
+++ b/client/src/features/alerts/alertsApi.ts
@@ -5,17 +5,21 @@ import type {
   WatchlistDigestPreference,
 } from "./types";
 
-const ALERTS_BASE = apiUrl("/api/alerts");
-const NOTIFICATIONS_BASE = apiUrl("/api/notifications");
+// Base URLs are resolved lazily, per call: resolving them at module scope
+// throws ApiUnavailableError at import time when the backend URL is not
+// configured, which blanks the entire app because this module is imported
+// (via AlertsModal) from App.tsx (#913).
+const alertsBase = () => apiUrl("/api/alerts");
+const notificationsBase = () => apiUrl("/api/notifications");
 
 export async function fetchAlerts(walletAddress: string): Promise<UserAlert[]> {
-  const res = await fetch(`${ALERTS_BASE}/${encodeURIComponent(walletAddress)}`);
+  const res = await fetch(`${alertsBase()}/${encodeURIComponent(walletAddress)}`);
   if (!res.ok) throw new Error("Failed to fetch alerts");
   return res.json() as Promise<UserAlert[]>;
 }
 
 export async function createAlert(payload: CreateAlertPayload): Promise<UserAlert> {
-  const res = await fetch(ALERTS_BASE, {
+  const res = await fetch(alertsBase(), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
@@ -28,7 +32,7 @@ export async function createAlert(payload: CreateAlertPayload): Promise<UserAler
 }
 
 export async function deleteAlert(id: string, walletAddress: string): Promise<void> {
-  const res = await fetch(`${ALERTS_BASE}/${encodeURIComponent(id)}`, {
+  const res = await fetch(`${alertsBase()}/${encodeURIComponent(id)}`, {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ walletAddress }),
@@ -40,7 +44,7 @@ export async function fetchDigestPreference(
   walletAddress: string,
 ): Promise<WatchlistDigestPreference> {
   const res = await fetch(
-    `${NOTIFICATIONS_BASE}/digest/preferences/${encodeURIComponent(walletAddress)}`,
+    `${notificationsBase()}/digest/preferences/${encodeURIComponent(walletAddress)}`,
   );
   if (!res.ok) throw new Error("Failed to fetch digest preferences");
   return res.json() as Promise<WatchlistDigestPreference>;
@@ -51,7 +55,7 @@ export async function saveDigestPreference(
   payload: WatchlistDigestPreference,
 ): Promise<WatchlistDigestPreference> {
   const res = await fetch(
-    `${NOTIFICATIONS_BASE}/digest/preferences/${encodeURIComponent(walletAddress)}`,
+    `${notificationsBase()}/digest/preferences/${encodeURIComponent(walletAddress)}`,
     {
       method: "PUT",
       headers: { "Content-Type": "application/json" },

--- a/client/src/pages/transparency/IndexerCheckpointPanel.tsx
+++ b/client/src/pages/transparency/IndexerCheckpointPanel.tsx
@@ -8,9 +8,9 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { Database, RefreshCw, AlertTriangle } from "lucide-react";
+import { Database, RefreshCw, AlertTriangle, WifiOff } from "lucide-react";
 import StatusBadge from "../../components/StatusBadge";
-import { apiUrl } from "../../lib/api";
+import { apiUrl, isApiUnavailableError } from "../../lib/api";
 import {
   getIndexerStatusDisplay,
   formatLag,
@@ -22,11 +22,13 @@ export default function IndexerCheckpointPanel() {
   const [status, setStatus] = useState<IndexerStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isUnavailable, setIsUnavailable] = useState(false);
 
   const fetchStatus = useCallback(async () => {
     try {
       setIsLoading(true);
       setError(null);
+      setIsUnavailable(false);
       const res = await fetch(apiUrl("/api/indexer/status"));
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
@@ -34,8 +36,12 @@ export default function IndexerCheckpointPanel() {
       const body = await res.json();
       setStatus(body.data as IndexerStatus);
     } catch (err) {
-      console.error("Failed to fetch indexer status:", err);
-      setError(err instanceof Error ? err.message : "Failed to fetch indexer status");
+      if (isApiUnavailableError(err)) {
+        setIsUnavailable(true);
+      } else {
+        console.error("Failed to fetch indexer status:", err);
+        setError(err instanceof Error ? err.message : "Failed to fetch indexer status");
+      }
     } finally {
       setIsLoading(false);
     }
@@ -66,18 +72,27 @@ export default function IndexerCheckpointPanel() {
         </button>
       </div>
 
-      {error && (
+      {isUnavailable && (
+        <div className="flex items-center gap-2 p-3 bg-gray-500/10 border border-gray-500/30 rounded-lg">
+          <WifiOff className="w-5 h-5 text-gray-400" />
+          <span className="text-sm text-gray-400">
+            Backend unavailable — configure <code>VITE_API_BASE_URL</code> to enable live indexer data.
+          </span>
+        </div>
+      )}
+
+      {error && !isUnavailable && (
         <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/30 rounded-lg">
           <AlertTriangle className="w-5 h-5 text-red-500" />
           <span className="text-sm text-red-400">{error}</span>
         </div>
       )}
 
-      {!error && isLoading && !status && (
+      {!error && !isUnavailable && isLoading && !status && (
         <p className="text-sm text-gray-400">Loading indexer status…</p>
       )}
 
-      {status && display && (
+      {!isUnavailable && status && display && (
         <>
           <div className="flex flex-wrap items-center gap-3">
             <StatusBadge variant={display.variant} label={display.label} />


### PR DESCRIPTION
## Summary

Two components crashed or errored when the backend URL was not configured
(preview builds, offline dev, no `VITE_API_BASE_URL` set). This PR makes
both resilient: the indexer panel shows a friendly banner instead of
throwing, and the alerts API module defers URL resolution until request
time so it no longer breaks the app at import.

closes #913

## Changes

- **#913 — IndexerCheckpointPanel.tsx**: Added `isUnavailable` state.
  `fetchStatus()` now distinguishes `ApiUnavailableError` (from
  `isApiUnavailableError`) from generic network/HTTP errors. When the
  error is a backend-unavailability error, `setIsUnavailable(true)` is
  called and a banner is shown:
  > "Backend unavailable — configure `VITE_API_BASE_URL` to enable live
  > indexer data."
  with a `WifiOff` icon (gray styling, non-alarming). The existing red
  error banner is guarded with `!isUnavailable` so it only shows for
  genuine backend errors. The status display and loading spinner are also
  guarded so they don't flash behind the unavailable banner. `isUnavailable`
  is reset to `false` at the start of each `fetchStatus()` call so a
  successful re-fetch clears the banner.

- **alertsApi.ts**: Changed `ALERTS_BASE` and `NOTIFICATIONS_BASE` from
  module-level `const` resolved at import time to lazy resolver functions
  `alertsBase()` / `notificationsBase()` called inside each request
  function. `apiUrl()` throws `ApiUnavailableError` when
  `VITE_API_BASE_URL` is unset; calling it at module scope propagated
  the throw through `AlertsModal` → `App.tsx`, blanking the entire app in
  preview environments. Lazy resolution confines the throw to the moment
  a request is actually attempted.

## Test plan

- Unset `VITE_API_BASE_URL` in a local dev build; navigate to the
  Transparency page — the indexer panel should show the unavailable banner
  rather than an error or blank screen.
- Set `VITE_API_BASE_URL` to a valid backend and confirm the panel loads
  normally.
- Run the vitest suite (`pnpm test` or `vitest run`) — existing tests
  should continue to pass; no new test files added.