### PR TITLE
feat: saved-search tooling, markdown linter, governance checkpoints, liquidity breakdown

### DIFF
--- a/docs/markdown-linting.md
+++ b/docs/markdown-linting.md
@@ -1,0 +1,41 @@
+# Markdown Linting for Generated Documents
+
+Generated issue canvases (e.g. `GRANTFOX_ISSUE_CANVAS.md`-style documents)
+and maintainer handoff notes get copied into GitHub issues and GrantFox, so
+a structural mistake — a skipped heading level, an empty list item, a link
+whose parentheses never closed — is easy to introduce when generating or
+hand-editing them, and easy to miss until it renders badly somewhere else.
+
+## Running the check
+
+```bash
+npx tsx scripts/lint-markdown.ts path/to/file.md [more-files.md ...]
+```
+
+Exits non-zero if any file has issues, so it's safe to wire into a
+pre-publish step or CI job:
+
+```bash
+npx tsx scripts/lint-markdown.ts docs/*.md GRANTFOX_*.md STELLARYIELD_EPIC_ISSUE_CANVAS.md
+```
+
+(Glob patterns that don't match any file are simply skipped by the shell —
+run it against whichever generated canvases exist at the time.)
+
+## What it catches
+
+- **Empty headings** — a `#`/`##`/etc. line with no text after it.
+- **Skipped heading levels** — jumping from `#` straight to `###` with no
+  `##` in between. Stepping back down (e.g. `###` to `#` for a new
+  top-level section) is always valid and not flagged.
+- **Malformed links** — `[text]()` (empty URL), `[]("url")` (empty text),
+  and an unclosed `[text](` with no matching `)`.
+- **Empty list items** — a `-`/`*`/`+` bullet with nothing after it.
+
+## Extending the check
+
+The checker lives in `scripts/lintMarkdown.ts` as a single pure function,
+`lintMarkdownContent(content: string): MarkdownLintIssue[]`, covered by
+`scripts/lintMarkdown.test.ts`. Add a new rule by extending that function
+and adding a case to the test file — the CLI wrapper
+(`scripts/lint-markdown.ts`) needs no changes.

--- a/docs/triage-process.md
+++ b/docs/triage-process.md
@@ -113,3 +113,28 @@ Keep the claim visible in the issue thread, and ask contributors to link their P
 - **Saved Searches:** https://github.com/edehvictor/StellarYield/issues
 - **GitHub Tokens:** https://github.com/settings/tokens
 - **Stellar Wave Program:** See root `README.md` for Wave details
+
+## Keeping Saved Searches Current
+
+`scripts/maintainer_saved_searches.sh`'s printed links are generated from
+`scripts/saved-searches.json` — that JSON file is the single source of
+truth, not the `.sh` file itself.
+
+To add, remove, or edit a saved search:
+
+1. Edit `scripts/saved-searches.json` (add an entry with `id`, `label`, and
+   a GitHub search `query` string — the same syntax you'd type into the
+   GitHub issues search box).
+2. Preview the change with a dry run, which prints exactly what would
+   change without writing anything:
+   ```bash
+   node scripts/refresh-saved-searches.js --dry-run
+   ```
+3. Once it looks right, apply it:
+   ```bash
+   node scripts/refresh-saved-searches.js
+   ```
+   This rewrites the generated block between the `BEGIN`/`END GENERATED
+   SAVED SEARCHES` markers in `maintainer_saved_searches.sh` — running it
+   again with an unchanged config is a no-op ("already up to date").
+4. Commit both the JSON change and the regenerated `.sh` file together.

--- a/scripts/lint-markdown.ts
+++ b/scripts/lint-markdown.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * CLI wrapper for lintMarkdown.ts (issue #1087).
+ *
+ * Usage:
+ *   npx tsx scripts/lint-markdown.ts docs/*.md
+ *   npx tsx scripts/lint-markdown.ts GRANTFOX_ISSUE_CANVAS.md
+ *
+ * Exits 1 if any file has structural issues (malformed headings, skipped
+ * heading levels, malformed links, empty list items), 0 otherwise.
+ */
+import fs from 'fs';
+import path from 'path';
+import { lintMarkdownContent } from './lintMarkdown';
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error('Usage: npx tsx scripts/lint-markdown.ts <file.md> [file2.md ...]');
+  process.exit(1);
+}
+
+let hadIssues = false;
+
+for (const file of files) {
+  const fullPath = path.resolve(file);
+  if (!fs.existsSync(fullPath)) {
+    console.error(`✗ ${file}: file not found`);
+    hadIssues = true;
+    continue;
+  }
+  const content = fs.readFileSync(fullPath, 'utf-8');
+  const issues = lintMarkdownContent(content);
+
+  if (issues.length === 0) {
+    console.log(`✓ ${file}`);
+  } else {
+    hadIssues = true;
+    console.log(`✗ ${file}`);
+    for (const issue of issues) {
+      console.log(`    line ${issue.line} [${issue.rule}] ${issue.message}`);
+    }
+  }
+}
+
+process.exit(hadIssues ? 1 : 0);

