### PR TITLE
fix: contract-address sanity checks, rebalance queue fixtures, simulator input clamping

### DIFF
--- a/scripts/validateContractAddresses.test.ts
+++ b/scripts/validateContractAddresses.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { validateContractAddresses, ContractAddressRole } from './validateContractAddresses';
+
+const VALID_A = 'C'.padEnd(56, 'A'); // 56 chars, all valid base32
+const VALID_B = 'C' + 'B'.repeat(55);
+
+const roles: ContractAddressRole[] = [
+  { varName: 'VAULT_CONTRACT_ID', role: 'vault', required: true },
+  { varName: 'STABLECOIN_MANAGER_CONTRACT_ID', role: 'stablecoin manager', required: true },
+  { varName: 'OPTIONAL_CONTRACT_ID', role: 'optional extra', required: false },
+];
+
+describe('validateContractAddresses', () => {
+  it('returns no issues for a valid, non-duplicated address matrix', () => {
+    const issues = validateContractAddresses(
+      { VAULT_CONTRACT_ID: VALID_A, STABLECOIN_MANAGER_CONTRACT_ID: VALID_B },
+      roles,
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it('flags a missing required contract id', () => {
+    const issues = validateContractAddresses({ STABLECOIN_MANAGER_CONTRACT_ID: VALID_B }, roles);
+    expect(issues).toEqual([
+      expect.objectContaining({ varName: 'VAULT_CONTRACT_ID', code: 'missing' }),
+    ]);
+  });
+
+  it('does not flag a missing optional contract id', () => {
+    const issues = validateContractAddresses(
+      { VAULT_CONTRACT_ID: VALID_A, STABLECOIN_MANAGER_CONTRACT_ID: VALID_B },
+      roles,
+    );
+    expect(issues.some((i) => i.varName === 'OPTIONAL_CONTRACT_ID')).toBe(false);
+  });
+
+  it('flags a malformed contract address (wrong prefix)', () => {
+    const issues = validateContractAddresses(
+      { VAULT_CONTRACT_ID: 'G' + 'A'.repeat(55), STABLECOIN_MANAGER_CONTRACT_ID: VALID_B },
+      roles,
+    );
+    expect(issues).toEqual([
+      expect.objectContaining({ varName: 'VAULT_CONTRACT_ID', code: 'malformed' }),
+    ]);
+  });
+
+  it('flags a malformed contract address (wrong length)', () => {
+    const issues = validateContractAddresses(
+      { VAULT_CONTRACT_ID: 'CTOOSHORT', STABLECOIN_MANAGER_CONTRACT_ID: VALID_B },
+      roles,
+    );
+    expect(issues).toEqual([
+      expect.objectContaining({ varName: 'VAULT_CONTRACT_ID', code: 'malformed' }),
+    ]);
+  });
+
+  it('flags two incompatible roles sharing the same address', () => {
+    const issues = validateContractAddresses(
+      { VAULT_CONTRACT_ID: VALID_A, STABLECOIN_MANAGER_CONTRACT_ID: VALID_A },
+      roles,
+    );
+    expect(issues).toEqual([
+      expect.objectContaining({ varName: 'STABLECOIN_MANAGER_CONTRACT_ID', code: 'duplicate_role' }),
+    ]);
+  });
+
+  it('identifies the exact variable and role for every issue', () => {
+    const issues = validateContractAddresses({}, roles);
+    const vaultIssue = issues.find((i) => i.varName === 'VAULT_CONTRACT_ID');
+    expect(vaultIssue).toMatchObject({ role: 'vault', code: 'missing' });
+    expect(vaultIssue?.message).toContain('VAULT_CONTRACT_ID');
+  });
+});

--- a/scripts/validateContractAddresses.ts
+++ b/scripts/validateContractAddresses.ts
@@ -1,0 +1,94 @@
+/**
+ * Contract-address sanity checks for deployment configuration (issue #1054).
+ *
+ * Deployment scripts should fail fast when a configured contract ID is
+ * malformed, missing, or accidentally duplicated across incompatible roles
+ * (e.g. the vault contract and the stablecoin manager pointing at the same
+ * address is almost certainly a copy-paste mistake, not a real deployment).
+ *
+ * This is a pure, dependency-free module (no @stellar/stellar-sdk import)
+ * so it can run as a fast pre-flight check before any RPC/network calls.
+ * "Wrong network" detection (does this contract ID actually exist on the
+ * configured network?) requires a live Soroban RPC lookup and is out of
+ * scope for this static check — left as a follow-up once a network client
+ * is wired into the deploy pipeline.
+ */
+
+/** Stellar StrKey contract address: version byte 'C' + 55 base32 chars = 56 total. */
+const CONTRACT_ADDRESS_PATTERN = /^C[A-Z2-7]{55}$/;
+
+export interface ContractAddressRole {
+  /** The environment variable name this contract ID is read from. */
+  varName: string;
+  /** Human-readable role, e.g. "vault contract" or "stablecoin manager". */
+  role: string;
+  required: boolean;
+}
+
+export interface ContractAddressIssue {
+  varName: string;
+  role: string;
+  code: 'missing' | 'malformed' | 'duplicate_role';
+  message: string;
+}
+
+/**
+ * Validates a set of configured contract-address environment variables
+ * against their expected roles. Returns one issue per problem found; an
+ * empty array means every configured address is well-formed and no two
+ * incompatible roles share the same address.
+ */
+export function validateContractAddresses(
+  env: Record<string, string | undefined>,
+  roles: ContractAddressRole[],
+): ContractAddressIssue[] {
+  const issues: ContractAddressIssue[] = [];
+  const seenAddresses = new Map<string, ContractAddressRole>();
+
+  for (const roleSpec of roles) {
+    const value = env[roleSpec.varName]?.trim();
+
+    if (!value) {
+      if (roleSpec.required) {
+        issues.push({
+          varName: roleSpec.varName,
+          role: roleSpec.role,
+          code: 'missing',
+          message: `${roleSpec.varName} (${roleSpec.role}) is required but not set.`,
+        });
+      }
+      continue;
+    }
+
+    if (!CONTRACT_ADDRESS_PATTERN.test(value)) {
+      issues.push({
+        varName: roleSpec.varName,
+        role: roleSpec.role,
+        code: 'malformed',
+        message: `${roleSpec.varName} (${roleSpec.role}) = "${value}" is not a valid Stellar contract address (expected "C" followed by 55 base32 characters).`,
+      });
+      continue;
+    }
+
+    const existing = seenAddresses.get(value);
+    if (existing) {
+      issues.push({
+        varName: roleSpec.varName,
+        role: roleSpec.role,
+        code: 'duplicate_role',
+        message: `${roleSpec.varName} (${roleSpec.role}) has the same address as ${existing.varName} (${existing.role}) — this is almost always a misconfiguration.`,
+      });
+    } else {
+      seenAddresses.set(value, roleSpec);
+    }
+  }
+
+  return issues;
+}
+
+/** The contract-role variables this deployment currently configures, mirroring FRONTEND_VARS/BACKEND_VARS in verify-deployment.ts. */
+export const DEPLOYMENT_CONTRACT_ROLES: ContractAddressRole[] = [
+  { varName: 'VITE_CONTRACT_ID', role: 'frontend vault contract', required: true },
+  { varName: 'VAULT_CONTRACT_ID', role: 'keeper vault contract', required: true },
+  { varName: 'STABLECOIN_MANAGER_CONTRACT_ID', role: 'stablecoin manager contract', required: true },
+];

--- a/scripts/verify-deployment.ts
+++ b/scripts/verify-deployment.ts
@@ -21,6 +21,7 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import semver from 'semver';
+import { validateContractAddresses, DEPLOYMENT_CONTRACT_ROLES } from './validateContractAddresses';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 
@@ -227,6 +228,14 @@ printSection('Node.js Version');
 const nodeCheck = checkNodeVersion();
 console.log(`  ${nodeCheck.ok ? '✓' : '✗'} ${nodeCheck.message}`);
 
+printSection('Contract Address Sanity Checks');
+const contractAddressIssues = validateContractAddresses(process.env, DEPLOYMENT_CONTRACT_ROLES);
+if (contractAddressIssues.length === 0) {
+  console.log('  ✓ All configured contract addresses are well-formed and unique per role');
+} else {
+  contractAddressIssues.forEach((issue) => console.log(`  ✗ [${issue.code}] ${issue.message}`));
+}
+
 printSection('Vercel Config');
 const vercelCheck = checkVercelConfig();
 if (!vercelCheck.found) {
@@ -245,9 +254,10 @@ const allResults = [...frontendResults, ...backendResults];
 const missingRequired = allResults.filter((r) => r.status === 'missing' && r.required);
 const nodeOk = nodeCheck.ok;
 const vercelOk = vercelCheck.ok;
+const contractAddressesOk = contractAddressIssues.length === 0;
 
 console.log('\n' + '═'.repeat(60));
-if (missingRequired.length === 0 && nodeOk && vercelOk) {
+if (missingRequired.length === 0 && nodeOk && vercelOk && contractAddressesOk) {
   console.log('DEPLOYMENT CHECK: ALL PASSED');
   process.exit(0);
 } else {
@@ -257,5 +267,8 @@ if (missingRequired.length === 0 && nodeOk && vercelOk) {
   }
   if (!nodeOk) console.log(`  Node version issue: ${nodeCheck.message}`);
   if (!vercelOk) console.log(`  Vercel config issues: ${vercelCheck.issues.join('; ')}`);
+  if (!contractAddressesOk) {
+    console.log(`  Contract address issues: ${contractAddressIssues.map((i) => i.message).join('; ')}`);
+  }
   process.exit(1);
 }

--- a/server/src/__tests__/fixtures/rebalanceQueueFixtures.ts
+++ b/server/src/__tests__/fixtures/rebalanceQueueFixtures.ts
@@ -1,0 +1,62 @@
+/**
+ * Replayable fixtures for the rebalance queue processor job (issue #1049).
+ *
+ * Each fixture is a plain `RebalanceQueueEntryDTO`-shaped object with no
+ * external dependencies (no DB, no RPC), so the processor job can be
+ * replayed against them entirely offline by mocking
+ * `rebalanceQueueService`/`rebalanceExecutorService` to return them. Add a
+ * new fixture here (and a matching case in
+ * `server/src/jobs/__tests__/rebalanceQueueProcessorJob.fixtures.test.ts`)
+ * whenever a new queue edge case needs a regression test.
+ */
+
+export const NOW = new Date('2026-01-15T12:00:00.000Z');
+
+function baseEntry(overrides: Record<string, any> = {}) {
+  return {
+    id: 'entry-base',
+    poolId: 'pool-1',
+    status: 'PENDING',
+    executionType: 'FULL',
+    attemptCount: 0,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+/** A retry that has already failed many times — should still be attempted
+ * again (there is no attempt cap in the current job), not silently dropped. */
+export const stuckEntryFixture = baseEntry({
+  id: 'entry-stuck',
+  status: 'FAILED',
+  attemptCount: 12,
+  lastError: 'TRANSIENT: RPC timeout',
+});
+
+/** An entry already locked in-flight by the executor (e.g. a prior worker
+ * tick that hasn't finished) — the job must skip it rather than double-submit. */
+export const duplicateEntryFixture = baseEntry({
+  id: 'entry-duplicate',
+  status: 'PROCESSING',
+  attemptCount: 1,
+});
+
+/** A deferred entry whose window has passed — exercises the
+ * getDeferredEntries() path rather than getPendingRetries(). */
+export const expiredEntryFixture = baseEntry({
+  id: 'entry-expired',
+  status: 'PENDING',
+  executionType: 'DEFERRED',
+  deferredUntil: new Date(NOW.getTime() - 60_000),
+  attemptCount: 0,
+});
+
+/** An entry whose execution fails because a dependency (e.g. an allocation
+ * constraint breach) was not met — must be classified and recorded, not
+ * retried blindly the same way a transient network error would be. */
+export const dependencyFailedEntryFixture = baseEntry({
+  id: 'entry-dependency-failed',
+  status: 'PENDING',
+  attemptCount: 2,
+});

--- a/server/src/__tests__/simulationInputClamping.test.ts
+++ b/server/src/__tests__/simulationInputClamping.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Boundary/clamping tests for simulator inputs (issue #1053): extreme
+ * deposits, negative APY assumptions, and fee/weight boundaries.
+ */
+import {
+  simulateDeposit,
+  validateRebalanceParams,
+  simulateRebalance,
+  MAX_SIMULATION_DEPOSIT,
+  RebalanceParams,
+} from '../services/simulationService';
+
+describe('simulateDeposit — extreme deposit clamping', () => {
+  it('rejects a negative amount', () => {
+    const result = simulateDeposit({ strategyId: 'balanced', amount: -100, token: 'USDC' });
+    expect(result.warnings[0]).toMatch(/greater than zero/);
+    expect(result.allocations).toHaveLength(0);
+  });
+
+  it('rejects a zero amount', () => {
+    const result = simulateDeposit({ strategyId: 'balanced', amount: 0, token: 'USDC' });
+    expect(result.warnings[0]).toMatch(/greater than zero/);
+  });
+
+  it('rejects a non-finite amount (NaN / Infinity)', () => {
+    expect(simulateDeposit({ strategyId: 'balanced', amount: NaN, token: 'USDC' }).warnings[0]).toMatch(
+      /finite number/,
+    );
+    expect(simulateDeposit({ strategyId: 'balanced', amount: Infinity, token: 'USDC' }).warnings[0]).toMatch(
+      /finite number/,
+    );
+  });
+
+  it('rejects an amount over the maximum supported deposit', () => {
+    const result = simulateDeposit({
+      strategyId: 'balanced',
+      amount: MAX_SIMULATION_DEPOSIT + 1,
+      token: 'USDC',
+    });
+    expect(result.warnings[0]).toMatch(/exceeds the maximum/);
+    expect(result.allocations).toHaveLength(0);
+  });
+
+  it('accepts an amount exactly at the maximum without numeric overflow', () => {
+    const result = simulateDeposit({
+      strategyId: 'balanced',
+      amount: MAX_SIMULATION_DEPOSIT,
+      token: 'USDC',
+    });
+    expect(result.warnings.some((w) => w.match(/exceeds the maximum/))).toBe(false);
+    expect(Number.isFinite(result.expectedShares)).toBe(true);
+    expect(Number.isFinite(result.postDepositExposure.expectedApy)).toBe(true);
+  });
+});
+
+describe('validateRebalanceParams — negative APY and extreme value guards', () => {
+  function baseParams(overrides: Partial<RebalanceParams> = {}): RebalanceParams {
+    return {
+      totalValueUsd: 10_000,
+      allocations: [
+        { label: 'Blend', currentWeight: 50, targetWeight: 50, apy: 5 },
+        { label: 'Aggressive', currentWeight: 50, targetWeight: 50, apy: 8 },
+      ],
+      ...overrides,
+    };
+  }
+
+  it('accepts valid, non-negative APY assumptions', () => {
+    expect(validateRebalanceParams(baseParams())).toEqual([]);
+  });
+
+  it('rejects a negative APY assumption', () => {
+    const errors = validateRebalanceParams(
+      baseParams({
+        allocations: [
+          { label: 'Blend', currentWeight: 50, targetWeight: 50, apy: -5 },
+          { label: 'Aggressive', currentWeight: 50, targetWeight: 50, apy: 8 },
+        ],
+      }),
+    );
+    expect(errors.some((e) => e.includes('apy for Blend'))).toBe(true);
+  });
+
+  it('rejects a non-finite APY assumption', () => {
+    const errors = validateRebalanceParams(
+      baseParams({
+        allocations: [
+          { label: 'Blend', currentWeight: 50, targetWeight: 50, apy: NaN },
+          { label: 'Aggressive', currentWeight: 50, targetWeight: 50, apy: 8 },
+        ],
+      }),
+    );
+    expect(errors.some((e) => e.includes('apy for Blend'))).toBe(true);
+  });
+
+  it('rejects an implausibly large APY assumption', () => {
+    const errors = validateRebalanceParams(
+      baseParams({
+        allocations: [
+          { label: 'Blend', currentWeight: 50, targetWeight: 50, apy: 50_000 },
+          { label: 'Aggressive', currentWeight: 50, targetWeight: 50, apy: 8 },
+        ],
+      }),
+    );
+    expect(errors.some((e) => e.includes('not a plausible assumption'))).toBe(true);
+  });
+
+  it('rejects an extreme totalValueUsd', () => {
+    const errors = validateRebalanceParams(baseParams({ totalValueUsd: MAX_SIMULATION_DEPOSIT + 1 }));
+    expect(errors.some((e) => e.includes('exceeds the maximum'))).toBe(true);
+  });
+
+  it('simulateRebalance throws a clear error for invalid inputs instead of producing a misleading chart', () => {
+    expect(() =>
+      simulateRebalance(
+        baseParams({
+          allocations: [
+            { label: 'Blend', currentWeight: 50, targetWeight: 50, apy: -5 },
+            { label: 'Aggressive', currentWeight: 50, targetWeight: 50, apy: 8 },
+          ],
+        }),
+      ),
+    ).toThrow(/Invalid rebalance parameters/);
+  });
+});

--- a/server/src/jobs/__tests__/rebalanceQueueProcessorJob.fixtures.test.ts
+++ b/server/src/jobs/__tests__/rebalanceQueueProcessorJob.fixtures.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Replays fixture rebalance-queue entries through the real processor job
+ * (issue #1049), with `rebalanceQueueService`/`rebalanceExecutorService`
+ * mocked so no DB or Soroban RPC is needed. Covers: a stuck/repeatedly-failed
+ * job, duplicate-in-flight suppression, an expired/deferred job, and a
+ * dependency (constraint) failure.
+ */
+import { runRebalanceQueueProcessorJob } from '../rebalanceQueueProcessorJob';
+import {
+  stuckEntryFixture,
+  duplicateEntryFixture,
+  expiredEntryFixture,
+  dependencyFailedEntryFixture,
+} from '../../__tests__/fixtures/rebalanceQueueFixtures';
+
+const mockGetPendingRetries = jest.fn();
+const mockGetDeferredEntries = jest.fn();
+const mockMarkAsProcessing = jest.fn();
+const mockRecordPartialExecution = jest.fn();
+const mockRecordFailedAttempt = jest.fn();
+
+jest.mock('../../services/rebalanceQueueService', () => ({
+  rebalanceQueueService: {
+    getPendingRetries: (...args: any[]) => mockGetPendingRetries(...args),
+    getDeferredEntries: (...args: any[]) => mockGetDeferredEntries(...args),
+    markAsProcessing: (...args: any[]) => mockMarkAsProcessing(...args),
+    recordPartialExecution: (...args: any[]) => mockRecordPartialExecution(...args),
+    recordFailedAttempt: (...args: any[]) => mockRecordFailedAttempt(...args),
+  },
+}));
+
+const mockExecute = jest.fn();
+const mockClassifyError = jest.fn();
+const mockIsLocked = jest.fn().mockReturnValue(false);
+
+jest.mock('../../services/rebalanceExecutorService', () => ({
+  rebalanceExecutorService: {
+    execute: (...args: any[]) => mockExecute(...args),
+    classifyError: (...args: any[]) => mockClassifyError(...args),
+    isLocked: (...args: any[]) => mockIsLocked(...args),
+  },
+}));
+
+function baseConfig(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    enabled: true,
+    batchSize: 10,
+    enableRetries: true,
+    enableDeferredProcessing: true,
+    logResults: false,
+    ...overrides,
+  };
+}
+
+describe('runRebalanceQueueProcessorJob — fixture replay', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetPendingRetries.mockResolvedValue([]);
+    mockGetDeferredEntries.mockResolvedValue([]);
+    mockMarkAsProcessing.mockResolvedValue(undefined);
+    mockRecordPartialExecution.mockResolvedValue(undefined);
+    mockRecordFailedAttempt.mockResolvedValue(undefined);
+    mockIsLocked.mockReturnValue(false);
+  });
+
+  it('retries a stuck (repeatedly-failed) entry rather than dropping it', async () => {
+    mockGetPendingRetries.mockResolvedValue([stuckEntryFixture]);
+    mockExecute.mockResolvedValue({ transactionHash: 'tx-stuck', filledPercentage: 100 });
+
+    const result = await runRebalanceQueueProcessorJob(baseConfig());
+
+    expect(mockMarkAsProcessing).toHaveBeenCalledWith(stuckEntryFixture.id);
+    expect(mockExecute).toHaveBeenCalled();
+    expect(result.processedRetries).toBe(1);
+    expect(result.failedProcessing).toBe(0);
+  });
+
+  it('deterministically produces the same outcome across repeated replays', async () => {
+    mockGetPendingRetries.mockResolvedValue([stuckEntryFixture]);
+    mockExecute.mockResolvedValue({ transactionHash: 'tx-stuck', filledPercentage: 100 });
+
+    const first = await runRebalanceQueueProcessorJob(baseConfig());
+    jest.clearAllMocks();
+    mockGetPendingRetries.mockResolvedValue([stuckEntryFixture]);
+    mockExecute.mockResolvedValue({ transactionHash: 'tx-stuck', filledPercentage: 100 });
+    const second = await runRebalanceQueueProcessorJob(baseConfig());
+
+    expect(second).toMatchObject({
+      success: first.success,
+      processedRetries: first.processedRetries,
+      processedDeferred: first.processedDeferred,
+      failedProcessing: first.failedProcessing,
+    });
+  });
+
+  it('skips an entry already locked in-flight instead of double-submitting', async () => {
+    mockGetPendingRetries.mockResolvedValue([duplicateEntryFixture]);
+    mockIsLocked.mockReturnValue(true);
+
+    const result = await runRebalanceQueueProcessorJob(baseConfig());
+
+    expect(mockMarkAsProcessing).not.toHaveBeenCalled();
+    expect(mockExecute).not.toHaveBeenCalled();
+    expect(result.processedRetries).toBe(1); // counted as processed (no-op skip), not failed
+    expect(result.failedProcessing).toBe(0);
+  });
+
+  it('processes an expired/deferred entry via the deferred-entries path', async () => {
+    mockGetDeferredEntries.mockResolvedValue([expiredEntryFixture]);
+    mockExecute.mockResolvedValue({ transactionHash: 'tx-expired', filledPercentage: 100 });
+
+    const result = await runRebalanceQueueProcessorJob(baseConfig());
+
+    expect(mockMarkAsProcessing).toHaveBeenCalledWith(expiredEntryFixture.id);
+    expect(result.processedDeferred).toBe(1);
+  });
+
+  it('records a dependency/constraint failure without crashing the batch', async () => {
+    mockGetPendingRetries.mockResolvedValue([dependencyFailedEntryFixture]);
+    const constraintError = new Error('Allocation constraint breached: max slippage exceeded');
+    mockExecute.mockRejectedValue(constraintError);
+    mockClassifyError.mockReturnValue('CONSTRAINT');
+
+    const result = await runRebalanceQueueProcessorJob(baseConfig());
+
+    // execute()'s rejection is caught and recorded *inside* processQueueEntry
+    // rather than propagating — so the job counts this as a processed retry
+    // (a failure was recorded for it), not a job-level `failedProcessing`.
+    expect(mockClassifyError).toHaveBeenCalledWith(constraintError);
+    expect(mockRecordFailedAttempt).toHaveBeenCalledWith(
+      dependencyFailedEntryFixture.id,
+      expect.stringContaining('[CONSTRAINT]'),
+      undefined,
+    );
+    expect(result.processedRetries).toBe(1);
+    expect(result.failedProcessing).toBe(0);
+  });
+});

--- a/server/src/services/simulationService.ts
+++ b/server/src/services/simulationService.ts
@@ -32,6 +32,14 @@ export interface SimulationResult {
   warnings: string[];
 }
 
+/**
+ * Hard ceiling on a simulated deposit amount (issue #1053). Well above any
+ * realistic deposit, but finite enough that downstream percentage/blended-APY
+ * math (`amount * bps / sum`, chart axis scaling) can't overflow or render a
+ * misleading chart for a client-supplied extreme value.
+ */
+export const MAX_SIMULATION_DEPOSIT = 1_000_000_000;
+
 export function simulateDeposit(params: SimulationParams): SimulationResult {
   const { amount, strategyId, token: _token } = params;
 
@@ -46,8 +54,15 @@ export function simulateDeposit(params: SimulationParams): SimulationResult {
     warnings: [],
   };
 
-  if (amount <= 0) {
-    result.warnings.push("Amount must be greater than zero.");
+  if (!Number.isFinite(amount) || amount <= 0) {
+    result.warnings.push("Amount must be a finite number greater than zero.");
+    return result;
+  }
+
+  if (amount > MAX_SIMULATION_DEPOSIT) {
+    result.warnings.push(
+      `Amount exceeds the maximum supported simulation deposit of ${MAX_SIMULATION_DEPOSIT.toLocaleString()}.`,
+    );
     return result;
   }
 
@@ -189,6 +204,10 @@ export function validateRebalanceParams(params: RebalanceParams): string[] {
 
   if (!Number.isFinite(params.totalValueUsd) || params.totalValueUsd <= 0) {
     errors.push("totalValueUsd must be a positive number.");
+  } else if (params.totalValueUsd > MAX_SIMULATION_DEPOSIT) {
+    errors.push(
+      `totalValueUsd exceeds the maximum supported simulation value of ${MAX_SIMULATION_DEPOSIT.toLocaleString()}.`,
+    );
   }
 
   if (!Array.isArray(params.allocations) || params.allocations.length === 0) {
@@ -218,6 +237,15 @@ export function validateRebalanceParams(params: RebalanceParams): string[] {
           `${field} for ${alloc.label || "allocation"} must be between 0 and 100.`,
         );
       }
+    }
+    if (!Number.isFinite(alloc.apy) || alloc.apy < 0) {
+      errors.push(
+        `apy for ${alloc.label || "allocation"} must be a non-negative number (got ${alloc.apy}).`,
+      );
+    } else if (alloc.apy > 10_000) {
+      errors.push(
+        `apy for ${alloc.label || "allocation"} of ${alloc.apy}% is not a plausible assumption.`,
+      );
     }
     currentSum += alloc.currentWeight;
     targetSum += alloc.targetWeight;


### PR DESCRIPTION
## Summary
Closes #1054
Closes #1049
Closes #1053
Closes #1052 

- **#1054** — `scripts/validateContractAddresses.ts`: validates configured contract-ID env vars against Stellar StrKey format, flags missing required roles, and flags two incompatible roles (e.g. vault vs. stablecoin manager) accidentally sharing the same address. Wired into `verify-deployment.ts`'s report and exit code, so a bad matrix now fails the deployment check. "Wrong network" detection needs a live Soroban RPC lookup against the deployed contract — left as follow-up since this check is intentionally static/offline.
- **#1049** — `server/src/__tests__/fixtures/rebalanceQueueFixtures.ts` + `server/src/jobs/__tests__/rebalanceQueueProcessorJob.fixtures.test.ts`: replayable fixtures for a stuck/repeatedly-failed entry, a duplicate-in-flight entry, an expired/deferred entry, and a dependency (allocation-constraint) failure — replayed through the real `runRebalanceQueueProcessorJob` with `rebalanceQueueService`/`rebalanceExecutorService` mocked, so it runs fully offline with deterministic output verified by a repeat-replay test.
- **#1053** — `simulateDeposit` now rejects non-finite and extreme deposit amounts (new `MAX_SIMULATION_DEPOSIT` ceiling) instead of only warning and continuing; `validateRebalanceParams` now rejects negative, non-finite, and implausibly large (>10,000%) per-allocation APY assumptions, plus an extreme `totalValueUsd`. Note: the deposit simulator has no simulation-horizon input in this codebase today (APY comes from protocol config, not user input elsewhere), so horizon clamping isn't applicable yet — flagged rather than inventing an unused field.

.

## Test plan
- [x] `npx jest src/__tests__/simulationInputClamping.test.ts src/jobs/__tests__/rebalanceQueueProcessorJob.fixtures.test.ts` (server workspace) — 16/16 passing
- [x] `npx vitest run scripts/validateContractAddresses.test.ts` — 7/7 passing