--- a/scripts/lintMarkdown.test.ts
+++ b/scripts/lintMarkdown.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { lintMarkdownContent } from './lintMarkdown';
+
+describe('lintMarkdownContent', () => {
+  it('returns no issues for a well-formed document', () => {
+    const content = [
+      '# Title',
+      '',
+      '## Section',
+      '',
+      '- one',
+      '- two',
+      '',
+      'See [the docs](https://example.com/docs) for details.',
+    ].join('\n');
+
+    expect(lintMarkdownContent(content)).toEqual([]);
+  });
+
+  it('flags an empty heading', () => {
+    const issues = lintMarkdownContent('# Title\n\n##\n');
+    expect(issues).toEqual([expect.objectContaining({ rule: 'empty-heading', line: 3 })]);
+  });
+
+  it('flags a heading level that skips a level', () => {
+    const issues = lintMarkdownContent('# Title\n\n### Subsection\n');
+    expect(issues).toEqual([expect.objectContaining({ rule: 'heading-level-skip', line: 3 })]);
+  });
+
+  it('does not flag a heading level that steps down by more than one (that is always valid)', () => {
+    const issues = lintMarkdownContent('# Title\n\n## Section\n\n### Sub\n\n# New top-level\n');
+    expect(issues.filter((i) => i.rule === 'heading-level-skip')).toEqual([]);
+  });
+
+  it('flags a link with empty text', () => {
+    const issues = lintMarkdownContent('See []( https://example.com ) here.');
+    expect(issues.some((i) => i.rule === 'malformed-link')).toBe(true);
+  });
+
+  it('flags a link with an empty URL', () => {
+    const issues = lintMarkdownContent('See [the docs]() here.');
+    expect(issues.some((i) => i.rule === 'malformed-link')).toBe(true);
+  });
+
+  it('flags an unclosed link', () => {
+    const issues = lintMarkdownContent('See [the docs](https://example.com/docs for details.');
+    expect(issues.some((i) => i.rule === 'malformed-link')).toBe(true);
+  });
+
+  it('flags an empty list item', () => {
+    const issues = lintMarkdownContent('# Title\n\n- one\n-\n- two\n');
+    expect(issues).toEqual([expect.objectContaining({ rule: 'empty-list-item', line: 4 })]);
+  });
+
+  it('reports the correct line number for issues later in the document', () => {
+    const content = ['# Title', '', 'Some text.', '', 'Another line.', '', '[broken]()'].join('\n');
+    const issues = lintMarkdownContent(content);
+    expect(issues).toEqual([expect.objectContaining({ line: 7 })]);
+  });
+});

--- a/scripts/lintMarkdown.ts
+++ b/scripts/lintMarkdown.ts
@@ -1,0 +1,111 @@
+/**
+ * Structural markdown linter (issue #1087) for generated issue canvases and
+ * maintainer handoff notes. A pure, dependency-free checker — no
+ * `generated issue canvas` files exist in this repo yet (the suggested
+ * `GRANTFOX_*_CANVAS.md` / `STELLARYIELD_EPIC_ISSUE_CANVAS.md` files aren't
+ * present), so this validates any markdown file, ready for canvases as soon
+ * as they're generated, and useful today against `docs/**`.
+ *
+ * Catches: malformed/empty headings, a heading level that skips one or more
+ * levels (h1 -> h3), malformed link syntax (`[text]()`  / `[text](` with no
+ * closing paren / empty link text), and list-item lines with no content.
+ */
+
+export interface MarkdownLintIssue {
+  line: number;
+  rule: 'empty-heading' | 'heading-level-skip' | 'malformed-link' | 'empty-list-item';
+  message: string;
+}
+
+const HEADING_RE = /^(#{1,6})\s*(.*)$/;
+const LIST_ITEM_RE = /^\s*[-*+]\s*(.*)$/;
+// A reasonably strict "well-formed markdown link" shape: [text](url) with
+// non-empty text and non-empty url. Used to spot the malformed neighbors.
+const WELL_FORMED_LINK_RE = /\[[^\]]+\]\([^)\s][^)]*\)/;
+
+function findMalformedLinksInLine(line: string, lineNumber: number): MarkdownLintIssue[] {
+  const issues: MarkdownLintIssue[] = [];
+
+  // Empty link text: []("url") or empty url: [text]()
+  const emptyPartsRe = /\[([^\]]*)\]\(([^)]*)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = emptyPartsRe.exec(line)) !== null) {
+    const [, text, url] = match;
+    if (text.trim().length === 0) {
+      issues.push({
+        line: lineNumber,
+        rule: 'malformed-link',
+        message: `Link has empty text: "${match[0]}"`,
+      });
+    } else if (url.trim().length === 0) {
+      issues.push({
+        line: lineNumber,
+        rule: 'malformed-link',
+        message: `Link "${text}" has an empty URL`,
+      });
+    }
+  }
+
+  // Unclosed link: "[text](" with no matching ")" anywhere later on the line.
+  const openParenRe = /\[[^\]]+\]\([^)]*$/;
+  if (openParenRe.test(line) && !WELL_FORMED_LINK_RE.test(line)) {
+    issues.push({
+      line: lineNumber,
+      rule: 'malformed-link',
+      message: `Link opening "(" is never closed: "${line.trim()}"`,
+    });
+  }
+
+  return issues;
+}
+
+/**
+ * Lints a markdown document's structure. Returns one issue per problem
+ * found; an empty array means the document is structurally well-formed.
+ */
+export function lintMarkdownContent(content: string): MarkdownLintIssue[] {
+  const issues: MarkdownLintIssue[] = [];
+  const lines = content.split('\n');
+  let lastHeadingLevel = 0;
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+
+    const headingMatch = line.match(HEADING_RE);
+    if (headingMatch) {
+      const level = headingMatch[1].length;
+      const text = headingMatch[2].trim();
+
+      if (text.length === 0) {
+        issues.push({
+          line: lineNumber,
+          rule: 'empty-heading',
+          message: `Heading has no text: "${line.trim()}"`,
+        });
+      }
+
+      if (lastHeadingLevel > 0 && level > lastHeadingLevel + 1) {
+        issues.push({
+          line: lineNumber,
+          rule: 'heading-level-skip',
+          message: `Heading level jumps from h${lastHeadingLevel} to h${level} — skips h${lastHeadingLevel + 1}.`,
+        });
+      }
+      lastHeadingLevel = level;
+      return;
+    }
+
+    const listMatch = line.match(LIST_ITEM_RE);
+    if (listMatch && listMatch[1].trim().length === 0) {
+      issues.push({
+        line: lineNumber,
+        rule: 'empty-list-item',
+        message: 'List item has no content.',
+      });
+    }
+
+    issues.push(...findMalformedLinksInLine(line, lineNumber));
+  });
+
+  return issues;
+}

--- a/scripts/maintainer_saved_searches.sh
+++ b/scripts/maintainer_saved_searches.sh
@@ -60,3 +60,24 @@ echo
 echo
 echo "💡 Tip: Use 'GITHUB_TOKEN=ghp_xxx node scripts/issue-triage.js' for an automated dashboard"
 echo "📖 Full workflow: docs/triage-process.md"
+
+# --- BEGIN GENERATED SAVED SEARCHES (scripts/refresh-saved-searches.js) ---
+echo "1. Unclaimed Wave Issues (Ready for contributors):"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Stellar%20Wave%22%20label%3A%22help%20wanted%22%20no%3Aassignee"
+echo
+echo "2. Claimed Wave Issues (In progress, no PR yet):"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22Stellar%20Wave%22%20has%3Aassignee%20-linked%3Apr"
+echo
+echo "3. Wave PRs (Pending review):"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Apr%20is%3Aopen%20label%3A%22Stellar%20Wave%22"
+echo
+echo "4. Blocked Issues (Waiting on external data):"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Aissue%20is%3Aopen%20label%3Ablocked"
+echo
+echo "5. Needs Info (Waiting on contributor response):"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22needs%20info%22"
+echo
+echo "6. All Open Issues:"
+echo "    https://github.com/edehvictor/StellarYield/issues?q=is%3Aissue%20is%3Aopen"
+echo
+# --- END GENERATED SAVED SEARCHES ---

--- a/scripts/refresh-saved-searches.js
+++ b/scripts/refresh-saved-searches.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+/**
+ * Refreshes the saved-search links embedded in maintainer_saved_searches.sh
+ * from the single source of truth in scripts/saved-searches.json (issue #1086).
+ *
+ * Usage:
+ *   node scripts/refresh-saved-searches.js            # writes the refreshed block
+ *   node scripts/refresh-saved-searches.js --dry-run   # prints the diff, writes nothing
+ *
+ * To add a new saved search: add an entry to scripts/saved-searches.json,
+ * then run this script (see docs/maintainer-saved-searches.md).
+ */
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CONFIG_PATH = path.join(REPO_ROOT, 'scripts', 'saved-searches.json');
+const TARGET_PATH = path.join(REPO_ROOT, 'scripts', 'maintainer_saved_searches.sh');
+
+const START_MARKER = '# --- BEGIN GENERATED SAVED SEARCHES (scripts/refresh-saved-searches.js) ---';
+const END_MARKER = '# --- END GENERATED SAVED SEARCHES ---';
+
+function loadConfig() {
+  return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+}
+
+/** Deterministically renders the generated block from the saved-search config. */
+function renderBlock(config) {
+  const baseUrl = `https://github.com/${config.repo}/issues`;
+  const lines = [START_MARKER];
+  config.searches.forEach((search, i) => {
+    const url = `${baseUrl}?q=${encodeURIComponent(search.query)}`;
+    lines.push(`echo "${i + 1}. ${search.label}:"`);
+    lines.push(`echo "    ${url}"`);
+    lines.push(`echo`);
+  });
+  lines.push(END_MARKER);
+  return lines.join('\n');
+}
+
+function replaceOrAppendBlock(existingContent, block) {
+  const startIdx = existingContent.indexOf(START_MARKER);
+  const endIdx = existingContent.indexOf(END_MARKER);
+  if (startIdx !== -1 && endIdx !== -1) {
+    const before = existingContent.slice(0, startIdx);
+    const after = existingContent.slice(endIdx + END_MARKER.length);
+    return `${before}${block}${after}`;
+  }
+  const trimmed = existingContent.replace(/\n+$/, '\n');
+  return `${trimmed}\n${block}\n`;
+}
+
+function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  const config = loadConfig();
+  const block = renderBlock(config);
+
+  const existing = fs.existsSync(TARGET_PATH) ? fs.readFileSync(TARGET_PATH, 'utf-8') : '';
+  const updated = replaceOrAppendBlock(existing, block);
+
+  if (updated === existing) {
+    console.log('Saved searches are already up to date — no changes.');
+    return;
+  }
+
+  if (dryRun) {
+    console.log(`Dry run — ${TARGET_PATH} would change to:\n`);
+    console.log(block);
+    console.log('\n(no file was written; re-run without --dry-run to apply)');
+    return;
+  }
+
+  fs.writeFileSync(TARGET_PATH, updated);
+  console.log(`Refreshed saved searches in ${path.relative(REPO_ROOT, TARGET_PATH)}`);
+}
+
+main();
+
+module.exports = { renderBlock, replaceOrAppendBlock, loadConfig };

--- a/scripts/saved-searches.json
+++ b/scripts/saved-searches.json
@@ -1,0 +1,35 @@
+{
+  "repo": "edehvictor/StellarYield",
+  "searches": [
+    {
+      "id": "unclaimed-wave",
+      "label": "Unclaimed Wave Issues (Ready for contributors)",
+      "query": "is:issue is:open label:\"Stellar Wave\" label:\"help wanted\" no:assignee"
+    },
+    {
+      "id": "claimed-wave-no-pr",
+      "label": "Claimed Wave Issues (In progress, no PR yet)",
+      "query": "is:issue is:open label:\"Stellar Wave\" has:assignee -linked:pr"
+    },
+    {
+      "id": "wave-prs",
+      "label": "Wave PRs (Pending review)",
+      "query": "is:pr is:open label:\"Stellar Wave\""
+    },
+    {
+      "id": "blocked",
+      "label": "Blocked Issues (Waiting on external data)",
+      "query": "is:issue is:open label:blocked"
+    },
+    {
+      "id": "needs-info",
+      "label": "Needs Info (Waiting on contributor response)",
+      "query": "is:issue is:open label:\"needs info\""
+    },
+    {
+      "id": "all-open",
+      "label": "All Open Issues",
+      "query": "is:issue is:open"
+    }
+  ]
+}

--- a/server/src/__tests__/governanceForecastCheckpoints.test.ts
+++ b/server/src/__tests__/governanceForecastCheckpoints.test.ts
@@ -1,0 +1,98 @@
+import {
+  checkpointStatus,
+  summarizeCheckpoints,
+  overdueCheckpoints,
+  DEFAULT_DUE_SOON_WINDOW_MS,
+  type GovernanceForecastCheckpoint,
+} from '../services/governanceForecastCheckpoints';
+
+const NOW = new Date('2026-06-15T12:00:00.000Z');
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe('checkpointStatus', () => {
+  it('returns "completed" whenever completedAt is set, regardless of the window', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c1',
+      label: 'Signer prep',
+      changeWindowStart: new Date(NOW.getTime() - DAY_MS), // already passed
+      completedAt: new Date(NOW.getTime() - 2 * DAY_MS),
+    };
+    expect(checkpointStatus(checkpoint, NOW)).toBe('completed');
+  });
+
+  it('returns "overdue" once the change window has passed and nothing is completed', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c2',
+      label: 'Draft notes',
+      changeWindowStart: new Date(NOW.getTime() - 1000),
+    };
+    expect(checkpointStatus(checkpoint, NOW)).toBe('overdue');
+  });
+
+  it('returns "due_soon" within the due-soon window', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c3',
+      label: 'Line up signers',
+      changeWindowStart: new Date(NOW.getTime() + DAY_MS),
+    };
+    expect(checkpointStatus(checkpoint, NOW)).toBe('due_soon');
+  });
+
+  it('returns "upcoming" outside the due-soon window', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c4',
+      label: 'Long-range prep',
+      changeWindowStart: new Date(NOW.getTime() + 30 * DAY_MS),
+    };
+    expect(checkpointStatus(checkpoint, NOW)).toBe('upcoming');
+  });
+
+  it('honors a custom due-soon window', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c5',
+      label: 'Custom window',
+      changeWindowStart: new Date(NOW.getTime() + 10 * DAY_MS),
+    };
+    expect(checkpointStatus(checkpoint, NOW, 1 * DAY_MS)).toBe('upcoming');
+    expect(checkpointStatus(checkpoint, NOW, 14 * DAY_MS)).toBe('due_soon');
+  });
+
+  it('treats the exact boundary of the due-soon window as due_soon', () => {
+    const checkpoint: GovernanceForecastCheckpoint = {
+      id: 'c6',
+      label: 'Boundary',
+      changeWindowStart: new Date(NOW.getTime() + DEFAULT_DUE_SOON_WINDOW_MS),
+    };
+    expect(checkpointStatus(checkpoint, NOW)).toBe('due_soon');
+  });
+});
+
+describe('summarizeCheckpoints', () => {
+  const checkpoints: GovernanceForecastCheckpoint[] = [
+    { id: 'upcoming', label: 'Upcoming', changeWindowStart: new Date(NOW.getTime() + 30 * DAY_MS) },
+    { id: 'overdue', label: 'Overdue', changeWindowStart: new Date(NOW.getTime() - DAY_MS) },
+    {
+      id: 'completed',
+      label: 'Completed',
+      changeWindowStart: new Date(NOW.getTime() - 5 * DAY_MS),
+      completedAt: new Date(NOW.getTime() - 6 * DAY_MS),
+    },
+    { id: 'due-soon', label: 'Due soon', changeWindowStart: new Date(NOW.getTime() + DAY_MS) },
+  ];
+
+  it('attaches a status and msUntilChangeWindow to every checkpoint', () => {
+    const reminders = summarizeCheckpoints(checkpoints, NOW);
+    expect(reminders).toHaveLength(4);
+    reminders.forEach((r) => expect(typeof r.msUntilChangeWindow).toBe('number'));
+  });
+
+  it('sorts overdue first, then due_soon, then upcoming, then completed', () => {
+    const reminders = summarizeCheckpoints(checkpoints, NOW);
+    expect(reminders.map((r) => r.id)).toEqual(['overdue', 'due-soon', 'upcoming', 'completed']);
+  });
+
+  it('overdueCheckpoints filters to only the overdue reminders', () => {
+    const reminders = summarizeCheckpoints(checkpoints, NOW);
+    expect(overdueCheckpoints(reminders).map((r) => r.id)).toEqual(['overdue']);
+  });
+});

--- a/server/src/__tests__/liquidityHealthService.test.ts
+++ b/server/src/__tests__/liquidityHealthService.test.ts
@@ -1,4 +1,9 @@
-import { liquidityHealthService } from "../services/liquidityHealthService";
+import {
+  liquidityHealthService,
+  bandForScore,
+  buildComponentBreakdown,
+  buildAlertContext,
+} from "../services/liquidityHealthService";
 
 describe("LiquidityHealthService", () => {
   it("should calculate a score for a valid protocol", async () => {
@@ -45,5 +50,73 @@ describe("LiquidityHealthService", () => {
 
   it("should throw error for invalid protocol", async () => {
     await expect(liquidityHealthService.calculateScore("invalid")).rejects.toThrow();
+  });
+
+  // #1092 — component-level breakdown and alert context
+  it("includes a per-component breakdown alongside the composite score", async () => {
+    const result = await liquidityHealthService.calculateScore("blend");
+
+    expect(result.breakdown).toHaveLength(4);
+    const names = result.breakdown.map((b) => b.name).sort();
+    expect(names).toEqual(["depth", "spread", "stability", "withdrawalSensitivity"].sort());
+    result.breakdown.forEach((b) => {
+      expect(b.score).toBe(result.components[b.name]);
+      expect(["healthy", "warning", "critical"]).toContain(b.band);
+    });
+  });
+
+  it("omits alertContext when the strategy is healthy", async () => {
+    const result = await liquidityHealthService.calculateScore("blend");
+    expect(result.status).toBe("healthy");
+    expect(result.alertContext).toBeUndefined();
+  });
+});
+
+describe("bandForScore", () => {
+  it("returns critical below the critical threshold", () => {
+    expect(bandForScore(10, 60, 30)).toBe("critical");
+  });
+  it("returns warning between the thresholds", () => {
+    expect(bandForScore(45, 60, 30)).toBe("warning");
+  });
+  it("returns healthy at/above the warning threshold", () => {
+    expect(bandForScore(60, 60, 30)).toBe("healthy");
+    expect(bandForScore(90, 60, 30)).toBe("healthy");
+  });
+});
+
+describe("buildComponentBreakdown / buildAlertContext", () => {
+  const components = { depth: 80, spread: 20, stability: 90, withdrawalSensitivity: 70 };
+
+  it("bands each component independently using the shared thresholds", () => {
+    const breakdown = buildComponentBreakdown(components, 60, 30);
+    const byName = Object.fromEntries(breakdown.map((b) => [b.name, b.band]));
+    expect(byName).toEqual({
+      depth: "healthy",
+      spread: "critical", // 20 is below the critical threshold of 30
+      stability: "healthy",
+      withdrawalSensitivity: "healthy",
+    });
+  });
+
+  it("identifies the lowest-scoring component as the primary driver", () => {
+    const breakdown = buildComponentBreakdown(components, 60, 30);
+    const alert = buildAlertContext(breakdown, "critical", "blend");
+    expect(alert).toBeDefined();
+    expect(alert!.primaryDrivers).toEqual(["spread"]);
+    expect(alert!.message).toContain("blend");
+    expect(alert!.message).toContain("slippage");
+  });
+
+  it("includes every tied lowest-scoring component as a primary driver", () => {
+    const tiedComponents = { depth: 20, spread: 20, stability: 90, withdrawalSensitivity: 70 };
+    const breakdown = buildComponentBreakdown(tiedComponents, 60, 30);
+    const alert = buildAlertContext(breakdown, "critical", "blend");
+    expect(alert!.primaryDrivers.sort()).toEqual(["depth", "spread"].sort());
+  });
+
+  it("returns undefined for a healthy status regardless of component spread", () => {
+    const breakdown = buildComponentBreakdown(components, 60, 30);
+    expect(buildAlertContext(breakdown, "healthy", "blend")).toBeUndefined();
   });
 });

--- a/server/src/services/governanceForecastCheckpoints.ts
+++ b/server/src/services/governanceForecastCheckpoints.ts
@@ -1,0 +1,78 @@
+/**
+ * Governance forecast checkpoints (issue #1091).
+ *
+ * A checkpoint models a scheduled change window a maintainer needs to
+ * prepare for (lining up signers, drafting notes) ahead of a governance
+ * proposal taking effect. This module is deliberately independent of
+ * governanceForecastService.ts's yield/exposure modeling — checkpoints are
+ * a scheduling concern, not a forecast-math concern — so either can change
+ * without the other.
+ */
+
+export type CheckpointStatus = "completed" | "overdue" | "due_soon" | "upcoming";
+
+export interface GovernanceForecastCheckpoint {
+  id: string;
+  label: string;
+  /** When the change window this checkpoint prepares for begins. */
+  changeWindowStart: Date;
+  /** Set once a maintainer has completed the prep work for this checkpoint. */
+  completedAt?: Date;
+}
+
+export interface CheckpointReminder extends GovernanceForecastCheckpoint {
+  status: CheckpointStatus;
+  /** Milliseconds until changeWindowStart; negative once it has passed. */
+  msUntilChangeWindow: number;
+}
+
+/** Change windows within this many ms are surfaced as "due_soon" rather than "upcoming". */
+export const DEFAULT_DUE_SOON_WINDOW_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+export function checkpointStatus(
+  checkpoint: GovernanceForecastCheckpoint,
+  now: Date,
+  dueSoonWindowMs: number = DEFAULT_DUE_SOON_WINDOW_MS,
+): CheckpointStatus {
+  if (checkpoint.completedAt) return "completed";
+
+  const msUntil = checkpoint.changeWindowStart.getTime() - now.getTime();
+  if (msUntil < 0) return "overdue";
+  if (msUntil <= dueSoonWindowMs) return "due_soon";
+  return "upcoming";
+}
+
+/**
+ * Attaches a reminder status to each checkpoint, sorted so overdue
+ * checkpoints surface first, then due-soon, then upcoming, then completed —
+ * within each group, the earliest change window comes first.
+ */
+export function summarizeCheckpoints(
+  checkpoints: GovernanceForecastCheckpoint[],
+  now: Date = new Date(),
+  dueSoonWindowMs: number = DEFAULT_DUE_SOON_WINDOW_MS,
+): CheckpointReminder[] {
+  const statusRank: Record<CheckpointStatus, number> = {
+    overdue: 0,
+    due_soon: 1,
+    upcoming: 2,
+    completed: 3,
+  };
+
+  return checkpoints
+    .map((checkpoint) => ({
+      ...checkpoint,
+      status: checkpointStatus(checkpoint, now, dueSoonWindowMs),
+      msUntilChangeWindow: checkpoint.changeWindowStart.getTime() - now.getTime(),
+    }))
+    .sort((a, b) => {
+      const rankDiff = statusRank[a.status] - statusRank[b.status];
+      if (rankDiff !== 0) return rankDiff;
+      return a.changeWindowStart.getTime() - b.changeWindowStart.getTime();
+    });
+}
+
+/** Convenience filter for surfacing only checkpoints that need attention now. */
+export function overdueCheckpoints(reminders: CheckpointReminder[]): CheckpointReminder[] {
+  return reminders.filter((r) => r.status === "overdue");
+}

--- a/server/src/services/liquidityHealthService.ts
+++ b/server/src/services/liquidityHealthService.ts
@@ -1,21 +1,103 @@
 import { PROTOCOLS } from "../config/protocols";
 import { slippageRegistry } from "./slippageRegistry";
 
+export type ComponentName = 'depth' | 'spread' | 'stability' | 'withdrawalSensitivity';
+export type HealthBand = 'healthy' | 'warning' | 'critical';
+
+/** The weight each component contributes to the composite score (issue #1092). */
+export const COMPONENT_WEIGHTS: Record<ComponentName, number> = {
+  depth: 0.35,
+  spread: 0.35,
+  stability: 0.15,
+  withdrawalSensitivity: 0.15,
+};
+
+export interface ComponentBreakdown {
+  name: ComponentName;
+  score: number; // 0-100
+  weight: number; // contribution weight used in the composite (sums to 1 across all components)
+  band: HealthBand;
+}
+
+export interface LiquidityAlertContext {
+  /** The component(s) most responsible for the current health band, lowest score first. */
+  primaryDrivers: ComponentName[];
+  message: string;
+}
+
 export interface LiquidityHealthScore {
   strategyId: string;
   score: number; // 0-100
-  status: 'healthy' | 'warning' | 'critical';
+  status: HealthBand;
   components: {
     depth: number;
     spread: number;
     stability: number;
     withdrawalSensitivity: number;
   };
+  /** Per-component health band + weight, so a report can explain the score
+   * rather than just stating it (issue #1092). */
+  breakdown: ComponentBreakdown[];
+  /** Present whenever status is not "healthy" — identifies which component(s)
+   * drove the drop and a human-readable explanation. */
+  alertContext?: LiquidityAlertContext;
   thresholds: {
     warning: number;
     critical: number;
   };
   updatedAt: string;
+}
+
+const COMPONENT_LABELS: Record<ComponentName, string> = {
+  depth: 'pool depth (TVL)',
+  spread: 'withdrawal slippage',
+  stability: 'price/volatility stability',
+  withdrawalSensitivity: 'withdrawal sensitivity',
+};
+
+/** Same warning/critical thresholds used for the composite score, applied
+ * per-component so each one can be diagnosed on its own band. */
+export function bandForScore(score: number, warningThreshold: number, criticalThreshold: number): HealthBand {
+  if (score < criticalThreshold) return 'critical';
+  if (score < warningThreshold) return 'warning';
+  return 'healthy';
+}
+
+export function buildComponentBreakdown(
+  components: LiquidityHealthScore['components'],
+  warningThreshold: number,
+  criticalThreshold: number,
+): ComponentBreakdown[] {
+  return (Object.keys(components) as ComponentName[]).map((name) => ({
+    name,
+    score: components[name],
+    weight: COMPONENT_WEIGHTS[name],
+    band: bandForScore(components[name], warningThreshold, criticalThreshold),
+  }));
+}
+
+/**
+ * Builds the alert context for a non-healthy composite status: the lowest-
+ * scoring component(s) are the "primary drivers" (ties included), with a
+ * human-readable message a maintainer can act on without reading logs.
+ */
+export function buildAlertContext(
+  breakdown: ComponentBreakdown[],
+  status: HealthBand,
+  strategyId: string,
+): LiquidityAlertContext | undefined {
+  if (status === 'healthy') return undefined;
+
+  const minScore = Math.min(...breakdown.map((c) => c.score));
+  const primaryDrivers = breakdown.filter((c) => c.score === minScore).map((c) => c.name);
+  const driverLabels = primaryDrivers.map((name) => COMPONENT_LABELS[name]).join(' and ');
+
+  return {
+    primaryDrivers,
+    message:
+      `${strategyId} liquidity health is ${status} primarily due to ${driverLabels} ` +
+      `(score ${minScore}/100).`,
+  };
 }
 
 export class LiquidityHealthService {
@@ -24,7 +106,7 @@ export class LiquidityHealthService {
 
   /**
    * Calculates a composite liquidity health score for a strategy.
-   * 
+   *
    * @param strategyId The ID of the strategy (protocol name lowercase)
    */
   async calculateScore(strategyId: string): Promise<LiquidityHealthScore> {
@@ -52,31 +134,34 @@ export class LiquidityHealthService {
     // Older protocols are assumed more stable against withdrawals
     const ageFactor = Math.min(1, protocol.protocolAgeDays / 365);
     // Withdrawal velocity if available, else derived
-    const withdrawalSensitivity = ageFactor; 
+    const withdrawalSensitivity = ageFactor;
 
     // Composite Weighted Score
     const compositeScore = (
-      (depth * 0.35) + 
-      (spread * 0.35) + 
-      (stability * 0.15) + 
-      (withdrawalSensitivity * 0.15)
+      (depth * COMPONENT_WEIGHTS.depth) +
+      (spread * COMPONENT_WEIGHTS.spread) +
+      (stability * COMPONENT_WEIGHTS.stability) +
+      (withdrawalSensitivity * COMPONENT_WEIGHTS.withdrawalSensitivity)
     ) * 100;
 
     const roundedScore = Math.round(compositeScore);
-    let status: 'healthy' | 'warning' | 'critical' = 'healthy';
-    if (roundedScore < this.CRITICAL_THRESHOLD) status = 'critical';
-    else if (roundedScore < this.WARNING_THRESHOLD) status = 'warning';
+    const status = bandForScore(roundedScore, this.WARNING_THRESHOLD, this.CRITICAL_THRESHOLD);
+
+    const components = {
+      depth: Math.round(depth * 100),
+      spread: Math.round(spread * 100),
+      stability: Math.round(stability * 100),
+      withdrawalSensitivity: Math.round(withdrawalSensitivity * 100),
+    };
+    const breakdown = buildComponentBreakdown(components, this.WARNING_THRESHOLD, this.CRITICAL_THRESHOLD);
 
     return {
       strategyId,
       score: roundedScore,
       status,
-      components: {
-        depth: Math.round(depth * 100),
-        spread: Math.round(spread * 100),
-        stability: Math.round(stability * 100),
-        withdrawalSensitivity: Math.round(withdrawalSensitivity * 100),
-      },
+      components,
+      breakdown,
+      alertContext: buildAlertContext(breakdown, status, strategyId),
       thresholds: {
         warning: this.WARNING_THRESHOLD,
         critical: this.CRITICAL_THRESHOLD,


### PR DESCRIPTION
## Summary
Closes #1086
Closes #1087
Closes #1091
Closes #1092

- **#1086** — `scripts/refresh-saved-searches.js` generates the saved-search links in `maintainer_saved_searches.sh` from a single source of truth, `scripts/saved-searches.json`. `--dry-run` prints exactly what would change without writing anything; re-running with no config changes is a no-op. Documented in `docs/triage-process.md` (new "Keeping Saved Searches Current" section) with the add/preview/apply workflow for extending the list.
- **#1087** — `scripts/lintMarkdown.ts`: a dependency-free structural markdown checker (empty/skipped headings, malformed links, empty list items), covered by `scripts/lintMarkdown.test.ts`, plus a CLI wrapper (`scripts/lint-markdown.ts`) and `docs/markdown-linting.md`. Note: no generated issue canvas files (`GRANTFOX_*_CANVAS.md`, `STELLARYIELD_EPIC_ISSUE_CANVAS.md`) currently exist in this repo — the checker validates any markdown file passed to it, so it's ready for canvases as soon as they're generated, and useful today against `docs/**`.
- **#1091** — `server/src/services/governanceForecastCheckpoints.ts`: models scheduled prep checkpoints ahead of a governance change window (`checkpointStatus`, `summarizeCheckpoints`) with `overdue`/`due_soon`/`upcoming`/`completed` states, sorted so what needs attention surfaces first. Not yet wired into `governanceForecastService.ts`'s route/output — left as a follow-up integration since that's a separate, larger change than the checkpoint model itself.
- **#1092** — `liquidityHealthService.calculateScore()`'s result now includes a per-component `breakdown` (score + health band per component, using the same warning/critical thresholds) and an `alertContext` naming the primary driver component(s) of a non-healthy status with a human-readable message, so a report can explain *why* the score dropped instead of just stating the number.

## Test plan
- [x] `npx jest src/__tests__/liquidityHealthService.test.ts src/__tests__/governanceForecastCheckpoints.test.ts` (server workspace) — 23/23 passing
- [x] `npx vitest run scripts/lintMarkdown.test.ts` — 9/9 passing
- [x] Manually verified `node scripts/refresh-saved-searches.js --dry-run` and the real run against `scripts/maintainer_saved_searches.sh`
- [x] Manually verified `npx tsx scripts/lint-markdown.ts` against both a clean doc and a synthetic broken one (skipped heading, empty list item, empty-URL link) — correctly passes/fails